### PR TITLE
Issue #86: enable strict tests for F2008 intrinsics

### DIFF
--- a/tests/Fortran2008/test_basic_f2008_features.py
+++ b/tests/Fortran2008/test_basic_f2008_features.py
@@ -90,18 +90,29 @@ end module test"""
         assert tree is not None, "DO CONCURRENT failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for DO CONCURRENT, got {errors}"
 
-    @pytest.mark.skip(reason="Fortran 2008 intrinsic procedure call syntax not yet fully implemented (see issue #86)")
     def test_enhanced_intrinsic_tokens(self):
-        """Test that F2008 intrinsic function tokens are recognized (future strict test)"""
+        """Test that F2008 intrinsic function tokens are recognized"""
         code = """module test_intrinsics
     implicit none
+    integer :: n, int_result
     contains
     subroutine test_functions()
         real :: x, result_val
         x = 1.0
         result_val = bessel_j0(x)
+        result_val = bessel_j1(x)
+        result_val = bessel_jn(n, x)
+        result_val = bessel_y0(x)
+        result_val = bessel_y1(x)
+        result_val = bessel_yn(n, x)
         result_val = erf(x)
+        result_val = erfc(x)
         result_val = gamma(x)
+        result_val = log_gamma(x)
+        result_val = norm2((/ x, 2.0*x /))
+        int_result = findloc((/ x, 2.0*x /), x)
+        int_result = storage_size(x)
+        int_result = parity((/ .true., .false., .true. /))
     end subroutine test_functions
 end module test_intrinsics"""
 


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Remove skip marker from F2008 intrinsic test, enabling strict validation

- Expand test coverage with additional Bessel, error, and gamma functions

- Add new intrinsic procedures: `findloc`, `storage_size`, `parity`, `norm2`

- Include comprehensive test cases for F2008 intrinsic function recognition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["F2008 Intrinsic Test"] -->|Remove Skip| B["Enable Strict Testing"]
  B -->|Expand Coverage| C["Add Bessel Functions"]
  B -->|Expand Coverage| D["Add Math Functions"]
  B -->|Expand Coverage| E["Add New Intrinsics"]
  C --> F["bessel_j0, j1, jn, y0, y1, yn"]
  D --> G["erf, erfc, gamma, log_gamma"]
  E --> H["findloc, storage_size, parity, norm2"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_basic_f2008_features.py</strong><dd><code>Enable and expand F2008 intrinsic function test coverage</code>&nbsp; </dd></summary>
<hr>

tests/Fortran2008/test_basic_f2008_features.py

<ul><li>Removed <code>@pytest.mark.skip</code> decorator to enable the F2008 intrinsic test<br> <li> Updated docstring to remove "future strict test" qualifier<br> <li> Added variable declarations for <code>n</code> and <code>int_result</code> to support new test <br>cases<br> <li> Expanded test code with 10 additional F2008 intrinsic function calls <br>covering Bessel functions (<code>bessel_j1</code>, <code>bessel_jn</code>, <code>bessel_y0</code>, <code>bessel_y1</code>, <br><code>bessel_yn</code>), error functions (<code>erfc</code>), gamma functions (<code>log_gamma</code>), and <br>new intrinsics (<code>norm2</code>, <code>findloc</code>, <code>storage_size</code>, <code>parity</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/97/files#diff-fd68ceeecf8e7c7f1b710bd12ea00cc243ceb18485da7169038ec6ee3abd9de4">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

