### PR TITLE
Fortran 2003: defined derived-type I/O generics

### DIFF
--- a/grammars/Fortran2003Parser.g4
+++ b/grammars/Fortran2003Parser.g4
@@ -392,6 +392,17 @@ type_bound_generic_stmt
       POINTER_ASSIGN generic_binding_list NEWLINE
     ;
 
+// Override F90 generic_spec to support defined derived-type I/O
+// Fortran 2003 allows generic READ/WRITE with FORMATTED/UNFORMATTED
+// access specifiers, written as READ(FORMATTED) / WRITE(UNFORMATTED).
+generic_spec
+    : IDENTIFIER                            // Generic procedure name
+    | OPERATOR LPAREN operator_token RPAREN // Operator overloading
+    | ASSIGNMENT LPAREN ASSIGN RPAREN       // Assignment overloading
+    | READ LPAREN identifier_or_keyword RPAREN   // READ(FORMATTED) style generics
+    | WRITE LPAREN identifier_or_keyword RPAREN  // WRITE(UNFORMATTED) style generics
+    ;
+
 generic_binding_list
     : IDENTIFIER (COMMA IDENTIFIER)*
     ;

--- a/grammars/fortran_2003_limitations.md
+++ b/grammars/fortran_2003_limitations.md
@@ -130,6 +130,44 @@ These features are tracked in separate GitHub issues for future implementation:
 - Tests explicitly verify and document known limitations
 - **Status**: Basic C interoperability works; advanced features pending
 
+### 8. Defined Derived-Type I/O (Issue #68 - PARTIALLY COMPLETE)
+
+**Working Features:**
+- ✅ Generic specifications for defined I/O procedures:
+  - `INTERFACE READ(FORMATTED) / WRITE(FORMATTED|UNFORMATTED)`
+  - Type-bound `GENERIC :: READ(...) / WRITE(...) => proc` inside derived types
+- ✅ I/O statements that invoke these procedures via:
+  - Regular `READ` / `WRITE` statements with derived-type objects
+  - Explicit format strings that contain DT edit descriptors, e.g.
+    character literals of the form `'(DT\"name\"(10,2))'`
+    (treated as opaque strings by the grammar).
+
+**Known Limitations:**
+- ⚠️ The DT edit descriptor syntax itself is **not** parsed structurally.
+  It appears only inside character-literal format strings, which this
+  grammar models as single string tokens rather than a full sub-grammar
+  of edit descriptors.
+- ⚠️ The grammar intentionally does **not** attempt to enforce the full
+  Fortran 2003 semantics for defined derived-type I/O (such as the
+  required dummy argument lists of the defined I/O procedures).
+- ⚠️ Vendor-specific or non-standard I/O control specifiers remain
+  accepted through the generic `IDENTIFIER = primary` alternative in
+  `f2003_io_spec`; syntactic acceptance here does not imply standard
+  conformance.
+
+**Test Status:**
+- Positive tests in `tests/Fortran2003/test_issue68_defined_io.py` cover:
+  - Type-bound generics with `WRITE(FORMATTED)`
+  - Interface-based generics with `WRITE(FORMATTED)` / `WRITE(UNFORMATTED)`
+  - `WRITE` statements using format strings that contain DT edit descriptors
+    as character literals.
+- Negative tests confirm that malformed generic-spec forms such as
+  `WRITE(DT=...)` are rejected by the grammar.
+
+**Status:** Core generic syntax for defined derived-type I/O is implemented
+and tested; detailed DT edit-descriptor parsing and full semantic coverage
+remain out of scope for this grammar.
+
 ## Working Features
 
 ✅ **Fully Functional:**

--- a/tests/Fortran2003/test_issue68_defined_io.py
+++ b/tests/Fortran2003/test_issue68_defined_io.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Issue #68 – Fortran 2003 defined derived-type I/O (DT)
+
+This suite focuses on the *syntax* that Fortran 2003 introduces for
+defined derived-type I/O:
+
+- Generic READ/WRITE interfaces such as READ(FORMATTED) / WRITE(UNFORMATTED)
+- Type-bound GENERIC statements using the same generic-spec forms
+- Use of DT edit descriptors inside explicit format strings
+
+Note: The DT edit descriptor itself lives inside character format strings
+and is therefore not parsed structurally by this grammar; we simply
+verify that such formats are accepted as string literals in I/O control
+lists.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from antlr4 import CommonTokenStream, InputStream
+
+# Add grammars directory to path
+sys.path.append(str(Path(__file__).parent.parent.parent / "grammars"))
+
+from Fortran2003Lexer import Fortran2003Lexer
+from Fortran2003Parser import Fortran2003Parser
+
+
+def parse_f2003(code: str):
+    """Parse Fortran 2003 code and return (tree, errors, parser)."""
+    input_stream = InputStream(code)
+    lexer = Fortran2003Lexer(input_stream)
+    parser = Fortran2003Parser(CommonTokenStream(lexer))
+    tree = parser.program_unit_f2003()
+    return tree, parser.getNumberOfSyntaxErrors(), parser
+
+
+class TestFortran2003DefinedDerivedTypeIO:
+    """Tests for Fortran 2003 defined derived-type I/O syntax."""
+
+    def test_type_bound_generic_write_formatted(self):
+        """Type-bound GENERIC :: WRITE(FORMATTED) => proc."""
+        code = """
+module defined_io_mod
+  implicit none
+
+  type :: point_t
+    real :: x, y
+  contains
+    procedure :: write_formatted
+    generic :: write(formatted) => write_formatted
+  end type point_t
+
+contains
+
+  subroutine write_formatted(dtv, u, iotype, v_list, ios, msg)
+    class(point_t), intent(in) :: dtv
+    integer, intent(in)        :: u
+    character(*), intent(in)   :: iotype
+    integer, intent(in)        :: v_list(:)
+    integer, intent(out)       :: ios
+    character(*), intent(inout):: msg
+
+    write(u, '(2F10.4)') dtv%x, dtv%y
+        ios    = 0
+        msg    = ''
+  end subroutine write_formatted
+
+end module defined_io_mod
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_interface_write_formatted_and_unformatted(self):
+        """INTERFACE WRITE(FORMATTED) / WRITE(UNFORMATTED)."""
+        code = """
+module interface_defined_io
+  implicit none
+
+  type :: point_t
+    real :: x, y
+  end type point_t
+
+  interface write(formatted)
+     subroutine write_point_formatted(dtv, u, iotype, v_list, ios, msg)
+       import :: point_t
+       class(point_t), intent(in) :: dtv
+       integer, intent(in)        :: u
+       character(*), intent(in)   :: iotype
+       integer, intent(in)        :: v_list(:)
+       integer, intent(out)       :: ios
+       character(*), intent(inout):: msg
+     end subroutine write_point_formatted
+  end interface
+
+  interface write(unformatted)
+     subroutine write_point_unformatted(dtv, u, iotype, v_list, ios, msg)
+       import :: point_t
+       class(point_t), intent(in) :: dtv
+       integer, intent(in)        :: u
+       character(*), intent(in)   :: iotype
+       integer, intent(in)        :: v_list(:)
+       integer, intent(out)       :: ios
+       character(*), intent(inout):: msg
+     end subroutine write_point_unformatted
+  end interface
+
+end module interface_defined_io
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_write_with_dt_edit_descriptor_in_format_string(self):
+        """
+        WRITE using an explicit format string that contains a DT edit descriptor.
+
+        The DT edit descriptor syntax itself lives inside the character literal
+        and is therefore not interpreted structurally by this grammar; we simply
+        ensure that such a format is accepted as a string literal in the I/O
+        control list.
+        """
+        code = """
+program use_defined_io
+  use defined_io_mod
+  implicit none
+
+  type(point_t) :: p
+
+  p%x = 1.0
+  p%y = 2.0
+
+  ! DT edit descriptor inside format string (simplified example)
+  write(*, '(DT\"point\"(10,2))') p
+end program use_defined_io
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_malformed_generic_dt_equals_is_rejected(self):
+        """
+        Malformed generic-spec using DT= inside READ/WRITE generic.
+
+        Fortran 2003 defines generics READ(FORMATTED) / WRITE(UNFORMATTED);
+        a form like WRITE(DT=...) is not valid and should result in a syntax
+        error under this grammar.
+        """
+        code = """
+module bad_dt_generic
+  implicit none
+
+  interface write(dt=point)
+     module procedure write_point
+  end interface
+
+contains
+
+  subroutine write_point(x)
+    real, intent(in) :: x
+  end subroutine write_point
+
+end module bad_dt_generic
+"""
+        _, errors, _ = parse_f2003(code)
+        assert errors > 0


### PR DESCRIPTION
### **User description**
Implements core syntax support and tests for Fortran 2003 defined derived-type I/O (issue #68), while staying aligned with the ISO Fortran 2003 specification.

### Grammar changes
- Override `generic_spec` in `Fortran2003Parser.g4` to extend the F90/F95 generic-spec with support for I/O generics:
  - `READ(FORMATTED)` / `WRITE(FORMATTED)` / `WRITE(UNFORMATTED)` forms via:
    - `READ LPAREN identifier_or_keyword RPAREN`
    - `WRITE LPAREN identifier_or_keyword RPAREN`
  - Existing generic forms (`generic-name`, `OPERATOR(...)`, `ASSIGNMENT(=)`) remain supported.
- Leave the DT edit descriptor itself inside character-literal format strings, which this grammar intentionally treats as opaque string tokens (no sub-grammar of edit descriptors is introduced).

### New tests
- Added `tests/Fortran2003/test_issue68_defined_io.py`:
  - **Positive tests**
    - `test_type_bound_generic_write_formatted`:
      - `type :: point_t` with type-bound `procedure :: write_formatted` and
        `generic :: write(formatted) => write_formatted`.
      - Defined-I/O-style subroutine with the expected dummy argument pattern
        (class dummy, unit, iotype, v_list, status, message), using non-keyword
        dummy names to respect current lexer keyword treatment.
    - `test_interface_write_formatted_and_unformatted`:
      - `INTERFACE WRITE(FORMATTED)` and `INTERFACE WRITE(UNFORMATTED)` blocks
        that declare subroutine interfaces with CLASS-based dummies and
        appropriate INTENT/CHARACTER dummy arguments.
    - `test_write_with_dt_edit_descriptor_in_format_string`:
      - `WRITE(*, '(DT"point"(10,2))') p` example that exercises a DT edit
        descriptor embedded in an explicit format character literal; the DT
        syntax is accepted as a single string token in the I/O control list.
  - **Negative test**
    - `test_malformed_generic_dt_equals_is_rejected`:
      - `INTERFACE WRITE(DT=point)` is rejected (non-zero syntax errors),
        confirming that malformed generic-spec forms using `DT=` are not
        accepted by this grammar.

### Documentation
- Updated `grammars/fortran_2003_limitations.md` (new section "Defined Derived-Type I/O (Issue #68 - PARTIALLY COMPLETE)"):
  - Documents the working subset (generic READ/WRITE syntax and DT-containing
    format strings) and explicitly calls out that DT edit descriptors are
    **not** parsed structurally and that full semantic validation of defined
    derived-type I/O remains out of scope.

### Tests
- `pytest tests/Fortran2003 -q` → 90 passed.
- `pytest tests -q` → 288 passed, 274 subtests passed.

Fixes #68.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implement Fortran 2003 defined derived-type I/O generic syntax support

- Add `generic_spec` override in parser to support READ/WRITE(FORMATTED|UNFORMATTED)

- Create comprehensive test suite for I/O generics and DT edit descriptors

- Document implementation scope and known limitations in specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fortran2003Parser.g4"] -->|override generic_spec| B["READ/WRITE I/O Generics"]
  C["test_issue68_defined_io.py"] -->|positive tests| B
  C -->|negative tests| B
  D["fortran_2003_limitations.md"] -->|document scope| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue68_defined_io.py</strong><dd><code>Test suite for defined derived-type I/O</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2003/test_issue68_defined_io.py

<ul><li>New test module for Fortran 2003 defined derived-type I/O syntax<br> <li> Positive tests: type-bound generics, interface-based generics, DT edit <br>descriptors in format strings<br> <li> Negative test: validates rejection of malformed <code>WRITE(DT=...)</code> syntax<br> <li> All tests verify zero syntax errors for valid constructs</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/75/files#diff-25d6f414e705938049582136f6dea09101e0fdbf1c9e200feb1666a8b03f961e">+169/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fortran2003Parser.g4</strong><dd><code>Add generic_spec override for I/O generics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/Fortran2003Parser.g4

<ul><li>Override <code>generic_spec</code> rule to extend F90/F95 support with I/O generics<br> <li> Add support for <code>READ(identifier_or_keyword)</code> and <br><code>WRITE(identifier_or_keyword)</code> forms<br> <li> Preserve existing generic forms: generic-name, <code>OPERATOR(...)</code>, <br><code>ASSIGNMENT(=)</code><br> <li> Enable type-bound and interface-based defined I/O procedure <br>declarations</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/75/files#diff-b0e283de2d16fdeeb25bac0ff02e9392443cca77cb7f4085f338676f9a23ff4a">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortran_2003_limitations.md</strong><dd><code>Document defined derived-type I/O scope and limitations</code>&nbsp; &nbsp; </dd></summary>
<hr>

grammars/fortran_2003_limitations.md

<ul><li>New section documenting defined derived-type I/O implementation status<br> <li> Lists working features: generic READ/WRITE syntax and DT format <br>strings<br> <li> Clarifies known limitations: DT edit descriptors not parsed <br>structurally, semantic validation out of scope<br> <li> References test coverage and confirms core syntax is implemented</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/75/files#diff-c69500015427facc624c22a2abd00b42c35d165a96e98d26753a5173feac96ee">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

