### PR TITLE
Issue #85: complete Fortran 2008 submodule grammar

### DIFF
--- a/grammars/Fortran2008Lexer.g4
+++ b/grammars/Fortran2008Lexer.g4
@@ -30,7 +30,7 @@ MEMORY           : M E M O R Y ;
 
 // Submodules (NEW in F2008)
 SUBMODULE        : S U B M O D U L E ;
-END_SUBMODULE    : E N D '_' S U B M O D U L E ;
+END_SUBMODULE    : E N D WS+ S U B M O D U L E ;
 
 // Enhanced DO Constructs (NEW in F2008)
 DO_CONCURRENT    : D O '_' C O N C U R R E N T ;

--- a/grammars/Fortran2008Parser.g4
+++ b/grammars/Fortran2008Parser.g4
@@ -83,7 +83,8 @@ end_submodule_stmt
     ;
 
 parent_identifier
-    : IDENTIFIER (COLON IDENTIFIER)?  // parent_module_name[:parent_submodule_name]
+    : IDENTIFIER (COLON IDENTIFIER)*
+      // parent_module_name[:parent_submodule_name[:...]]
     ;
 
 submodule_identifier
@@ -242,10 +243,39 @@ lhs_expression
 
 // Override the F2003 module_subprogram rule so that module-contained
 // procedures use the F2008-aware subprogram rules and therefore can
-// contain coarray and SYNC constructs.
+// contain coarray and SYNC constructs.  For F2008 submodules we also
+// need to support "separate module procedure" definitions that start
+// with MODULE SUBROUTINE / MODULE FUNCTION.
 module_subprogram
     : function_subprogram_f2008
     | subroutine_subprogram_f2008
+    | module_subroutine_subprogram_f2008
+    | module_function_subprogram_f2008
+    ;
+
+// Separate module subroutine definition inside a submodule
+module_subroutine_subprogram_f2008
+    : module_subroutine_stmt_f2008 specification_part_f2008?
+      execution_part_f2008? internal_subprogram_part? end_subroutine_stmt
+    ;
+
+// Separate module function definition inside a submodule
+module_function_subprogram_f2008
+    : module_function_stmt_f2008 specification_part_f2008?
+      execution_part_f2008? internal_subprogram_part? end_function_stmt
+    ;
+
+// MODULE SUBROUTINE statement (F2008 submodules)
+module_subroutine_stmt_f2008
+    : MODULE SUBROUTINE IDENTIFIER
+      (LPAREN dummy_arg_name_list? RPAREN)?
+      binding_spec? NEWLINE
+    ;
+
+// MODULE FUNCTION statement (F2008 submodules)
+module_function_stmt_f2008
+    : MODULE FUNCTION IDENTIFIER LPAREN dummy_arg_name_list? RPAREN
+      suffix? binding_spec? NEWLINE
     ;
 
 // ============================================================================

--- a/tests/Fortran2008/test_f2008_submodules.py
+++ b/tests/Fortran2008/test_f2008_submodules.py
@@ -16,7 +16,6 @@ from antlr4 import *
 from Fortran2008Lexer import Fortran2008Lexer
 from Fortran2008Parser import Fortran2008Parser
 
-@pytest.mark.skip(reason="Fortran 2008 submodule grammar is not yet fully implemented (see issue #85)")
 class TestF2008Submodules:
     """Test F2008 submodule functionality"""
     
@@ -34,7 +33,8 @@ class TestF2008Submodules:
         """Test basic submodule declaration syntax"""
         code = """submodule (parent_mod) child_sub
     implicit none
-end submodule child_sub"""
+end submodule child_sub
+"""
         tree, errors = self.parse_code(code)
         assert tree is not None, "Basic submodule failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for basic submodule, got {errors}"
@@ -43,7 +43,8 @@ end submodule child_sub"""
         """Test submodule with parent submodule reference"""
         code = """submodule (parent_mod:parent_sub) child_sub
     implicit none
-end submodule child_sub"""
+end submodule child_sub
+"""
         tree, errors = self.parse_code(code)
         assert tree is not None, "Parent hierarchy failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for parent hierarchy, got {errors}"
@@ -54,14 +55,15 @@ end submodule child_sub"""
     implicit none
 contains
     module subroutine calculate_result()
-        print *, 'Calculation performed in submodule'  
+        print *, 'Calculation performed in submodule'
     end subroutine calculate_result
-    
+
     module function compute_value() result(val)
         real :: val
         val = 42.0
     end function compute_value
-end submodule implementation_sub"""
+end submodule implementation_sub
+"""
         tree, errors = self.parse_code(code)
         assert tree is not None, "Procedure submodule failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for procedure submodule, got {errors}"
@@ -70,7 +72,8 @@ end submodule implementation_sub"""
         """Test deeply nested submodule references"""
         code = """submodule (grandparent_mod:parent_sub:child_sub) grandchild_sub
     implicit none
-end submodule grandchild_sub"""
+end submodule grandchild_sub
+"""
         tree, errors = self.parse_code(code)
         assert tree is not None, "Nested submodule failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for nested submodule, got {errors}"


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Remove skip marker from F2008 submodule tests, enabling test execution

- Fix lexer token for `END_SUBMODULE` to use whitespace instead of underscore

- Add support for deeply nested parent submodule hierarchies with multiple colons

- Implement separate module procedure definitions (`MODULE SUBROUTINE`/`MODULE FUNCTION`) for submodules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["F2008 Submodule Grammar"] --> B["Lexer: Fix END_SUBMODULE Token"]
  A --> C["Parser: Support Nested Hierarchies"]
  A --> D["Parser: Module Procedure Definitions"]
  A --> E["Tests: Enable Submodule Tests"]
  B -- "WS+ instead of underscore" --> F["Correct Token Recognition"]
  C -- "Multiple COLON separators" --> G["Grandparent:Parent:Child Support"]
  D -- "MODULE SUBROUTINE/FUNCTION" --> H["Separate Procedure Implementations"]
  E -- "Remove @pytest.mark.skip" --> I["Tests Now Execute"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_f2008_submodules.py</strong><dd><code>Enable F2008 submodule tests and fix formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2008/test_f2008_submodules.py

<ul><li>Remove <code>@pytest.mark.skip</code> decorator to enable test execution<br> <li> Fix code formatting: add trailing newlines to test code strings<br> <li> Remove trailing whitespace from test code snippets<br> <li> Normalize blank lines in multi-line test code blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/96/files#diff-42a70785031d2b0fcd03a9172ba6959483770c6b51c7102ca35ae74a080f9ca7">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fortran2008Lexer.g4</strong><dd><code>Fix END_SUBMODULE token whitespace handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/Fortran2008Lexer.g4

<ul><li>Change <code>END_SUBMODULE</code> token definition from underscore separator to <br>whitespace pattern<br> <li> Replace <code>E N D '_' S U B M O D U L E</code> with <code>E N D WS+ S U B M O D U L E</code><br> <li> Aligns lexer with standard Fortran syntax for <code>END SUBMODULE</code> statement</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/96/files#diff-e0a13689c99b67be61ec6097657b55cbb13aacf45b89867605751eecf11ad335">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fortran2008Parser.g4</strong><dd><code>Add nested hierarchies and module procedure definitions</code>&nbsp; &nbsp; </dd></summary>
<hr>

grammars/Fortran2008Parser.g4

<ul><li>Change <code>parent_identifier</code> rule from single optional colon to multiple <br>colons using <code>*</code> quantifier<br> <li> Support deeply nested submodule hierarchies (e.g., <br><code>grandparent:parent:child</code>)<br> <li> Add two new grammar rules for separate module procedure definitions: <br><code>module_subroutine_subprogram_f2008</code> and <br><code>module_function_subprogram_f2008</code><br> <li> Add <code>module_subroutine_stmt_f2008</code> and <code>module_function_stmt_f2008</code> rules <br>to handle <code>MODULE SUBROUTINE</code> and <code>MODULE FUNCTION</code> declarations<br> <li> Update <code>module_subprogram</code> rule to include new separate module procedure <br>alternatives<br> <li> Enhance documentation comments explaining F2008 submodule support for <br>separate procedure definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/96/files#diff-219c1b2de302541f84c4c05a7a245385248f446057497c796f6df193422f49d8">+32/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

