### PR TITLE
Issue #100: move F2018 basic feature tests to fixtures

### DIFF
--- a/tests/Fortran2018/test_basic_f2018_features.py
+++ b/tests/Fortran2018/test_basic_f2018_features.py
@@ -9,11 +9,15 @@ These are REAL tests that:
 """
 
 import sys
-import os
 import pytest
+from pathlib import Path
+
+# Ensure we can import shared test fixtures utilities
+sys.path.append(str(Path(__file__).parent.parent))
+from fixture_utils import load_fixture
 
 # Add grammars directory to Python path for generated parsers
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../grammars'))
+sys.path.append(str(Path(__file__).parent.parent.parent / "grammars"))
 
 from antlr4 import *
 from Fortran2018Lexer import Fortran2018Lexer  
@@ -49,8 +53,11 @@ class TestBasicF2018Features:
     
     def test_basic_module_parsing_works(self):
         """REAL TEST: Verify basic module parsing works (inherited from F2008)"""
-        code = """module basic_test
-end module basic_test"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_basic_f2018_features",
+            "basic_module.f90",
+        )
         
         tree, errors = self.parse_code(code)
         
@@ -63,16 +70,11 @@ end module basic_test"""
     @pytest.mark.skip(reason="F2018 coarray inheritance from F2008 is incomplete (see issues #83 and #88)")
     def test_f2018_grammar_inheritance(self):
         """REAL TEST: Verify F2018 inherits F2008 coarray features"""
-        code = """module coarray_test
-    integer :: data[*]
-contains
-    subroutine test()
-        sync all
-        if (this_image() == 1) then
-            print *, 'inherited from F2008'
-        end if
-    end subroutine
-end module"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_basic_f2018_features",
+            "coarray_test_module.f90",
+        )
         
         tree, errors = self.parse_code(code)
         
@@ -85,20 +87,17 @@ end module"""
     @pytest.mark.skip(reason="F2018 coarray and SYNC support still being aligned with F2008 (see issues #83 and #88)")
     def test_f2018_parser_vs_f2008_functionality(self):
         """REAL TEST: Compare F2018 vs F2008 parsing on same code"""
-        code = """module comparison
-    integer :: x[*]
-    contains
-    subroutine sync_test()
-        sync all
-    end subroutine
-end module"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_basic_f2018_features",
+            "comparison_module.f90",
+        )
         
         # Test with F2018 parser
         f2018_tree, f2018_errors = self.parse_code(code)
         
         # Test with F2008 parser for comparison
         try:
-            sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../grammars'))
             from Fortran2008Lexer import Fortran2008Lexer
             from Fortran2008Parser import Fortran2008Parser
             
@@ -119,15 +118,11 @@ end module"""
     @pytest.mark.skip(reason="F2018 program-structure parsing still being aligned with the standard")
     def test_complex_program_structure_limitations(self):
         """REAL TEST: Document known program structure parsing limitations"""
-        code = """program complex_test
-    integer :: i
-    real :: x
-    
-    i = 1
-    x = 2.0
-    
-    print *, i, x
-end program"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_basic_f2018_features",
+            "complex_program.f90",
+        )
         
         tree, errors = self.parse_code(code)
         

--- a/tests/fixtures/Fortran2018/test_basic_f2018_features/basic_module.f90
+++ b/tests/fixtures/Fortran2018/test_basic_f2018_features/basic_module.f90
@@ -1,0 +1,3 @@
+module basic_test
+end module basic_test
+

--- a/tests/fixtures/Fortran2018/test_basic_f2018_features/coarray_test_module.f90
+++ b/tests/fixtures/Fortran2018/test_basic_f2018_features/coarray_test_module.f90
@@ -1,0 +1,11 @@
+module coarray_test
+    integer :: data[*]
+contains
+    subroutine test()
+        sync all
+        if (this_image() == 1) then
+            print *, 'inherited from F2008'
+        end if
+    end subroutine
+end module
+

--- a/tests/fixtures/Fortran2018/test_basic_f2018_features/comparison_module.f90
+++ b/tests/fixtures/Fortran2018/test_basic_f2018_features/comparison_module.f90
@@ -1,0 +1,8 @@
+module comparison
+    integer :: x[*]
+    contains
+    subroutine sync_test()
+        sync all
+    end subroutine
+end module
+

--- a/tests/fixtures/Fortran2018/test_basic_f2018_features/complex_program.f90
+++ b/tests/fixtures/Fortran2018/test_basic_f2018_features/complex_program.f90
@@ -1,0 +1,10 @@
+program complex_test
+    integer :: i
+    real :: x
+
+    i = 1
+    x = 2.0
+
+    print *, i, x
+end program
+


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Move F2018 test code samples to fixture files

- Replace hardcoded strings with fixture loader utility

- Refactor import paths using pathlib for better portability

- Improve test maintainability by separating test data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_basic_f2018_features.py<br/>with hardcoded strings"] -- "extract code samples" --> B["fixture files<br/>in tests/fixtures/"]
  A -- "refactor imports" --> C["use pathlib<br/>and load_fixture"]
  B --> D["basic_module.f90"]
  B --> E["coarray_test_module.f90"]
  B --> F["comparison_module.f90"]
  B --> G["complex_program.f90"]
  C --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_basic_f2018_features.py</strong><dd><code>Migrate test code to fixtures with pathlib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_basic_f2018_features.py

<ul><li>Replaced <code>os</code> module with <code>pathlib.Path</code> for path handling<br> <li> Added import of <code>load_fixture</code> utility from <code>fixture_utils</code><br> <li> Updated sys.path manipulation to use pathlib instead of os.path.join<br> <li> Refactored four test methods to load Fortran code from fixture files <br>instead of hardcoded strings<br> <li> Removed redundant sys.path.insert call in <br>test_f2018_parser_vs_f2008_functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/107/files#diff-7d416dadf00ac88201bf11a2e5e6f9663af181a51caf3e652c1fa03420080c46">+26/-31</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>basic_module.f90</strong><dd><code>Add basic module fixture file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_basic_f2018_features/basic_module.f90

<ul><li>Created new fixture file containing basic Fortran module test code<br> <li> Simple module structure for test_basic_module_parsing_works test</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/107/files#diff-0d258db4d760140eb26d6aa8354470ed68ecd94f16bed52c21c5ca840d7e35e4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>coarray_test_module.f90</strong><dd><code>Add coarray test module fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_basic_f2018_features/coarray_test_module.f90

<ul><li>Created new fixture file with coarray syntax test code<br> <li> Contains module with coarray declaration and sync operations<br> <li> Used by test_f2018_grammar_inheritance test</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/107/files#diff-d98b156178c73dcf084029667cb6a68090652c166493ca765046f10358aa9ba4">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>comparison_module.f90</strong><dd><code>Add parser comparison module fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_basic_f2018_features/comparison_module.f90

<ul><li>Created new fixture file for F2018 vs F2008 parser comparison<br> <li> Contains module with coarray and sync subroutine<br> <li> Used by test_f2018_parser_vs_f2008_functionality test</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/107/files#diff-d5c475619f872354f6d95425c2f365f8f1e3666406c9fc2e8d94bb160d3049f7">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>complex_program.f90</strong><dd><code>Add complex program structure fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_basic_f2018_features/complex_program.f90

<ul><li>Created new fixture file with complex program structure<br> <li> Contains program with variable declarations and assignments<br> <li> Used by test_complex_program_structure_limitations test</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/107/files#diff-da1861da468dc925412d5856145023830f049aeec6a1836ce01c283475a9eef3">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

