### PR TITLE
fix: Fortran 2018: SELECT RANK and assumed-rank support (fixes #89)

### DIFF
--- a/grammars/Fortran2018Parser.g4
+++ b/grammars/Fortran2018Parser.g4
@@ -94,7 +94,11 @@ declaration_construct_f2018
 // ============================================================================
 
 execution_part_f2018
-    : executable_construct_f2018*
+    : execution_construct_f2018*
+    ;
+
+execution_construct_f2018
+    : NEWLINE* executable_construct_f2018 NEWLINE*
     ;
 
 // Enhanced executable construct for F2018
@@ -128,7 +132,7 @@ executable_construct_f2018
 
 select_rank_construct
     : select_rank_stmt
-      (rank_case_stmt execution_part_f2018?)*
+      rank_construct*
       end_select_rank_stmt
     ;
 
@@ -136,18 +140,23 @@ select_rank_stmt
     : (IDENTIFIER COLON)? SELECT RANK_KEYWORD LPAREN expr_f90 RPAREN NEWLINE
     ;
 
+rank_construct
+    : rank_case_stmt
+      execution_part_f2018?
+    ;
+
 rank_case_stmt
-    : RANK_KEYWORD LPAREN rank_value RPAREN NEWLINE   // RANK (n) or RANK (*)
+    : RANK_KEYWORD LPAREN rank_value RPAREN NEWLINE   // RANK (selector) or RANK (*)
     | RANK_KEYWORD DEFAULT NEWLINE                    // RANK DEFAULT
     ;
 
 rank_value
-    : INTEGER_LITERAL              // Specific rank: RANK (n)
-    | '*'                          // Assumed-rank case: RANK (*)
+    : expr_f90                     // Specific rank selector: scalar-int-constant-expr
+    | MULTIPLY                     // Assumed-rank case: RANK (*)
     ;
 
 end_select_rank_stmt
-    : END SELECT (IDENTIFIER)? NEWLINE
+    : END_SELECT (IDENTIFIER)? NEWLINE
     ;
 
 // ============================================================================
@@ -390,9 +399,9 @@ stop_code
 // ============================================================================
 
 type_declaration_stmt_f2018
-    : type_declaration_stmt           // Inherit F2003 declarations
+    : assumed_rank_declaration        // NEW in F2018 (DIMENSION(..))
+    | type_declaration_stmt           // Inherit F2003 declarations
     | enhanced_intrinsic_declaration  // Inherit F2008 enhanced types
-    | assumed_rank_declaration        // NEW in F2018
     ;
 
 assumed_rank_declaration

--- a/tests/Fortran2018/test_basic_f2018_features.py
+++ b/tests/Fortran2018/test_basic_f2018_features.py
@@ -212,5 +212,17 @@ end module"""
         assert working_basic >= 1, \
             f"At least one basic Fortran form should parse without errors, got {working_basic}"
 
+    def test_assumed_rank_dummy_argument_parses_without_errors(self):
+        """REAL TEST: Assumed-rank dummy arguments using DIMENSION(..) are supported."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_basic_f2018_features",
+            "assumed_rank_dummy.f90",
+        )
+
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "Assumed-rank dummy argument code should parse"
+        assert errors == 0, f"Assumed-rank dummy should parse with zero errors, got {errors}"
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/Fortran2018/test_issue61_teams_and_collectives.py
+++ b/tests/Fortran2018/test_issue61_teams_and_collectives.py
@@ -70,14 +70,8 @@ class TestF2018TeamsAndCollectivesStatus:
         best_errors = min(errors_actual, errors_legacy)
         assert best_errors == 0
 
-    @pytest.mark.xfail(
-        reason=(
-            "SELECT RANK construct is only partially implemented "
-            "(status test for Issue #61; full support tracked in issue #88)"
-        )
-    )
     def test_select_rank_construct_minimal_example(self):
-        """Minimal SELECT RANK construct intended to become strict once implemented."""
+        """SELECT RANK construct with basic rank cases and default branch parses cleanly."""
         code = load_fixture(
             "Fortran2018",
             "test_issue61_teams_and_collectives",

--- a/tests/fixtures/Fortran2018/test_basic_f2018_features/assumed_rank_dummy.f90
+++ b/tests/fixtures/Fortran2018/test_basic_f2018_features/assumed_rank_dummy.f90
@@ -1,0 +1,4 @@
+subroutine assumed_rank_demo(a)
+  real, dimension(..) :: a
+end subroutine assumed_rank_demo
+

--- a/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_minimal.f90
+++ b/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_minimal.f90
@@ -2,8 +2,12 @@ program select_rank_demo
   implicit none
   integer :: rank_value
 
-  ! Minimal SELECT RANK construct to document current behavior.
   select rank (rank_value)
+  rank (0)
+     rank_value = 0
+  rank (*)
+     rank_value = -1
+  rank default
+     rank_value = -2
   end select
 end program select_rank_demo
-


### PR DESCRIPTION
### **User description**
Summary
- Wire up the Fortran 2018 SELECT RANK construct (including RANK(n), RANK(*), and RANK DEFAULT cases) so representative examples parse with zero syntax errors.
- Add explicit assumed-rank dummy argument support via DIMENSION(..) in the F2018 grammar and a focused fixture/test.
- Make the F2018 execution part newline-aware (via execution_construct_f2018) so SELECT RANK blocks can contain ordinary executable statements.

Verification
- make Fortran2018 ANTLR4="/opt/homebrew/opt/openjdk/bin/java -jar ../antlr-4.13.2-complete.jar"
  - Rebuilds updated Fortran 2018 lexer/parser from grammars/Fortran2018Lexer.g4 and grammars/Fortran2018Parser.g4.
- make test-fortran2018 ANTLR4="/opt/homebrew/opt/openjdk/bin/java -jar ../antlr-4.13.2-complete.jar"
  - All Fortran 2018 tests pass, including:
    - tests/Fortran2018/test_issue61_teams_and_collectives.py::TestF2018TeamsAndCollectivesStatus::test_select_rank_construct_minimal_example
    - tests/Fortran2018/test_basic_f2018_features.py::TestBasicF2018Features::test_assumed_rank_dummy_argument_parses_without_errors
- Key fixtures exercised:
  - tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_minimal.f90
  - tests/fixtures/Fortran2018/test_basic_f2018_features/assumed_rank_dummy.f90


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement Fortran 2018 SELECT RANK construct with RANK(n), RANK(*), and RANK DEFAULT cases

- Add assumed-rank dummy argument support via DIMENSION(..) syntax

- Make execution part newline-aware for proper SELECT RANK block parsing

- Remove xfail marker from SELECT RANK test; now fully functional


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["F2018 Grammar Updates"] --> B["SELECT RANK Construct"]
  A --> C["Assumed-Rank DIMENSION(..)"]
  B --> D["rank_construct Rule"]
  B --> E["rank_value Expressions"]
  C --> F["Type Declaration Support"]
  D --> G["Execution Part Newlines"]
  G --> H["Test Fixtures Pass"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fortran2018Parser.g4</strong><dd><code>Wire up SELECT RANK and assumed-rank grammar rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

grammars/Fortran2018Parser.g4

<ul><li>Refactored <code>execution_part_f2018</code> to use newline-aware <br><code>execution_construct_f2018</code> rule<br> <li> Added <code>rank_construct</code> rule to properly structure RANK cases with <br>optional execution parts<br> <li> Enhanced <code>rank_value</code> to accept expressions instead of just literals and <br>asterisk<br> <li> Changed <code>rank_case_stmt</code> to use <code>RANK_KEYWORD</code> consistently<br> <li> Reordered <code>type_declaration_stmt_f2018</code> to prioritize <br><code>assumed_rank_declaration</code><br> <li> Fixed <code>end_select_rank_stmt</code> to use <code>END_SELECT</code> token</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/121/files#diff-4309d6fcbf7bcf8d83fb3c53f89bdaf1a3e09a7f9e1e3f1aab4ad28072a8a1c1">+17/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_basic_f2018_features.py</strong><dd><code>Add assumed-rank dummy argument parsing test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_basic_f2018_features.py

<ul><li>Added new test <code>test_assumed_rank_dummy_argument_parses_without_errors</code> <br>to verify assumed-rank support<br> <li> Test loads and parses <code>assumed_rank_dummy.f90</code> fixture with zero syntax <br>errors</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/121/files#diff-7d416dadf00ac88201bf11a2e5e6f9663af181a51caf3e652c1fa03420080c46">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_issue61_teams_and_collectives.py</strong><dd><code>Promote SELECT RANK test from xfail to passing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_issue61_teams_and_collectives.py

<ul><li>Removed <code>@pytest.mark.xfail</code> decorator from <br><code>test_select_rank_construct_minimal_example</code><br> <li> Updated docstring to reflect full SELECT RANK implementation status</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/121/files#diff-c5bef2a5b4233472d01a83e480e8a684d4e8622eed510890b42f0c1739473726">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>assumed_rank_dummy.f90</strong><dd><code>Add assumed-rank dummy argument fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_basic_f2018_features/assumed_rank_dummy.f90

<ul><li>New fixture demonstrating assumed-rank dummy argument syntax<br> <li> Subroutine with <code>real, dimension(..) :: a</code> parameter declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/121/files#diff-7409e69f1f1be878de9cd619232c6a6bfc486606c6f01683dd29678f35f86968">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>select_rank_minimal.f90</strong><dd><code>Expand SELECT RANK fixture with complete rank cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_minimal.f90

<ul><li>Expanded minimal SELECT RANK example with three rank cases: RANK(0), <br>RANK(*), and RANK DEFAULT<br> <li> Added executable statements within each rank case block<br> <li> Removed trailing blank line</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/121/files#diff-4d110fb0021df214c7cd35dae1243a137f56852362c64492b721fea9898d0c2f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

