### PR TITLE
Issue #87: implement ERROR STOP and CONTIGUOUS attribute

### DIFF
--- a/grammars/Fortran2008Lexer.g4
+++ b/grammars/Fortran2008Lexer.g4
@@ -40,7 +40,7 @@ CONCURRENT       : C O N C U R R E N T ;
 CONTIGUOUS       : C O N T I G U O U S ;
 
 // Enhanced Error Handling (NEW in F2008)
-ERROR_STOP       : E R R O R '_' S T O P ;
+ERROR_STOP       : E R R O R WS+ S T O P ;
 
 // Additional Intrinsic Procedures (NEW in F2008)
 BESSEL_J0        : B E S S E L '_' J '0' ;

--- a/grammars/Fortran2008Parser.g4
+++ b/grammars/Fortran2008Parser.g4
@@ -349,6 +349,22 @@ contiguous_stmt
     : CONTIGUOUS DOUBLE_COLON object_name_list NEWLINE
     ;
 
+// Extend F2003 attr_spec to include CONTIGUOUS as a valid attribute
+attr_spec
+    : PUBLIC
+    | PRIVATE
+    | ALLOCATABLE
+    | POINTER
+    | INTENT LPAREN intent_spec RPAREN
+    | OPTIONAL
+    | TARGET
+    | VOLATILE
+    | PROTECTED
+    | PARAMETER
+    | VALUE
+    | CONTIGUOUS
+    ;
+
 // ============================================================================
 // ENHANCED ALLOCATE STATEMENT (F2008)
 // ============================================================================

--- a/tests/Fortran2008/test_basic_f2008_features.py
+++ b/tests/Fortran2008/test_basic_f2008_features.py
@@ -134,21 +134,18 @@ end module test_kinds"""
         assert tree is not None, "Integer kinds failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for integer kinds, got {errors}"
 
-    @pytest.mark.skip(reason="Fortran 2008 ERROR STOP not yet fully implemented (see issue #87)")
     def test_error_stop_token(self):
-        """Test ERROR STOP statement token"""
+        """Test ERROR STOP statement"""
         code = """program test
     error stop 'Critical error occurred'
 end program test"""
 
         tree, errors = self.parse_code(code)
         assert tree is not None, "ERROR STOP failed to produce parse tree"
-        # Track remaining work in issue #87
         assert errors == 0, f"Expected 0 errors for ERROR STOP, got {errors}"
     
-    @pytest.mark.skip(reason="Fortran 2008 CONTIGUOUS attribute not yet fully implemented (see issue #87)")
     def test_contiguous_attribute_token(self):
-        """Test CONTIGUOUS attribute token"""
+        """Test CONTIGUOUS attribute"""
         code = """module test_contiguous
     implicit none
     real, contiguous, pointer :: array_ptr(:)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implement ERROR STOP statement support in Fortran 2008

- Add CONTIGUOUS attribute to attribute specification rules

- Fix ERROR_STOP lexer token to use whitespace separator

- Remove skip decorators from passing test cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fortran 2008 Features"] --> B["ERROR STOP Statement"]
  A --> C["CONTIGUOUS Attribute"]
  B --> D["Lexer: WS+ separator"]
  C --> E["Parser: attr_spec rule"]
  D --> F["Tests: Enabled"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_basic_f2008_features.py</strong><dd><code>Enable ERROR STOP and CONTIGUOUS attribute tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2008/test_basic_f2008_features.py

<ul><li>Removed <code>@pytest.mark.skip</code> decorator from <code>test_error_stop_token</code> test<br> <li> Removed <code>@pytest.mark.skip</code> decorator from <br><code>test_contiguous_attribute_token</code> test<br> <li> Updated docstrings to remove "token" suffix<br> <li> Removed obsolete issue tracking comment</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/98/files#diff-fd68ceeecf8e7c7f1b710bd12ea00cc243ceb18485da7169038ec6ee3abd9de4">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fortran2008Lexer.g4</strong><dd><code>Fix ERROR_STOP lexer token whitespace handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/Fortran2008Lexer.g4

<ul><li>Changed ERROR_STOP token definition from underscore separator to <br>whitespace<br> <li> Updated pattern from <code>E R R O R '_' S T O P</code> to <code>E R R O R WS+ S T O P</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/98/files#diff-e0a13689c99b67be61ec6097657b55cbb13aacf45b89867605751eecf11ad335">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fortran2008Parser.g4</strong><dd><code>Add CONTIGUOUS to attribute specification rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/Fortran2008Parser.g4

<ul><li>Added new <code>attr_spec</code> rule extending F2003 attribute specifications<br> <li> Includes CONTIGUOUS as valid attribute alongside existing attributes<br> <li> Covers PUBLIC, PRIVATE, ALLOCATABLE, POINTER, INTENT, OPTIONAL, <br>TARGET, VOLATILE, PROTECTED, PARAMETER, VALUE</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/98/files#diff-219c1b2de302541f84c4c05a7a245385248f446057497c796f6df193422f49d8">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

