### PR TITLE
Issue #84: use DO CONCURRENT keywords and enable strict test

### DIFF
--- a/grammars/Fortran2008Parser.g4
+++ b/grammars/Fortran2008Parser.g4
@@ -265,7 +265,7 @@ do_concurrent_construct
     ;
 
 do_concurrent_stmt
-    : (IDENTIFIER COLON)? DO_CONCURRENT concurrent_header NEWLINE
+    : (IDENTIFIER COLON)? DO CONCURRENT concurrent_header NEWLINE
     ;
 
 concurrent_header

--- a/tests/Fortran2008/test_basic_f2008_features.py
+++ b/tests/Fortran2008/test_basic_f2008_features.py
@@ -76,7 +76,6 @@ end submodule child_sub"""
         assert tree is not None, "Submodule syntax failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for basic submodule, got {errors}"
 
-    @pytest.mark.skip(reason="Fortran 2008 DO CONCURRENT syntax not yet fully implemented (see issue #84)")
     def test_do_concurrent_tokens(self):
         """Test DO CONCURRENT token recognition (future strict test)"""
         code = """module test


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace `DO_CONCURRENT` token with separate `DO` and `CONCURRENT` keywords

- Enable previously skipped DO CONCURRENT syntax test

- Improve Fortran 2008 grammar compliance for parallelization constructs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DO_CONCURRENT Token"] -- "split into" --> B["DO Keyword"]
  A -- "split into" --> C["CONCURRENT Keyword"]
  B -- "combined in" --> D["do_concurrent_stmt Rule"]
  C -- "combined in" --> D
  E["Skipped Test"] -- "enabled" --> F["test_do_concurrent_tokens"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fortran2008Parser.g4</strong><dd><code>Split DO_CONCURRENT token into separate keywords</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/Fortran2008Parser.g4

<ul><li>Changed <code>do_concurrent_stmt</code> rule to use separate <code>DO CONCURRENT</code> keywords <br>instead of single <code>DO_CONCURRENT</code> token<br> <li> Maintains concurrent_header and overall construct structure<br> <li> Aligns grammar with Fortran 2008 standard syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/95/files#diff-219c1b2de302541f84c4c05a7a245385248f446057497c796f6df193422f49d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_basic_f2008_features.py</strong><dd><code>Enable DO CONCURRENT syntax recognition test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2008/test_basic_f2008_features.py

<ul><li>Removed <code>@pytest.mark.skip</code> decorator from <code>test_do_concurrent_tokens</code> <br>test<br> <li> Test now executes to validate DO CONCURRENT token recognition<br> <li> Enables strict testing for Fortran 2008 parallelization features</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/95/files#diff-fd68ceeecf8e7c7f1b710bd12ea00cc243ceb18485da7169038ec6ee3abd9de4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

