### PR TITLE
FORTRAN 1957: computed GOTO and FREQUENCY support

### DIFF
--- a/grammars/FORTRANParser.g4
+++ b/grammars/FORTRANParser.g4
@@ -23,11 +23,7 @@ options {
 
 // Core program unit - can be extended by format-specific parsers
 program_unit_core
-    : statement_list EOF
-    ;
-
-statement_list
-    : statement*
+    : (NEWLINE* statement)* NEWLINE* EOF
     ;
 
 // ============================================================================

--- a/tests/FORTRAN/test_fortran_historical_stub.py
+++ b/tests/FORTRAN/test_fortran_historical_stub.py
@@ -144,10 +144,13 @@ class TestFORTRANHistoricalStub:
         """
         
         parser = self.create_parser(test_input)
-        
+
         try:
             tree = parser.program_unit_core()
             assert tree is not None
+            # Now that computed GOTO has an explicit grammar rule,
+            # ensure the input parses without syntax errors.
+            assert parser.getNumberOfSyntaxErrors() == 0
         except Exception as e:
             pytest.fail(f"Computed GOTO parsing failed: {e}")
 
@@ -211,10 +214,13 @@ class TestFORTRANHistoricalStub:
         """
         
         parser = self.create_parser(test_input)
-        
+
         try:
             tree = parser.program_unit_core()
             assert tree is not None
+            # FREQUENCY is explicitly modelled in the stub grammar,
+            # so this should parse with zero syntax errors.
+            assert parser.getNumberOfSyntaxErrors() == 0
         except Exception as e:
             pytest.fail(f"FREQUENCY statement parsing failed: {e}")
 


### PR DESCRIPTION
### **User description**
Implements computed GOTO and FREQUENCY statement support in the FORTRAN (1957) historical stub grammar and updates documentation to remain honest about stub status.

- Extend FORTRANParser.g4 with:
  - computed GOTO: 
  - FREQUENCY optimization hint: 
- Keep parser focused on historically grounded core subset.
- All tests pass locally: .................................................................                        [100%]
65 passed, 200 subtests passed in 0.07s and ...................................................................... [ 24%]
........................................................................................ [ 55%]
........................................................................ [ 80%]
......................................................                   [100%]
=============================== warnings summary ===============================
tests/Fortran2018/test_clean_if.py:14
  /Users/ert/code/standard/tests/Fortran2018/test_clean_if.py:14: PytestCollectionWarning: cannot collect test class 'TestErrorListener' because it has a __init__ constructor (from: tests/Fortran2018/test_clean_if.py)
    class TestErrorListener(ErrorListener):

tests/Fortran2018/test_endif_simple.py:14
  /Users/ert/code/standard/tests/Fortran2018/test_endif_simple.py:14: PytestCollectionWarning: cannot collect test class 'TestErrorListener' because it has a __init__ constructor (from: tests/Fortran2018/test_endif_simple.py)
    class TestErrorListener(ErrorListener):

tests/Fortran2018/test_if_construct.py:14
  /Users/ert/code/standard/tests/Fortran2018/test_if_construct.py:14: PytestCollectionWarning: cannot collect test class 'TestErrorListener' because it has a __init__ constructor (from: tests/Fortran2018/test_if_construct.py)
    class TestErrorListener(ErrorListener):

tests/Fortran2018/test_if_construct_direct.py:14
  /Users/ert/code/standard/tests/Fortran2018/test_if_construct_direct.py:14: PytestCollectionWarning: cannot collect test class 'TestErrorListener' because it has a __init__ constructor (from: tests/Fortran2018/test_if_construct_direct.py)
    class TestErrorListener(ErrorListener):

tests/Fortran2018/test_if_with_body.py:14
  /Users/ert/code/standard/tests/Fortran2018/test_if_with_body.py:14: PytestCollectionWarning: cannot collect test class 'TestErrorListener' because it has a __init__ constructor (from: tests/Fortran2018/test_if_with_body.py)
    class TestErrorListener(ErrorListener):

tests/Fortran2018/test_parse_tree.py:14
  /Users/ert/code/standard/tests/Fortran2018/test_parse_tree.py:14: PytestCollectionWarning: cannot collect test class 'TestErrorListener' because it has a __init__ constructor (from: tests/Fortran2018/test_parse_tree.py)
    class TestErrorListener(ErrorListener):

tests/Fortran2018/test_parse_tree.py::test_if_parse_tree
  /opt/homebrew/Cellar/pytest/9.0.0/libexec/lib/python3.14/site-packages/_pytest/python.py:170: PytestReturnNotNoneWarning: Test functions should return None, but tests/Fortran2018/test_parse_tree.py::test_if_parse_tree returned <class 'bool'>.
  Did you mean to use `assert` instead of `return`?
  See https://docs.pytest.org/en/stable/how-to/assert.html#return-not-none for more information.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
284 passed, 7 warnings, 274 subtests passed in 8.92s.

Fixes #62.


___

### **PR Type**
Enhancement


___

### **Description**
- Add computed GOTO statement support for multi-way branching

- Add FREQUENCY statement for optimization hints

- Update documentation to clarify stub status and scope

- Improve code formatting and comment clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FORTRANParser.g4"] -->|Add computed_goto_stmt| B["Computed GOTO support"]
  A -->|Add frequency_stmt| C["FREQUENCY optimization hints"]
  A -->|Update docs| D["Clarify stub grammar scope"]
  B --> E["label_list rule"]
  C --> F["expr_list rule"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FORTRANParser.g4</strong><dd><code>Add computed GOTO and FREQUENCY statement rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/FORTRANParser.g4

<ul><li>Add <code>computed_goto_stmt</code> rule supporting multi-way branching with label <br>lists<br> <li> Add <code>frequency_stmt</code> rule for optimization hints with expression lists<br> <li> Add <code>label_list</code> and <code>expr_list</code> helper rules for statement arguments<br> <li> Update header documentation to clarify parser implements historically <br>grounded core subset rather than full reconstruction<br> <li> Improve formatting and comment clarity throughout</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/74/files#diff-659faf9405795fbad5713cd37047989b862e962afdf508fb421d6bbb7d43c3c1">+27/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

