### PR TITLE
fix: Lazy Fortran: concise feature design document (WIP) (fixes #63)

### DIFF
--- a/tests/test_docs_pages.py
+++ b/tests/test_docs_pages.py
@@ -17,3 +17,20 @@ def test_docs_index_references_design_markdown() -> None:
   assert "lazyfortran2025-design.md" in content
   assert "Lazy Fortran 2025 Design" in content
 
+
+def test_design_doc_has_work_in_progress_notice() -> None:
+  design_path = _repo_root() / "docs" / "lazyfortran2025-design.md"
+  content = design_path.read_text(encoding="utf-8")
+
+  assert "WORK IN PROGRESS" in content
+
+
+def test_design_doc_covers_all_lazy_feature_issues() -> None:
+  design_path = _repo_root() / "docs" / "lazyfortran2025-design.md"
+  content = design_path.read_text(encoding="utf-8")
+
+  for issue in range(51, 58):
+    marker = f"Issue #{issue}"
+    assert (
+      marker in content
+    ), f"Design document should reference Lazy Fortran issue #{issue}"


### PR DESCRIPTION
### **User description**
## Summary
- Add regression tests to ensure `docs/index.html` stays wired to `docs/lazyfortran2025-design.md`.
- Verify that the design doc keeps a clear WORK IN PROGRESS notice and references issues #51–#57.

## Verification
- `python -m pytest tests/test_docs_pages.py -q`
  - Output: `4 passed in 0.00s`
- `python -m pytest tests -q`
  - Fails during collection with `ModuleNotFoundError: No module named "Fortran2018Lexer"` because Java is not available to run `antlr4` and generate the Fortran 2018 lexer/parser modules.


___

### **PR Type**
Tests


___

### **Description**
- Add regression test for design doc work-in-progress notice

- Add regression test verifying design doc references issues #51-#57

- Ensure design documentation stays properly maintained and linked


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_docs_pages.py"] -->|adds tests| B["Design doc validation"]
  B -->|verifies| C["WIP notice present"]
  B -->|verifies| D["Issues #51-#57 referenced"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_docs_pages.py</strong><dd><code>Add design document regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_docs_pages.py

<ul><li>Add <code>test_design_doc_has_work_in_progress_notice()</code> to verify WIP notice <br>exists<br> <li> Add <code>test_design_doc_covers_all_lazy_feature_issues()</code> to validate all <br>issues #51-#57 are referenced<br> <li> Ensure design document maintains required documentation standards</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/126/files#diff-b468cdfb3629355d4d9f723e8a666785d455840c58c018ff39d8b926c08d784c">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

