### PR TITLE
fix: Remove xfail markers from now-passing F2018 tests (fixes #122)

### DIFF
--- a/tests/Fortran2018/test_basic_f2018_features.py
+++ b/tests/Fortran2018/test_basic_f2018_features.py
@@ -67,7 +67,6 @@ class TestBasicF2018Features:
         # REAL TEST: For a basic module, errors should be zero
         assert errors == 0, f"Basic module should parse with zero errors, got {errors}"
     
-    @pytest.mark.xfail(reason="F2018 coarray inheritance from F2008 is incomplete (see issues #83 and #88)")
     def test_f2018_grammar_inheritance(self):
         """REAL TEST: Verify F2018 inherits F2008 coarray features"""
         code = load_fixture(
@@ -80,11 +79,10 @@ class TestBasicF2018Features:
         
         # REAL TEST: F2008 features should eventually work in F2018
         assert tree is not None, "F2008 coarray features should work in F2018"
-        # This expectation is tightened in issue #88; for now keep the assertion
-        # here but mark the test as xfail below.
+        # This expectation was tightened as F2018 coarray support improved
+        # (see issues #83 and #88).
         assert errors == 0, f"F2008 inheritance should parse with zero errors, got {errors}"
     
-    @pytest.mark.xfail(reason="F2018 coarray and SYNC support still being aligned with F2008 (see issues #83 and #88)")
     def test_f2018_parser_vs_f2008_functionality(self):
         """REAL TEST: Compare F2018 vs F2008 parsing on same code"""
         code = load_fixture(
@@ -115,13 +113,6 @@ class TestBasicF2018Features:
         except ImportError:
             pytest.skip("F2008 parser not available for comparison")
     
-    @pytest.mark.xfail(
-        reason=(
-            "F2018 program-structure parsing still being aligned with the "
-            "standard (no dedicated GitHub issue yet; this test documents "
-            "the gap until an issue is opened)"
-        )
-    )
     def test_complex_program_structure_limitations(self):
         """REAL TEST: Document known program structure parsing limitations"""
         code = load_fixture(


### PR DESCRIPTION
### **User description**
Summary

- Remove pytest xfail markers from three Fortran 2018 tests that now pass after SELECT RANK and assumed-rank support.
- Keep expectations and comments aligned with updated coarray and program-structure behavior.

Verification

- `pytest tests/Fortran2018/test_basic_f2018_features.py -k "test_f2018_grammar_inheritance or test_f2018_parser_vs_f2008_functionality or test_complex_program_structure_limitations" -q`
  - Output: `3 passed, 6 deselected in 1.92s`
- `make test`
  - Fails early while rebuilding grammars because no Java runtime is available: `The operation could not be completed. Unable to locate a Java Runtime.`
- Artifacts:
  - `tests/Fortran2018/test_basic_f2018_features.py`


___

### **PR Type**
Bug fix


___

### **Description**
- Remove xfail markers from three F2018 tests now passing

- Update test comments reflecting improved coarray support

- Align test expectations with current parser capabilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["F2018 Tests with xfail markers"] -- "Remove xfail decorators" --> B["Tests now passing"]
  C["Outdated test comments"] -- "Update documentation" --> D["Comments reflect current state"]
  A --> B
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_basic_f2018_features.py</strong><dd><code>Remove xfail markers from three F2018 tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_basic_f2018_features.py

<ul><li>Removed <code>@pytest.mark.xfail</code> decorator from <br><code>test_f2018_grammar_inheritance</code> test<br> <li> Removed <code>@pytest.mark.xfail</code> decorator from <br><code>test_f2018_parser_vs_f2008_functionality</code> test<br> <li> Removed <code>@pytest.mark.xfail</code> decorator from <br><code>test_complex_program_structure_limitations</code> test<br> <li> Updated comments in <code>test_f2018_grammar_inheritance</code> to reflect improved <br>coarray support status</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/123/files#diff-7d416dadf00ac88201bf11a2e5e6f9663af181a51caf3e652c1fa03420080c46">+2/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

