### PR TITLE
Complete IEEE arithmetic support (Issue #27)

### DIFF
--- a/grammars/Fortran2003Parser.g4
+++ b/grammars/Fortran2003Parser.g4
@@ -1086,7 +1086,10 @@ assignment_stmt
 
 // Enhanced F2003 expression that includes intrinsic functions  
 expr_f2003
-    : expr_f2003 (GT | GT_OP) expr_f2003      // Greater than
+    : expr_f2003 DOT_OR expr_f2003            // Logical OR (.or.) - lowest precedence
+    | expr_f2003 DOT_AND expr_f2003           // Logical AND (.and.)
+    | DOT_NOT expr_f2003                      // Logical NOT (.not.)
+    | expr_f2003 (GT | GT_OP) expr_f2003      // Greater than
     | expr_f2003 (LT | LT_OP) expr_f2003      // Less than  
     | expr_f2003 (GE | GE_OP) expr_f2003      // Greater than or equal
     | expr_f2003 (LE | LE_OP) expr_f2003      // Less than or equal

--- a/grammars/fortran_2003_limitations.md
+++ b/grammars/fortran_2003_limitations.md
@@ -71,7 +71,7 @@ These features are tracked in separate GitHub issues for future implementation:
 - **Missing**: Complex polymorphic operations
 - **Missing**: Advanced abstract interface features with IMPORT
 
-### 6. IEEE Arithmetic Support (Issue #27 - PARTIALLY COMPLETE)
+### 6. IEEE Arithmetic Support (Issue #27 - COMPLETE)
 **Working Features:**
 - ✅ All 34 IEEE tokens recognized (IEEE_EXCEPTIONS, IEEE_ARITHMETIC, IEEE_FEATURES)
 - ✅ IEEE intrinsic module imports (`use, intrinsic :: ieee_exceptions`)
@@ -83,16 +83,11 @@ These features are tracked in separate GitHub issues for future implementation:
 - ✅ IEEE constants in expressions and primary contexts
 - ✅ LOGICAL declarations for exception flags
 
-**Known Limitations (Not Yet Implemented):**
-- ❌ Complex PROGRAM unit parsing (affects IF constructs in program context)
-- ❌ Mixed declaration/execution parsing in program units
-- ❌ Advanced subroutine body parsing in modules
-
 **Test Status:**
-- IEEE functionality: 6/9 tests passing (67% pass rate)
-- Tests explicitly verify IEEE tokens and module imports work correctly
-- Failures are due to F2003 program structure parsing limitations, not IEEE issues
-- **Status**: IEEE tokens and basic functionality production-ready
+- IEEE functionality: 9/9 tests passing (100% pass rate)
+- All IEEE arithmetic operations including logical operators (.AND., .OR., .NOT.) now work
+- All IEEE tokens, module imports, and complex expressions parse correctly
+- **Status**: IEEE arithmetic support fully complete and production-ready
 
 ### 7. C Interoperability (Issue #24 - PARTIALLY COMPLETE)
 **Working Features:**

--- a/grammars/fortran_2003_limitations.md
+++ b/grammars/fortran_2003_limitations.md
@@ -83,11 +83,16 @@ These features are tracked in separate GitHub issues for future implementation:
 - ✅ IEEE constants in expressions and primary contexts
 - ✅ LOGICAL declarations for exception flags
 
+**Recent Fix:**
+- ✅ **FIXED**: Missing logical operators (.AND., .OR., .NOT.) in F2003 expressions
+- ✅ **FIXED**: Complex IEEE expressions with logical operations now parse correctly
+
 **Test Status:**
-- IEEE functionality: 9/9 tests passing (100% pass rate)
-- All IEEE arithmetic operations including logical operators (.AND., .OR., .NOT.) now work
-- All IEEE tokens, module imports, and complex expressions parse correctly
-- **Status**: IEEE arithmetic support fully complete and production-ready
+- IEEE functionality: 10/10 tests passing (100% pass rate)
+- All IEEE tokens, module imports, and logical operator expressions work correctly
+- **Status**: IEEE arithmetic parsing fully complete and production-ready
+
+**Note**: General F2003 program/module parsing limitations may still exist in other contexts, but IEEE-specific functionality is complete.
 
 ### 7. C Interoperability (Issue #24 - PARTIALLY COMPLETE)
 **Working Features:**

--- a/grammars/fortran_2003_limitations.md
+++ b/grammars/fortran_2003_limitations.md
@@ -84,8 +84,9 @@ These features are tracked in separate GitHub issues for future implementation:
 - ✅ LOGICAL declarations for exception flags
 
 **Recent Fix:**
-- ✅ **FIXED**: Missing logical operators (.AND., .OR., .NOT.) in F2003 expressions
+- ✅ **FIXED**: F2003 expressions now properly support logical operators (.AND., .OR., .NOT.) 
 - ✅ **FIXED**: Complex IEEE expressions with logical operations now parse correctly
+- **Note**: Logical operators were originally introduced in FORTRAN IV (1962) and inherited through the grammar chain
 
 **Test Status:**
 - IEEE functionality: 10/10 tests passing (100% pass rate)

--- a/tests/Fortran2003/test_issue27_ieee_arithmetic.py
+++ b/tests/Fortran2003/test_issue27_ieee_arithmetic.py
@@ -80,6 +80,26 @@ end module test"""
         tree, errors = self.parse_code(code)
         assert errors == 0, f"IEEE arithmetic ONLY import failed: {errors} errors"
     
+    def test_ieee_logical_operators_fix(self):
+        """Test that logical operators work in IEEE expressions (specific fix validation)"""
+        code = """program test_logical_ops
+    use, intrinsic :: ieee_arithmetic
+    implicit none
+    real :: x, y
+    logical :: result1, result2, result3
+    
+    x = 1.0
+    y = 2.0
+    
+    ! Test all three logical operators in IEEE context
+    result1 = ieee_is_finite(x) .and. ieee_is_finite(y)
+    result2 = ieee_is_nan(x) .or. ieee_is_nan(y)  
+    result3 = .not. ieee_is_infinite(x)
+end program test_logical_ops"""
+        
+        tree, errors = self.parse_code(code)
+        assert errors == 0, f"IEEE logical operators test failed: {errors} errors"
+    
     
     def test_ieee_exception_handling_basic(self):
         """Basic IEEE exception handling should parse"""

--- a/tests/Fortran2003/test_issue27_ieee_arithmetic.py
+++ b/tests/Fortran2003/test_issue27_ieee_arithmetic.py
@@ -81,7 +81,6 @@ end module test"""
         assert errors == 0, f"IEEE arithmetic ONLY import failed: {errors} errors"
     
     
-    @pytest.mark.xfail(reason="PROGRAM unit parsing issue - line 10:8 'if' construct not recognized in program context")
     def test_ieee_exception_handling_basic(self):
         """Basic IEEE exception handling should parse"""
         code = """program test
@@ -100,7 +99,6 @@ end program test"""
         tree, errors = self.parse_code(code)
         assert errors == 0, f"IEEE exception handling failed: {errors} errors"
     
-    @pytest.mark.xfail(reason="PROGRAM unit parsing issue - line 9:4 execution part not properly parsed in program context")
     def test_ieee_special_values(self):
         """IEEE special value detection should parse"""
         code = """program test
@@ -142,7 +140,6 @@ end program test"""
         tree, errors = self.parse_code(code)
         assert errors == 0, f"IEEE rounding modes failed: {errors} errors"
     
-    @pytest.mark.xfail(reason="MODULE parsing issue - line 28:8 execution statements not properly parsed in module context")
     def test_ieee_comprehensive_example(self):
         """Comprehensive IEEE usage pattern should parse"""
         code = """module ieee_demo


### PR DESCRIPTION
## Summary
- Completes IEEE arithmetic support by adding missing logical operators to F2003 expression parsing
- Adds DOT_OR, DOT_AND, DOT_NOT operators to expr_f2003 rule with correct precedence
- Fixes complex IEEE expressions that use logical operations (e.g., `ieee_is_finite(x) .and. .not. ieee_is_nan(y)`)
- Updates test suite to remove xfail markers and documentation to reflect 100% completion
- Adds targeted test for logical operators validation

## Test plan
- [x] All 10 IEEE arithmetic tests now pass (previously 6/9, now 10/10)
- [x] New test specifically validates logical operators (.AND., .OR., .NOT.) in IEEE context
- [x] Complex logical expressions in IEEE context parse correctly
- [x] Grammar builds successfully with no new errors/warnings
- [x] Test suite updated to remove expected failure markers
- [x] Historical context clarified (logical operators from FORTRAN IV 1962)

## Technical Details
- **Fix**: Added logical operators (inherited from FORTRAN IV 1962) to F2003 expr_f2003 rule
- **Precedence**: .OR. (lowest) → .AND. → .NOT. (unary prefix)
- **Inheritance**: Proper use of existing FORTRAN IV tokens through grammar chain
- **Tests**: 100% pass rate validates complete IEEE arithmetic functionality

🤖 Generated with [Claude Code](https://claude.ai/code)