### PR TITLE
Fortran 2003: SELECT TYPE semantics tests

### DIFF
--- a/tests/Fortran2003/test_issue69_select_type_semantics.py
+++ b/tests/Fortran2003/test_issue69_select_type_semantics.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Issue #69 – Fortran 2003 SELECT TYPE and polymorphism semantics
+
+This suite exercises the SELECT TYPE construct more systematically:
+
+- Intrinsic, derived and CLASS(*) selectors
+- Selector renames with `=>` in the SELECT TYPE header
+- Multiple type-guard branches with and without selector names
+- Nested SELECT TYPE blocks
+- Clearly invalid guard forms that should produce syntax errors
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from antlr4 import InputStream, CommonTokenStream
+
+sys.path.append(str(Path(__file__).parent.parent.parent / "grammars"))
+
+from Fortran2003Lexer import Fortran2003Lexer
+from Fortran2003Parser import Fortran2003Parser
+
+
+def parse_f2003(code: str):
+    """Parse Fortran 2003 code and return (tree, errors, parser)."""
+    input_stream = InputStream(code)
+    lexer = Fortran2003Lexer(input_stream)
+    parser = Fortran2003Parser(CommonTokenStream(lexer))
+    tree = parser.program_unit_f2003()
+    return tree, parser.getNumberOfSyntaxErrors(), parser
+
+
+class TestF2003SelectTypeSemantics:
+    """Matrix of SELECT TYPE usage patterns."""
+
+    def test_select_type_with_intrinsic_and_default(self):
+        """SELECT TYPE with intrinsic TYPE IS and CLASS DEFAULT."""
+        code = """
+program select_intrinsic
+  implicit none
+  class(*), allocatable :: obj
+
+  select type (obj)
+  type is (integer)
+     print *, 'int'
+  type is (real)
+     print *, 'real'
+  class default
+     print *, 'other'
+  end select
+
+end program select_intrinsic
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_select_type_with_derived_and_selector_rename(self):
+        """
+        SELECT TYPE with derived type guards and selector rename.
+
+        Exercises:
+        - `select type (p => obj)`
+        - TYPE IS (point_t) with and without a selector name
+        - CLASS DEFAULT branch
+        """
+        code = """
+module m_points
+  implicit none
+
+  type :: point_t
+    real :: x, y
+  end type point_t
+
+contains
+
+  subroutine handle_point(obj)
+    class(*), intent(in) :: obj
+
+    select type (p => obj)
+    type is (point_t)
+      print *, 'point:', p%x, p%y
+    class default
+      print *, 'not a point'
+    end select
+
+  end subroutine handle_point
+
+end module m_points
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_nested_select_type_with_class_star_and_renamed_selector(self):
+        """
+        Nested SELECT TYPE with CLASS(*) and renamed selector inside a branch.
+        """
+        code = """
+program nested_select
+  implicit none
+  class(*), allocatable :: obj
+
+  select type (obj)
+  class is (shape_t)
+    select type (s => obj)
+    type is (circle_t)
+      print *, 'circle branch'
+    class default
+      print *, 'shape but not circle'
+    end select
+  class default
+    print *, 'non-shape'
+  end select
+
+end program nested_select
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+
+class TestF2003SelectTypeNegative:
+    """Negative tests for clearly invalid SELECT TYPE forms."""
+
+    def test_invalid_guard_missing_is_keyword(self):
+        """
+        Guard missing the `is` keyword should not parse cleanly.
+
+        Our grammar expects `TYPE is (type-spec)` / `CLASS is (type-spec)`.
+        A form like `type (integer)` is therefore rejected.
+        """
+        code = """
+program bad_guard
+  implicit none
+  class(*), allocatable :: obj
+
+  select type (obj)
+  type (integer)
+     print *, 'missing is'
+  class default
+     print *, 'default'
+  end select
+
+end program bad_guard
+"""
+        _, errors, _ = parse_f2003(code)
+        assert errors > 0
+
+    def test_invalid_class_default_with_type_spec(self):
+        """
+        CLASS DEFAULT must not carry a type-spec; this malformed form
+        should produce a syntax error under the current grammar.
+        """
+        code = """
+program bad_default
+  implicit none
+  class(*), allocatable :: obj
+
+  select type (obj)
+  class default (integer)
+     print *, 'illegal'
+  end select
+
+end program bad_default
+"""
+        _, errors, _ = parse_f2003(code)
+        assert errors > 0
+


### PR DESCRIPTION
### **User description**
Add spec-driven SELECT TYPE tests for Fortran 2003 (issue #69).

### Content
- New file `tests/Fortran2003/test_issue69_select_type_semantics.py` that:
  - Exercises a matrix of valid SELECT TYPE usages:
    - Intrinsic TYPE IS guards with CLASS DEFAULT fallback.
    - SELECT TYPE with selector rename (`select type (p => obj)`) and
      derived-type TYPE IS guards.
    - Nested SELECT TYPE with CLASS IS and renamed selector inside a branch.
  - Adds negative cases that must *not* parse cleanly under the current
    grammar:
    - Guard missing the `is` keyword (e.g. `type (integer)`).
    - `CLASS DEFAULT` carrying an illegal type-spec (e.g. `class default (integer)`).

### Notes
- These tests are written against the existing `select_type_construct` and
  `type_guard_stmt` rules in `Fortran2003Parser.g4` and do not widen the
  accepted syntax beyond the desired standard forms.
- All existing Fortran 2003 tests continue to pass, and Fortran 2003 now has
  95 tests in total.

### Tests
- `pytest tests/Fortran2003 -q` → 95 passed.
- `pytest tests -q` → 293 passed, 274 subtests passed.

Fixes #69.


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive SELECT TYPE semantics tests for Fortran 2003

- Test valid patterns: intrinsic types, derived types, selector renames

- Test nested SELECT TYPE with CLASS IS and renamed selectors

- Add negative tests for invalid guard syntax and malformed CLASS DEFAULT


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] --> B["Valid Cases"]
  A --> C["Negative Cases"]
  B --> B1["Intrinsic Types"]
  B --> B2["Derived Types with Rename"]
  B --> B3["Nested SELECT TYPE"]
  C --> C1["Missing IS Keyword"]
  C --> C2["Invalid CLASS DEFAULT"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue69_select_type_semantics.py</strong><dd><code>New SELECT TYPE semantics test suite for Fortran 2003</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2003/test_issue69_select_type_semantics.py

<ul><li>New test file with 5 test methods covering SELECT TYPE construct <br>semantics<br> <li> Positive tests: intrinsic types with CLASS DEFAULT, derived types with <br>selector rename, nested SELECT TYPE with CLASS IS<br> <li> Negative tests: invalid guard syntax (missing <code>is</code> keyword) and <br>malformed CLASS DEFAULT with type-spec<br> <li> Uses ANTLR4 parser to validate Fortran 2003 code against existing <br>grammar rules</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/76/files#diff-fc10a91ca8530f98634fd4e74d82fa7e94b9525d8837a469b9023c29803e012a">+171/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

