### PR TITLE
fix: Lazy Fortran: interactive REPL and notebooks (fixes #54)

### DIFF
--- a/tests/Fortran2018/test_direct_endif.py
+++ b/tests/Fortran2018/test_direct_endif.py
@@ -2,13 +2,14 @@
 """Test direct ENDIF parsing"""
 
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'grammars'))
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT.parent / "grammars"))
 
-from antlr4 import *
-from Fortran2018Lexer import Fortran2018Lexer  
-from Fortran2018Parser import Fortran2018Parser
+from antlr4 import *  # type: ignore
+from Fortran2018Lexer import Fortran2018Lexer  # type: ignore
+from Fortran2018Parser import Fortran2018Parser  # type: ignore
 
 def test_direct_parsing():
     code = "endif"

--- a/tests/Fortran2018/test_parse_tree.py
+++ b/tests/Fortran2018/test_parse_tree.py
@@ -2,16 +2,16 @@
 """Test parse tree structure for IF construct"""
 
 import sys
-import os
 from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'grammars'))
-sys.path.append(str(Path(__file__).parent.parent))
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT.parent / "grammars"))
+sys.path.append(str(ROOT))
 
-from antlr4 import *
-from Fortran2018Lexer import Fortran2018Lexer  
-from Fortran2018Parser import Fortran2018Parser
-from antlr4.error.ErrorListener import ErrorListener
+from antlr4 import *  # type: ignore
+from Fortran2018Lexer import Fortran2018Lexer  # type: ignore
+from Fortran2018Parser import Fortran2018Parser  # type: ignore
+from antlr4.error.ErrorListener import ErrorListener  # type: ignore
 from fixture_utils import load_fixture
 
 class TestErrorListener(ErrorListener):

--- a/tests/Fortran2018/test_simple_if.py
+++ b/tests/Fortran2018/test_simple_if.py
@@ -2,13 +2,14 @@
 """Test simple IF parsing step by step"""
 
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'grammars'))
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT.parent / "grammars"))
 
-from antlr4 import *
-from Fortran2018Lexer import Fortran2018Lexer  
-from Fortran2018Parser import Fortran2018Parser
+from antlr4 import *  # type: ignore
+from Fortran2018Lexer import Fortran2018Lexer  # type: ignore
+from Fortran2018Parser import Fortran2018Parser  # type: ignore
 
 def run_parser_method(code, method_name):
     print(f"Testing method: {method_name}")

--- a/tests/Fortran2018/test_tokens.py
+++ b/tests/Fortran2018/test_tokens.py
@@ -2,12 +2,13 @@
 """Test token recognition"""
 
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'grammars'))
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT.parent / "grammars"))
 
-from antlr4 import *
-from Fortran2018Lexer import Fortran2018Lexer
+from antlr4 import *  # type: ignore
+from Fortran2018Lexer import Fortran2018Lexer  # type: ignore
 
 def test_token_recognition():
     code = "endif"


### PR DESCRIPTION
### **User description**
Summary

- Expand `docs/lazyfortran2025-design.md` LF-TOOL-01 section to spell out the interactive REPL/notebook session model, mapping between cells and implicit `.lf` files, state persistence, type/implicit rules, and redefinition semantics.
- Clarify how REPL sessions integrate with traditional Fortran sources, including when sessions behave like implicit programs vs implicit modules.
- Align Fortran 2018 status tests with the shared grammars directory by using a consistent root-relative import pattern for generated parsers in `tests/Fortran2018/`.

Verification

- `python -m pytest tests/ -v --tb=short`
  - 458 passed, 49 xfailed, 7 warnings


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Document interactive REPL/notebook session model and semantics

- Standardize Fortran2018 test imports using root-relative paths

- Add type ignore comments for ANTLR4 imports

- Clarify state persistence, scoping, and redefinition rules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["REPL Session Model"] -->|"Maps to"| B["Implicit .lf File"]
  B -->|"Defines"| C["State & Scope"]
  C -->|"Follows"| D["Fortran Rules"]
  E["Test Imports"] -->|"Standardized to"| F["Root-relative Paths"]
  F -->|"Improves"| G["Import Consistency"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lazyfortran2025-design.md</strong><dd><code>Expand REPL session model documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/lazyfortran2025-design.md

<ul><li>Added comprehensive "Session model and mapping to files" section <br>explaining how REPL sessions map to implicit <code>.lf</code> files<br> <li> Documented state persistence, scoping rules, and variable/procedure <br>availability across cells<br> <li> Clarified type inference, implicit rules, and <code>implicit none</code> behavior <br>in REPL context<br> <li> Explained redefinition semantics, error handling, and integration with <br>traditional Fortran modules<br> <li> Added guidance on promoting stable REPL sessions to checked-in <code>.lf</code> <br>files</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/127/files#diff-67c482242a778a777b15cc9202e48abef52f1187b63bea87d553cb962916db20">+63/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_direct_endif.py</strong><dd><code>Standardize imports and path handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_direct_endif.py

<ul><li>Replaced <code>os.path</code> with <code>pathlib.Path</code> for path handling<br> <li> Changed import path calculation to use root-relative pattern via <code>ROOT</code> <br>variable<br> <li> Added <code># type: ignore</code> comments to ANTLR4 imports<br> <li> Fixed newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/127/files#diff-37eb2896d7c990accd4a08ab36b2a100b41ab1aaf864b70da72faba682610307">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_parse_tree.py</strong><dd><code>Standardize imports and path handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_parse_tree.py

<ul><li>Removed unused <code>os</code> import and consolidated path handling with <br><code>pathlib.Path</code><br> <li> Unified import path calculation using root-relative <code>ROOT</code> variable<br> <li> Added <code># type: ignore</code> comments to all ANTLR4 and ErrorListener imports<br> <li> Simplified sys.path manipulation for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/127/files#diff-4e1d042b5a092409bb5c1be441b1c92c260034b27c3829e085f3825c596ac1bf">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_simple_if.py</strong><dd><code>Standardize imports and path handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_simple_if.py

<ul><li>Replaced <code>os.path</code> with <code>pathlib.Path</code> for path handling<br> <li> Changed import path calculation to use root-relative pattern via <code>ROOT</code> <br>variable<br> <li> Added <code># type: ignore</code> comments to ANTLR4 imports<br> <li> Fixed newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/127/files#diff-c1a1d2daf2181d4c2efa7962884951a2dc214058df44b6f6fc60adb61a084ffe">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_tokens.py</strong><dd><code>Standardize imports and path handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Fortran2018/test_tokens.py

<ul><li>Replaced <code>os.path</code> with <code>pathlib.Path</code> for path handling<br> <li> Changed import path calculation to use root-relative pattern via <code>ROOT</code> <br>variable<br> <li> Added <code># type: ignore</code> comments to ANTLR4 imports<br> <li> Fixed newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/127/files#diff-0f3ec51513c7a2c53a5c40f72b43dc6bf7a930712548f7da983beb6d19b465a8">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

