### PR TITLE
Fortran 2003: fixed-form F2003 feature coverage

### DIFF
--- a/grammars/fortran_2003_limitations.md
+++ b/grammars/fortran_2003_limitations.md
@@ -181,6 +181,32 @@ These features are tracked in separate GitHub issues for future implementation:
 and tested; detailed DT edit-descriptor parsing and full semantic coverage
 remain out of scope for this grammar.
 
+### 9. Fixed-form F2003 Features (Issue #72 - SUBSTANTIAL COVERAGE)
+
+**Working Features:**
+- ✅ Fixed-form modules using F2003 features parse correctly, including:
+  - Type-bound procedures inside derived types.
+  - `CLASS(type_name)` and `CLASS(*)` dummy arguments.
+  - `SELECT TYPE` with TYPE IS and CLASS DEFAULT guards.
+  - ASSOCIATE constructs and BLOCK-like structured code.
+  - BIND(C) procedures and `type, bind(c)` derived types.
+- ✅ Fixed-form comments beginning with `C` or `*` and free-form comments
+  beginning with `!` coexist as expected under the unified lexer.
+- ✅ Tests exercise F2003 features written in upper-case, fixed-form style
+  to ensure they follow the same code paths as free-form input.
+
+**Test Status:**
+- Positive tests for fixed-form F2003 code live in:
+  - `tests/Fortran2003/test_fortran_2003_comprehensive.py`
+    (`test_fixed_form_compatibility`)
+  - `tests/Fortran2003/test_issue72_fixed_form_f2003.py`
+
+**Remaining Notes:**
+- ⚠️ Full emulation of historical column semantics (exact column-6
+  continuation, sequence fields 73–80, etc.) is intentionally not modeled.
+  The fixed-form support is aimed at “typical” fixed-layout Fortran that
+  appears in modern code bases rather than archival reconstruction.
+
 ## Working Features
 
 ✅ **Fully Functional:**

--- a/tests/Fortran2003/test_issue72_fixed_form_f2003.py
+++ b/tests/Fortran2003/test_issue72_fixed_form_f2003.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Issue #72 – Fortran 2003 fixed-form source with F2003 features
+
+These tests exercise F2003 features written in traditional fixed-form
+layout (upper-case, column-based style), to validate that the unified
+lexer/parser handle both formats.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from antlr4 import InputStream, CommonTokenStream
+
+sys.path.append(str(Path(__file__).parent.parent.parent / "grammars"))
+
+from Fortran2003Lexer import Fortran2003Lexer
+from Fortran2003Parser import Fortran2003Parser
+
+
+def parse_f2003(code: str):
+    """Parse Fortran 2003 code and return (tree, errors, parser)."""
+    input_stream = InputStream(code)
+    lexer = Fortran2003Lexer(input_stream)
+    parser = Fortran2003Parser(CommonTokenStream(lexer))
+    tree = parser.program_unit_f2003()
+    return tree, parser.getNumberOfSyntaxErrors(), parser
+
+
+class TestF2003FixedFormFeatures:
+    """Fixed-form tests for representative F2003 features."""
+
+    def test_fixed_form_oop_and_class_star(self):
+        """Fixed-form module with type-bound procedure and CLASS(*) dummy."""
+        code = """
+C   F2003 OOP and CLASS(*) in fixed-form
+      MODULE F2003_FIXED_OOP
+      IMPLICIT NONE
+
+      TYPE SHAPE_T
+        REAL :: AREA
+      CONTAINS
+        PROCEDURE :: PRINT_AREA
+      END TYPE SHAPE_T
+
+      CONTAINS
+
+      SUBROUTINE PRINT_AREA(THIS)
+        CLASS(SHAPE_T), INTENT(IN) :: THIS
+        WRITE(*,*) 'AREA =', THIS%AREA
+      END SUBROUTINE PRINT_AREA
+
+      END MODULE F2003_FIXED_OOP
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_fixed_form_select_type_and_associate(self):
+        """SELECT TYPE and ASSOCIATE in fixed-form style."""
+        code = """
+C   F2003 SELECT TYPE and ASSOCIATE in fixed form
+      MODULE F2003_FIXED_SELECT
+      IMPLICIT NONE
+
+      TYPE SHAPE_T
+        REAL :: R
+      END TYPE SHAPE_T
+
+      CONTAINS
+
+      SUBROUTINE RENDER(OBJ)
+        CLASS(*), INTENT(IN) :: OBJ
+        SELECT TYPE (OBJ)
+        TYPE IS (SHAPE_T)
+          ASSOCIATE (RADIUS => OBJ%R)
+            PRINT *, 'RADIUS =', RADIUS
+          END ASSOCIATE
+        CLASS DEFAULT
+          PRINT *, 'UNKNOWN SHAPE'
+        END SELECT
+      END SUBROUTINE RENDER
+
+      END MODULE F2003_FIXED_SELECT
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_fixed_form_pdt_and_bind_c(self):
+        """PDT and BIND(C) usage in fixed-form."""
+        code = """
+C   F2003 PDT and BIND(C) in fixed form
+      MODULE F2003_FIXED_PDT_C
+      USE ISO_C_BINDING
+      IMPLICIT NONE
+
+      TYPE MATRIX_T(K,M,N)
+        INTEGER, KIND :: K
+        INTEGER, LEN  :: M, N
+        REAL(K)       :: DATA(M,N)
+      END TYPE MATRIX_T
+
+      TYPE, BIND(C) :: POINT_T
+        REAL(C_DOUBLE) :: X
+        REAL(C_DOUBLE) :: Y
+      END TYPE POINT_T
+
+      CONTAINS
+
+      SUBROUTINE FILL_MATRIX(MAT) BIND(C, NAME=\"FILL_MATRIX\")
+        TYPE(MATRIX_T(8,3,3)), INTENT(OUT) :: MAT
+        INTEGER :: I, J
+        DO I = 1, 3
+          DO J = 1, 3
+            MAT%DATA(I,J) = REAL(I*J,8)
+          END DO
+        END DO
+      END SUBROUTINE FILL_MATRIX
+
+      END MODULE F2003_FIXED_PDT_C
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0


### PR DESCRIPTION
### **User description**
Add tests and documentation for Fortran 2003 features written in fixed-form source (issue #72).

### New tests
- **`tests/Fortran2003/test_issue72_fixed_form_f2003.py`**
  - `test_fixed_form_oop_and_class_star`
    - Fixed-form module `F2003_FIXED_OOP` with:
      - Derived type `SHAPE_T` and type-bound procedure `PRINT_AREA`.
      - Subroutine `PRINT_AREA` with `CLASS(SHAPE_T), INTENT(IN)` dummy and
        a simple `WRITE` statement.
  - `test_fixed_form_select_type_and_associate`
    - Fixed-form module `F2003_FIXED_SELECT` using:
      - `CLASS(*)` dummy argument.
      - `SELECT TYPE (OBJ)` with `TYPE IS (SHAPE_T)` and `CLASS DEFAULT`
        branches.
      - An `ASSOCIATE` construct inside the TYPE IS branch.
  - `test_fixed_form_pdt_and_bind_c`
    - Fixed-form module `F2003_FIXED_PDT_C` combining:
      - PDT `MATRIX_T(K,M,N)` with kind and len parameters and `DATA(M,N)`.
      - `type, bind(c) :: POINT_T` with `REAL(C_DOUBLE)` components.
      - Subroutine `FILL_MATRIX` with `BIND(C, NAME="FILL_MATRIX")` and a
        `TYPE(MATRIX_T(8,3,3)), INTENT(OUT)` dummy, using simple `DO` loops
        and component references `MAT%DATA(I,J)`.

### Documentation
- Updated **`grammars/fortran_2003_limitations.md`** with a new section
  "Fixed-form F2003 Features (Issue #72 - SUBSTANTIAL COVERAGE)" that:
  - Describes the level of fixed-form support for F2003 constructs
    (type-bound procedures, CLASS(*), SELECT TYPE, ASSOCIATE, BIND(C),
    and `type, bind(c)` derived types).
  - Notes that strict historical column semantics (exact column-6
    continuation rules, sequence fields) are intentionally not modeled;
    the focus is on typical fixed-layout Fortran as it appears in modern
    Fortran code bases.

### Tests
- `pytest tests/Fortran2003 -q` → 106 passed.
- `pytest tests -q` → 304 passed, 274 subtests passed.

Fixes #72.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add comprehensive tests for Fortran 2003 fixed-form features

- Test type-bound procedures, CLASS(*), SELECT TYPE constructs

- Test PDT and BIND(C) in fixed-form source code

- Document fixed-form F2003 feature coverage and limitations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed-form F2003 Tests"] --> B["Type-bound Procedures"]
  A --> C["CLASS(*) & SELECT TYPE"]
  A --> D["PDT & BIND(C)"]
  B --> E["Test Suite"]
  C --> E
  D --> E
  E --> F["Documentation Updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue72_fixed_form_f2003.py</strong><dd><code>New fixed-form F2003 feature test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2003/test_issue72_fixed_form_f2003.py

<ul><li>New test file with three test methods covering F2003 fixed-form <br>features<br> <li> <code>test_fixed_form_oop_and_class_star</code>: Tests type-bound procedures and <br>CLASS dummy arguments<br> <li> <code>test_fixed_form_select_type_and_associate</code>: Tests SELECT TYPE and <br>ASSOCIATE constructs<br> <li> <code>test_fixed_form_pdt_and_bind_c</code>: Tests parameterized derived types and <br>BIND(C) procedures<br> <li> All tests parse fixed-form Fortran code and verify zero syntax errors</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/79/files#diff-7725625f14f4dbd34e75960a1c8cf579657ba00927c5fb3048cd91103cabdadd">+126/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortran_2003_limitations.md</strong><dd><code>Document fixed-form F2003 feature coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/fortran_2003_limitations.md

<ul><li>Added new section "Fixed-form F2003 Features (Issue #72 - SUBSTANTIAL <br>COVERAGE)"<br> <li> Documents working features: type-bound procedures, CLASS(*), SELECT <br>TYPE, ASSOCIATE, BIND(C)<br> <li> Notes that fixed-form comments (C, *) and free-form comments (!) <br>coexist correctly<br> <li> References test locations and clarifies that historical column <br>semantics are intentionally not modeled<br> <li> Emphasizes support for "typical" fixed-layout Fortran in modern code <br>bases</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/79/files#diff-c69500015427facc624c22a2abd00b42c35d165a96e98d26753a5173feac96ee">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

