### PR TITLE
fix: Add LazyFortran2025 Grammar Extension (fixes #50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 LazyFortran2025 is a comprehensive ANTLR4-based grammar implementation covering all FORTRAN/Fortran standards from 1957 to 2023+. The project uses a revolutionary modular inheritance architecture where each standard only defines NEW features and imports from its predecessor.
 
+LazyFortran2025 now ships as an ANTLR4 grammar pair (`LazyFortran2025Lexer.g4` and `LazyFortran2025Parser.g4`) that imports the Fortran 2023 lexer and parser. The parser exposes two entry points:
+- `traditional_entry` for strict Fortran 2023 program units (standard `.f90+` files)
+- `lazy_entry` for `.lf` files with optional PROGRAM/MODULE wrappers, optional CONTAINS, and relaxed type declarations to support type inference at the semantic layer.
+
 ## Essential Build Commands
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TEST_DIR = tests
 PYTEST = python -m pytest
 
 # Grammar inheritance chain (build order matters!)
-GRAMMARS = FORTRAN FORTRANII FORTRAN66 FORTRAN77 Fortran90 Fortran95 Fortran2003 Fortran2008 Fortran2018 Fortran2023
+GRAMMARS = FORTRAN FORTRANII FORTRAN66 FORTRAN77 Fortran90 Fortran95 Fortran2003 Fortran2008 Fortran2018 Fortran2023 LazyFortran2025
 
 # Default target
 .PHONY: all clean test help
@@ -31,6 +31,8 @@ Fortran2003: $(GRAMMAR_DIR)/Fortran2003Lexer.py
 Fortran2008: $(GRAMMAR_DIR)/Fortran2008Lexer.py
 Fortran2018: $(GRAMMAR_DIR)/Fortran2018Lexer.py
 Fortran2023: $(GRAMMAR_DIR)/Fortran2023Lexer.py
+
+LazyFortran2025: $(GRAMMAR_DIR)/LazyFortran2025Lexer.py
 
 # FORTRAN I (1957) - Foundation
 $(GRAMMAR_DIR)/FORTRANLexer.py: $(GRAMMAR_DIR)/FORTRANLexer.g4 $(GRAMMAR_DIR)/FORTRANParser.g4
@@ -101,6 +103,13 @@ $(GRAMMAR_DIR)/Fortran2023Lexer.py: $(GRAMMAR_DIR)/Fortran2023Lexer.g4 $(GRAMMAR
 	cd $(GRAMMAR_DIR) && \
 	$(ANTLR4) $(ANTLR4_PYTHON) -lib . Fortran2023Lexer.g4 && \
 	$(ANTLR4) $(ANTLR4_PYTHON) -lib . Fortran2023Parser.g4
+
+# Lazy Fortran 2025 (future standard) - Relaxed syntax on top of Fortran 2023
+$(GRAMMAR_DIR)/LazyFortran2025Lexer.py: $(GRAMMAR_DIR)/LazyFortran2025Lexer.g4 $(GRAMMAR_DIR)/LazyFortran2025Parser.g4 Fortran2023
+	@echo "Building Lazy Fortran 2025..."
+	cd $(GRAMMAR_DIR) && \
+	$(ANTLR4) $(ANTLR4_PYTHON) -lib . LazyFortran2025Lexer.g4 && \
+	$(ANTLR4) $(ANTLR4_PYTHON) -lib . LazyFortran2025Parser.g4
 
 
 # ====================================================================

--- a/grammars/LazyFortran2025Lexer.g4
+++ b/grammars/LazyFortran2025Lexer.g4
@@ -1,0 +1,15 @@
+/*
+ * LazyFortran2025Lexer.g4
+ *
+ * Lazy Fortran 2025 lexer.
+ * Reuses the Fortran 2023 token vocabulary without changes.
+ */
+
+lexer grammar LazyFortran2025Lexer;
+
+import Fortran2023Lexer;
+
+// No additional tokens are required at the lexer level.
+// LazyFortran2025 relies on Fortran 2023 tokens and relaxes syntax
+// only in the parser.
+

--- a/grammars/LazyFortran2025Parser.g4
+++ b/grammars/LazyFortran2025Parser.g4
@@ -1,0 +1,79 @@
+/*
+ * LazyFortran2025Parser.g4
+ *
+ * Parser extension for Lazy Fortran 2025 (.lf files).
+ * Provides dual entry points:
+ * - traditional_entry: strict Fortran 2023 program units
+ * - lazy_entry: relaxed syntax without required PROGRAM or MODULE blocks
+ *   and without a required CONTAINS section before procedures.
+ */
+
+parser grammar LazyFortran2025Parser;
+
+options {
+    tokenVocab = LazyFortran2025Lexer;
+}
+
+import Fortran2023Parser;
+
+// ============================================================================
+// ENTRY POINTS
+// ============================================================================
+
+// Entry point for traditional Fortran source (.f90, .f95, .f03, .f08, .f18,
+// .f23). Uses the Fortran 2023 program unit structure unchanged.
+traditional_entry
+    : program_unit_f2023 EOF
+    ;
+
+// Entry point for LazyFortran2025 source (.lf). Allows top-level statements
+// and procedures without explicit PROGRAM, MODULE, or CONTAINS.
+lazy_entry
+    : lazy_program EOF
+    ;
+
+// ============================================================================
+// LAZY PROGRAM STRUCTURE
+// ============================================================================
+
+lazy_program
+    : NEWLINE* lazy_element* NEWLINE*
+    ;
+
+// A lazy element is either a declaration/statement or a procedure definition.
+lazy_element
+    : lazy_declaration_or_statement
+    | lazy_procedure_definition
+    ;
+
+// Allow specification items and executable statements to be interleaved at
+// the top level in a lazy source file.
+lazy_declaration_or_statement
+    : lazy_specification_construct
+    | lazy_executable_construct
+    ;
+
+// Specification constructs permitted at the top level in lazy mode.
+lazy_specification_construct
+    : use_stmt
+    | import_stmt
+    | implicit_stmt
+    | contains_stmt
+    | declaration_construct_f2018
+    ;
+
+// Lazy execution constructs include Fortran 2018 constructs and Fortran 2023
+// enhanced executable statements such as conditional expressions.
+lazy_executable_construct
+    : executable_stmt_f2023
+    | executable_construct_f2018
+    ;
+
+// Procedures that can appear at the top level without a CONTAINS section.
+// These reuse the Fortran 2018 function and subroutine subprogram rules so
+// that LazyFortran2025 remains compatible with the modern Fortran features.
+lazy_procedure_definition
+    : function_subprogram_f2018
+    | subroutine_subprogram_f2018
+    ;
+

--- a/tests/LazyFortran2025/test_lazyfortran2025_parser.py
+++ b/tests/LazyFortran2025/test_lazyfortran2025_parser.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Tests for LazyFortran2025 lexer and parser.
+
+These tests focus on the dual entry points and the relaxed program structure
+for .lf files, while preserving compatibility with strict Fortran 2023 code.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+GRAMMARS_DIR = Path(__file__).resolve().parents[2] / "grammars"
+sys.path.insert(0, str(GRAMMARS_DIR))
+
+TEST_ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(TEST_ROOT))
+
+from fixture_utils import load_fixture  # noqa: E402
+
+
+try:
+    from LazyFortran2025Lexer import LazyFortran2025Lexer  # type: ignore
+    from LazyFortran2025Parser import LazyFortran2025Parser  # type: ignore
+    PARSER_AVAILABLE = True
+except ImportError as exc:  # pragma: no cover - environment dependent
+    PARSER_AVAILABLE = False
+    LazyFortran2025Lexer = None  # type: ignore
+    LazyFortran2025Parser = None  # type: ignore
+    pytest.skip(f"LazyFortran2025 grammar not built: {exc}", allow_module_level=True)
+
+
+class TestLazyFortran2025Lexer:
+    """Basic lexer smoke tests ensuring F2023 compatibility."""
+
+    def create_lexer(self, input_text: str) -> LazyFortran2025Lexer:  # type: ignore[name-defined]
+        from antlr4 import InputStream  # type: ignore
+
+        stream = InputStream(input_text)
+        return LazyFortran2025Lexer(stream)  # type: ignore[call-arg]
+
+    def test_lexer_recognizes_f2023_tokens(self) -> None:
+        """LazyFortran2025 lexer reuses Fortran 2023 token vocabulary."""
+        lexer = self.create_lexer("PROGRAM test\nx = 42\n? IEEE_MAX\n")
+        tokens = []
+        while True:
+            token = lexer.nextToken()
+            if token.type == -1:
+                break
+            tokens.append(token)
+
+        assert any(t.type == LazyFortran2025Lexer.PROGRAM for t in tokens)  # type: ignore[attr-defined]
+        assert any(t.type == LazyFortran2025Lexer.QUESTION for t in tokens)  # type: ignore[attr-defined]
+        assert any(t.type == LazyFortran2025Lexer.IEEE_MAX for t in tokens)  # type: ignore[attr-defined]
+
+
+@pytest.mark.skipif(not PARSER_AVAILABLE, reason="Parser not available")
+class TestLazyFortran2025Parser:
+    """Tests for LazyFortran2025 parser entry points."""
+
+    def create_parser(self, input_text: str) -> LazyFortran2025Parser:  # type: ignore[name-defined]
+        from antlr4 import CommonTokenStream, InputStream  # type: ignore
+
+        stream = InputStream(input_text)
+        lexer = LazyFortran2025Lexer(stream)  # type: ignore[call-arg]
+        tokens = CommonTokenStream(lexer)
+        parser = LazyFortran2025Parser(tokens)  # type: ignore[call-arg]
+        return parser
+
+    def test_has_dual_entry_points(self) -> None:
+        """Parser exposes both traditional and lazy entry points."""
+        assert hasattr(LazyFortran2025Parser, "traditional_entry")  # type: ignore[attr-defined]
+        assert hasattr(LazyFortran2025Parser, "lazy_entry")  # type: ignore[attr-defined]
+
+    def test_traditional_entry_parses_traditional_fixture(self) -> None:
+        """traditional_entry preserves strict Fortran 2023 behavior."""
+        fixture_path = GRAMMARS_DIR / "test_traditional.f90"
+        code = fixture_path.read_text()
+
+        parser = self.create_parser(code)
+        tree = parser.traditional_entry()  # type: ignore[call-arg]
+        assert tree is not None
+
+    def test_lazy_entry_parses_lazy_fixture(self) -> None:
+        """lazy_entry accepts top-level statements and procedures."""
+        fixture_path = GRAMMARS_DIR / "test_lazy.lf"
+        code = fixture_path.read_text()
+
+        parser = self.create_parser(code)
+        tree = parser.lazy_entry()  # type: ignore[call-arg]
+        assert tree is not None
+
+    def test_lazy_entry_supports_implicit_program(self) -> None:
+        """Bare statements without PROGRAM or MODULE parse in lazy mode."""
+        code = (
+            "x = 3.14\n"
+            "y = 2.71\n"
+            "print *, x + y\n"
+        )
+        parser = self.create_parser(code)
+        tree = parser.lazy_entry()  # type: ignore[call-arg]
+        assert tree is not None
+
+    def test_lazy_entry_allows_procedures_without_contains(self) -> None:
+        """Procedures following executable statements parse without CONTAINS."""
+        code = (
+            "x = 5.0\n"
+            "print *, x\n"
+            "function double_value(v) result(r)\n"
+            "    real :: v, r\n"
+            "    r = v * 2.0\n"
+            "end function\n"
+            "y = double_value(x)\n"
+            "print *, y\n"
+        )
+        parser = self.create_parser(code)
+        tree = parser.lazy_entry()  # type: ignore[call-arg]
+        assert tree is not None
+
+    def test_lazy_entry_uses_f2023_conditional_expressions(self) -> None:
+        """Lazy programs can use F2023 conditional expressions."""
+        code = (
+            "x = 5.0\n"
+            "y = 10.0\n"
+            "max_val = (x > y ? x : y)\n"
+            "print *, max_val\n"
+        )
+        parser = self.create_parser(code)
+        tree = parser.lazy_entry()  # type: ignore[call-arg]
+        assert tree is not None
+
+    def test_traditional_entry_parses_f2023_fixture(self) -> None:
+        """traditional_entry delegates to program_unit_f2023 for strict code."""
+        # Reuse an existing Fortran2023 basic program fixture.
+        fixture = load_fixture(
+            "Fortran2023",
+            "test_fortran_2023_comprehensive",
+            "basic_program.f90",
+        )
+        parser = self.create_parser(fixture)
+        tree = parser.traditional_entry()  # type: ignore[call-arg]
+        assert tree is not None


### PR DESCRIPTION
### **User description**
Summary:
- Added LazyFortran2025 lexer and parser grammars that import Fortran2023.
- Implemented dual entry points (traditional_entry / lazy_entry) and a Makefile target for LazyFortran2025.
- Added focused parser tests and updated CLAUDE.md to describe the new standard.

Verification:
- python tests/test_code_compliance.py -q
  - OK
- python -m pytest tests/LazyFortran2025/test_lazyfortran2025_parser.py -q
  - Skipped: LazyFortran2025 ANTLR Python targets are not generated in this environment (no Java / antlr4 CLI).
  - Once Java and the antlr4 launcher are available, run "make LazyFortran2025" before rerunning pytest.

Artifacts:
- grammars/LazyFortran2025Lexer.g4
- grammars/LazyFortran2025Parser.g4
- tests/LazyFortran2025/test_lazyfortran2025_parser.py
- Makefile
- CLAUDE.md


___

### **PR Type**
Enhancement


___

### **Description**
- Added LazyFortran2025 grammar pair extending Fortran 2023

- Implemented dual entry points for traditional and lazy parsing modes

- Created comprehensive parser tests for lazy syntax features

- Updated build system and documentation for new standard


___

### Diagram Walkthrough


```mermaid
flowchart LR
  F2023["Fortran 2023<br/>Lexer & Parser"]
  LF2025Lex["LazyFortran2025Lexer<br/>imports F2023"]
  LF2025Par["LazyFortran2025Parser<br/>imports F2023"]
  TradEntry["traditional_entry<br/>strict F2023"]
  LazyEntry["lazy_entry<br/>relaxed syntax"]
  Tests["Parser Tests<br/>dual entry points"]
  Build["Makefile<br/>build target"]
  
  F2023 --> LF2025Lex
  F2023 --> LF2025Par
  LF2025Par --> TradEntry
  LF2025Par --> LazyEntry
  LF2025Par --> Tests
  LF2025Lex --> Build
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LazyFortran2025Lexer.g4</strong><dd><code>LazyFortran2025 lexer importing F2023 tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/LazyFortran2025Lexer.g4

<ul><li>New lexer grammar file that imports Fortran2023Lexer<br> <li> Reuses Fortran 2023 token vocabulary without modifications<br> <li> Minimal lexer implementation focusing on parser-level relaxation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/115/files#diff-3011c0612f6f0e65d419e558ec3c30e9c55096b089b13dbbedc79dbfdc22ad29">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LazyFortran2025Parser.g4</strong><dd><code>LazyFortran2025 parser with dual entry points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/LazyFortran2025Parser.g4

<ul><li>New parser grammar with dual entry points: <code>traditional_entry</code> and <br><code>lazy_entry</code><br> <li> <code>traditional_entry</code> delegates to strict Fortran 2023 program units<br> <li> <code>lazy_entry</code> enables relaxed syntax: optional PROGRAM/MODULE, optional <br>CONTAINS, interleaved declarations and statements<br> <li> Supports procedures at top level without CONTAINS section</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/115/files#diff-c330b84b3bfe66cef2e1fcb4ef30dfd78a16b1de2690ad0e1654b16b69156fc9">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_lazyfortran2025_parser.py</strong><dd><code>Comprehensive LazyFortran2025 parser test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/LazyFortran2025/test_lazyfortran2025_parser.py

<ul><li>New test file with 144 lines covering lexer and parser functionality<br> <li> Lexer smoke tests verify Fortran 2023 token compatibility<br> <li> Parser tests validate dual entry points and lazy syntax features<br> <li> Tests cover implicit programs, procedures without CONTAINS, and F2023 <br>conditional expressions<br> <li> Graceful skip when ANTLR Python targets unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/115/files#diff-49e0bdbddafc2406d639000ad345a4bcf91bebf2141e1fdaa46a1c8f35a4057a">+144/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add LazyFortran2025 build target to Makefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Added <code>LazyFortran2025</code> to GRAMMARS build chain<br> <li> New build target for LazyFortran2025 lexer and parser generation<br> <li> Build depends on Fortran2023 completion, maintaining inheritance order<br> <li> Includes ANTLR4 invocation for both lexer and parser grammar files</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/115/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Document LazyFortran2025 grammar and entry points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Added section describing LazyFortran2025 as ANTLR4 grammar pair<br> <li> Documented dual entry points and their purposes<br> <li> Explained <code>.lf</code> file format with optional PROGRAM/MODULE and CONTAINS<br> <li> Clarified support for relaxed type declarations and semantic type <br>inference</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/115/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

