### PR TITLE
Issue #100: add auto-discovery tests for fixture parsing

### DIFF
--- a/tests/test_fixture_parsing.py
+++ b/tests/test_fixture_parsing.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Generic fixture-based parsing tests for standard Fortran grammars.
+
+This module auto-discovers Fortran source fixtures under tests/fixtures/<Standard>/
+and verifies that each example parses with zero syntax errors using the
+appropriate lexer/parser and top-level program_unit rule for that standard.
+
+The goal is that adding a new .f / .f90 / .lf fixture file automatically
+adds coverage, without needing to edit per-standard pytest files.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+
+# Make grammars and fixture utilities importable
+ROOT = Path(__file__).resolve().parent
+GRAMMARS = ROOT.parent / "grammars"
+sys.path.insert(0, str(GRAMMARS))
+sys.path.append(str(ROOT))
+
+from fixture_utils import load_fixture  # noqa: E402
+
+FIXTURES_ROOT = ROOT / "fixtures"
+
+
+class StandardConfig:
+    """Configuration for a standard's lexer/parser and entry rule."""
+
+    def __init__(self, lexer_name: str, parser_name: str, entry_rule: str):
+        self.lexer_name = lexer_name
+        self.parser_name = parser_name
+        self.entry_rule = entry_rule
+        self.lexer_cls = None
+        self.parser_cls = None
+        self._import()
+
+    def _import(self) -> None:
+        try:
+            module = __import__(self.lexer_name, fromlist=[self.lexer_name])
+            self.lexer_cls = getattr(module, self.lexer_name)
+            parser_module = __import__(self.parser_name, fromlist=[self.parser_name])
+            self.parser_cls = getattr(parser_module, self.parser_name)
+        except Exception:
+            # Leave classes as None; tests will be skipped for this standard.
+            self.lexer_cls = None
+            self.parser_cls = None
+
+    @property
+    def available(self) -> bool:
+        return self.lexer_cls is not None and self.parser_cls is not None
+
+
+STANDARD_CONFIGS: Dict[str, StandardConfig] = {
+    "Fortran2003": StandardConfig(
+        lexer_name="Fortran2003Lexer",
+        parser_name="Fortran2003Parser",
+        entry_rule="program_unit_f2003",
+    ),
+    "Fortran2008": StandardConfig(
+        lexer_name="Fortran2008Lexer",
+        parser_name="Fortran2008Parser",
+        entry_rule="program_unit_f2008",
+    ),
+    "Fortran2023": StandardConfig(
+        lexer_name="Fortran2023Lexer",
+        parser_name="Fortran2023Parser",
+        entry_rule="program_unit_f2023",
+    ),
+}
+
+
+def _discover_fixtures() -> List[Tuple[str, Path]]:
+    """Discover all .f / .f90 / .lf fixtures under tests/fixtures."""
+    cases: List[Tuple[str, Path]] = []
+    if not FIXTURES_ROOT.exists():
+        return cases
+
+    for standard_dir in FIXTURES_ROOT.iterdir():
+        if not standard_dir.is_dir():
+            continue
+        standard = standard_dir.name
+        if standard not in STANDARD_CONFIGS:
+            continue
+        for path in standard_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in {".f", ".f90", ".lf"}:
+                continue
+            rel = path.relative_to(FIXTURES_ROOT)
+            cases.append((standard, rel))
+
+    # Deterministic order for stable test ids
+    cases.sort(key=lambda item: str(item[1]))
+    return cases
+
+
+FIXTURE_CASES = _discover_fixtures()
+
+# Fixtures that are known to produce syntax errors with the current
+# simplified grammars but are still valuable as examples. These are
+# covered by more focused tests and should not fail the generic
+# auto-discovery suite.
+XPASS_FIXTURES = {
+    # Fortran2003 fixed-form example currently requires a leading newline
+    # when wrapped in the existing test; direct program_unit_f2003 entry
+    # reports one syntax error on the leading comment.
+    ("Fortran2003", Path("Fortran2003/test_fortran_2003_comprehensive/fixed_form_f2003.f")),
+    # Fortran2023 fixtures exercising areas where the F2023 parser is still
+    # a forward-looking stub and not fully error-free.
+    ("Fortran2023", Path("Fortran2023/test_fortran_2023_comprehensive/basic_program.f90")),
+    ("Fortran2023", Path("Fortran2023/test_fortran_2023_comprehensive/boz_array_constructor.f90")),
+    ("Fortran2023", Path("Fortran2023/test_fortran_2023_comprehensive/conditional_expression.f90")),
+    ("Fortran2023", Path("Fortran2023/test_fortran_2023_comprehensive/f2018_compat_program.f90")),
+    ("Fortran2023", Path("Fortran2023/test_fortran_2023_comprehensive/enum_program.f90")),
+    ("Fortran2023", Path("Fortran2023/test_fortran_2023_comprehensive/ieee_program.f90")),
+    ("Fortran2023", Path("Fortran2023/test_fortran_2023_comprehensive/mixed_era_program.f90")),
+}
+
+
+@pytest.mark.parametrize("standard, relpath", FIXTURE_CASES)
+def test_fixture_parses_without_errors(standard: str, relpath: Path) -> None:
+    """Ensure each fixture parses with zero syntax errors for its standard."""
+    cfg = STANDARD_CONFIGS[standard]
+    if not cfg.available:
+        pytest.skip(f"{standard} lexer/parser not available")
+
+    # Lazy import to avoid importing antlr4 at module import time if unnecessary
+    from antlr4 import InputStream, CommonTokenStream  # type: ignore
+
+    # Load code from fixture and parse
+    code = load_fixture(*relpath.parts)
+    input_stream = InputStream(code)
+    lexer = cfg.lexer_cls(input_stream)
+    parser = cfg.parser_cls(CommonTokenStream(lexer))
+
+    entry = getattr(parser, cfg.entry_rule)
+    tree = entry()
+    errors = parser.getNumberOfSyntaxErrors()
+
+    assert tree is not None, f"{standard} fixture {relpath} did not produce a parse tree"
+
+    if (standard, relpath) in XPASS_FIXTURES:
+        pytest.xfail(
+            f"{standard} fixture {relpath} is a known forward-looking example "
+            f"that currently produces {errors} syntax errors"
+        )
+
+    assert errors == 0, (
+        f"{standard} fixture {relpath} expected 0 syntax errors, got {errors}"
+    )


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add auto-discovery test suite for Fortran fixture parsing

- Automatically discover and test all fixture files across standards

- Support Fortran2003, Fortran2008, and Fortran2023 standards

- Mark known failing fixtures with xfail for forward-looking examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixture Discovery"] --> B["StandardConfig Setup"]
  B --> C["Parametrized Tests"]
  C --> D["Parse Validation"]
  D --> E["Error Reporting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_fixture_parsing.py</strong><dd><code>Auto-discovery test suite for Fortran fixture parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_fixture_parsing.py

<ul><li>New test module implementing auto-discovery of Fortran fixture files<br> <li> <code>StandardConfig</code> class manages lexer/parser configuration per standard<br> <li> <code>_discover_fixtures()</code> function recursively finds .f/.f90/.lf files<br> <li> Parametrized test validates each fixture parses with zero syntax <br>errors<br> <li> <code>XPASS_FIXTURES</code> set marks known failing fixtures as expected failures</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/104/files#diff-10aa009b59d5e60452bb7a3d24cc175f7c3c74797b91d30fe39314862c8e497e">+155/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

