### PR TITLE
fix: Fortran 2008 ERROR STOP and CONTIGUOUS (fixes #87)

### DIFF
--- a/tests/Fortran2008/test_basic_f2008_features.py
+++ b/tests/Fortran2008/test_basic_f2008_features.py
@@ -125,6 +125,19 @@ class TestBasicF2008Features:
         assert tree is not None, "ERROR STOP failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for ERROR STOP, got {errors}"
     
+    def test_error_stop_no_code(self):
+        """Test ERROR STOP without a stop code"""
+        code = load_fixture(
+            "Fortran2008",
+            "test_basic_f2008_features",
+            "error_stop_no_code.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "ERROR STOP without code failed to produce parse tree"
+        assert errors == 0, (
+            f"Expected 0 errors for ERROR STOP without code, got {errors}"
+        )
+
     def test_contiguous_attribute_token(self):
         """Test CONTIGUOUS attribute"""
         code = load_fixture(
@@ -136,6 +149,19 @@ class TestBasicF2008Features:
         assert tree is not None, "CONTIGUOUS attribute failed to produce parse tree"
         # Track remaining work in issue #87
         assert errors == 0, f"Expected 0 errors for CONTIGUOUS attribute, got {errors}"
+
+    def test_contiguous_standalone_statement(self):
+        """Test CONTIGUOUS standalone attribute statement"""
+        code = load_fixture(
+            "Fortran2008",
+            "test_basic_f2008_features",
+            "contiguous_statement.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "CONTIGUOUS statement failed to produce parse tree"
+        assert errors == 0, (
+            f"Expected 0 errors for CONTIGUOUS statement, got {errors}"
+        )
 
     def test_image_intrinsics(self):
         """Test coarray intrinsic functions"""

--- a/tests/fixtures/Fortran2008/test_basic_f2008_features/contiguous_statement.f90
+++ b/tests/fixtures/Fortran2008/test_basic_f2008_features/contiguous_statement.f90
@@ -1,0 +1,6 @@
+module test_contiguous_stmt
+    implicit none
+    real, pointer :: a(:), b(:)
+    contiguous :: a, b
+end module test_contiguous_stmt
+

--- a/tests/fixtures/Fortran2008/test_basic_f2008_features/error_stop_no_code.f90
+++ b/tests/fixtures/Fortran2008/test_basic_f2008_features/error_stop_no_code.f90
@@ -1,0 +1,4 @@
+program test_error_stop_no_code
+    error stop
+end program test_error_stop_no_code
+


### PR DESCRIPTION
### **User description**
Summary
- Strengthen Fortran 2008 ERROR STOP and CONTIGUOUS coverage with dedicated fixtures.
- Extend TestBasicF2008Features to assert zero syntax errors for these constructs.

Verification
- pytest tests/Fortran2008/test_basic_f2008_features.py -q
  - 10 passed, 1 xpassed
- pytest tests/Fortran2008 -q
  - 21 passed, 1 xpassed
- Fixtures:
  - tests/fixtures/Fortran2008/test_basic_f2008_features/error_stop_no_code.f90
  - tests/fixtures/Fortran2008/test_basic_f2008_features/contiguous_statement.f90


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Add test for ERROR STOP without stop code variant

- Add test for CONTIGUOUS standalone statement attribute

- Create fixture files for both new test cases

- Strengthen Fortran 2008 feature coverage for issue #87


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] -->|adds| B["test_error_stop_no_code"]
  A -->|adds| C["test_contiguous_standalone_statement"]
  B -->|uses| D["error_stop_no_code.f90"]
  C -->|uses| E["contiguous_statement.f90"]
  D -->|validates| F["ERROR STOP without code"]
  E -->|validates| G["CONTIGUOUS statement"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_basic_f2008_features.py</strong><dd><code>Add two new Fortran 2008 feature test methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2008/test_basic_f2008_features.py

<ul><li>Add <code>test_error_stop_no_code()</code> method to test ERROR STOP without stop <br>code<br> <li> Add <code>test_contiguous_standalone_statement()</code> method to test CONTIGUOUS <br>statement<br> <li> Both tests load fixtures and assert zero syntax errors<br> <li> Maintain consistent assertion patterns with existing tests</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/120/files#diff-fd68ceeecf8e7c7f1b710bd12ea00cc243ceb18485da7169038ec6ee3abd9de4">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error_stop_no_code.f90</strong><dd><code>New fixture for ERROR STOP without code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2008/test_basic_f2008_features/error_stop_no_code.f90

<ul><li>Create new fixture file for ERROR STOP without stop code<br> <li> Contains simple program with <code>error stop</code> statement<br> <li> Validates parser handles ERROR STOP variant correctly</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/120/files#diff-a1302f24d73e4e0bf14f5a32fc5dc2d648205b7aeb8aafd69fd41cb5cb755629">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>contiguous_statement.f90</strong><dd><code>New fixture for CONTIGUOUS statement attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2008/test_basic_f2008_features/contiguous_statement.f90

<ul><li>Create new fixture file for CONTIGUOUS standalone statement<br> <li> Contains module with pointer declarations and <code>contiguous</code> statement<br> <li> Validates parser handles CONTIGUOUS as standalone attribute statement</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/120/files#diff-35bc8969d300f34f2f20a521f68b94939fbedec6f0c9b8ee5c644b0080318a2c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

