### PR TITLE
Issue #100: move F2018 IF program cases to fixtures

### DIFF
--- a/tests/Fortran2018/test_clean_if.py
+++ b/tests/Fortran2018/test_clean_if.py
@@ -2,14 +2,18 @@
 """Test clean IF construct parsing"""
 
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'grammars'))
+# Ensure we can import fixture utilities and grammars
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT.parent / "grammars"))
 
-from antlr4 import *
-from Fortran2018Lexer import Fortran2018Lexer  
-from Fortran2018Parser import Fortran2018Parser
-from antlr4.error.ErrorListener import ErrorListener
+from antlr4 import *  # type: ignore
+from antlr4.error.ErrorListener import ErrorListener  # type: ignore
+from Fortran2018Lexer import Fortran2018Lexer  # type: ignore
+from Fortran2018Parser import Fortran2018Parser  # type: ignore
+from fixture_utils import load_fixture
 
 class TestErrorListener(ErrorListener):
     def __init__(self):
@@ -47,10 +51,11 @@ endif"""
 
 def test_wrapped_program():
     # Test wrapped in program
-    code = """program test
-if (mydummy > 90.and.gggg > 0) then
-endif
-end program test"""
+    code = load_fixture(
+        "Fortran2018",
+        "test_clean_if",
+        "wrapped_program.f90",
+    )
     
     print(f"\nTesting wrapped in program:")
     print(f"Code: {repr(code)}")

--- a/tests/Fortran2018/test_endif_simple.py
+++ b/tests/Fortran2018/test_endif_simple.py
@@ -2,14 +2,18 @@
 """Test ENDIF parsing in programs"""
 
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'grammars'))
+# Ensure we can import fixture utilities and grammars
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT.parent / "grammars"))
 
-from antlr4 import *
-from Fortran2018Lexer import Fortran2018Lexer  
-from Fortran2018Parser import Fortran2018Parser
-from antlr4.error.ErrorListener import ErrorListener
+from antlr4 import *  # type: ignore
+from antlr4.error.ErrorListener import ErrorListener  # type: ignore
+from Fortran2018Lexer import Fortran2018Lexer  # type: ignore
+from Fortran2018Parser import Fortran2018Parser  # type: ignore
+from fixture_utils import load_fixture
 
 class TestErrorListener(ErrorListener):
     def __init__(self):
@@ -44,15 +48,17 @@ def run_program_case(code, description):
 
 if __name__ == "__main__":
     # Test the exact missing-spaces case wrapped in program
-    missing_spaces_wrapped = """program test
-   if (mydummy > 90.and.gggg > 0) then
-   endif
-end program test"""
+    missing_spaces_wrapped = load_fixture(
+        "Fortran2018",
+        "test_endif_simple",
+        "missing_spaces_wrapped.f90",
+    )
     run_program_case(missing_spaces_wrapped, "Missing-spaces wrapped in program")
     
     # Test simpler case
-    simple_endif = """program test
-if (x > 0) then
-endif
-end program test"""
+    simple_endif = load_fixture(
+        "Fortran2018",
+        "test_endif_simple",
+        "simple_endif.f90",
+    )
     run_program_case(simple_endif, "Simple ENDIF in program")

--- a/tests/fixtures/Fortran2018/test_clean_if/wrapped_program.f90
+++ b/tests/fixtures/Fortran2018/test_clean_if/wrapped_program.f90
@@ -1,0 +1,5 @@
+program test
+if (mydummy > 90.and.gggg > 0) then
+endif
+end program test
+

--- a/tests/fixtures/Fortran2018/test_endif_simple/missing_spaces_wrapped.f90
+++ b/tests/fixtures/Fortran2018/test_endif_simple/missing_spaces_wrapped.f90
@@ -1,0 +1,5 @@
+program test
+   if (mydummy > 90.and.gggg > 0) then
+   endif
+end program test
+

--- a/tests/fixtures/Fortran2018/test_endif_simple/simple_endif.f90
+++ b/tests/fixtures/Fortran2018/test_endif_simple/simple_endif.f90
@@ -1,0 +1,5 @@
+program test
+if (x > 0) then
+endif
+end program test
+


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Move hardcoded Fortran test cases to fixture files

- Update test imports to use `fixture_utils.load_fixture()`

- Improve path handling with `pathlib.Path` for better portability

- Add type ignore comments for ANTLR imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded test code<br/>in Python files"] -- "Extract to<br/>fixture files" --> B["Fortran fixture files<br/>in tests/fixtures/"]
  C["Test files<br/>with os module"] -- "Refactor imports<br/>and paths" --> D["Test files<br/>using fixture_utils"]
  D -- "load_fixture" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_clean_if.py</strong><dd><code>Migrate to fixture-based test data loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_clean_if.py

<ul><li>Replaced <code>os</code> module with <code>pathlib.Path</code> for path handling<br> <li> Updated sys.path configuration to use ROOT variable<br> <li> Added import of <code>fixture_utils.load_fixture()</code> function<br> <li> Added type ignore comments to ANTLR imports<br> <li> Refactored <code>test_wrapped_program()</code> to load code from fixture file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/109/files#diff-5b9cf5c7a5f2fe04a685a967e5226c5698b596b4a961cc4fecf266a4f5f1ec89">+16/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_endif_simple.py</strong><dd><code>Migrate to fixture-based test data loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_endif_simple.py

<ul><li>Replaced <code>os</code> module with <code>pathlib.Path</code> for path handling<br> <li> Updated sys.path configuration to use ROOT variable<br> <li> Added import of <code>fixture_utils.load_fixture()</code> function<br> <li> Added type ignore comments to ANTLR imports<br> <li> Refactored two test cases to load code from fixture files</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/109/files#diff-216b179117907828e682e22ecd7a21863fd63fca5cfbece54451a6451bebd7f1">+20/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wrapped_program.f90</strong><dd><code>Add wrapped program IF test fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_clean_if/wrapped_program.f90

<ul><li>New fixture file containing Fortran program with IF construct<br> <li> Contains test case for wrapped IF statement in program context</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/109/files#diff-44f4e68ca2d782fbda161310bdd5d1f523fb69567b15cadde150a06bebfc6a41">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>missing_spaces_wrapped.f90</strong><dd><code>Add missing spaces wrapped program fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_endif_simple/missing_spaces_wrapped.f90

<ul><li>New fixture file containing Fortran program with missing spaces in IF <br>condition<br> <li> Contains test case for ENDIF parsing with spacing variations</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/109/files#diff-775a972fbfd68dee6b663b5854230513ef7fdb2e55238a6896729f9785eb359b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>simple_endif.f90</strong><dd><code>Add simple ENDIF program fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_endif_simple/simple_endif.f90

<ul><li>New fixture file containing simple Fortran program with ENDIF<br> <li> Contains basic test case for ENDIF parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/109/files#diff-6ddb393216c1da2c805d5f4a01632696d8127d12ae6fc0d353c81cbdaa3d70f3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

