### PR TITLE
fix: Lazy Fortran: world-wide automatic specializations (fixes #51)

### DIFF
--- a/tests/test_docs_pages.py
+++ b/tests/test_docs_pages.py
@@ -34,3 +34,26 @@ def test_design_doc_covers_all_lazy_feature_issues() -> None:
     assert (
       marker in content
     ), f"Design document should reference Lazy Fortran issue #{issue}"
+
+
+def test_world_specializations_doc_spells_out_precedence_and_ambiguity() -> None:
+  design_path = _repo_root() / "docs" / "lazyfortran2025-design.md"
+  content = design_path.read_text(encoding="utf-8")
+
+  assert (
+    "LF‑SYN‑03 – World‑Wide Automatic Specializations (Issue #51)"
+    in content
+  )
+  assert "explicit, user-written specific procedures always" in content
+  assert "win over generated specializations" in content
+  assert "most specific candidate" in content
+  assert "compile-time ambiguity error" in content
+
+
+def test_world_specializations_doc_mentions_iso_generic_resolution() -> None:
+  design_path = _repo_root() / "docs" / "lazyfortran2025-design.md"
+  content = design_path.read_text(encoding="utf-8")
+
+  assert "ISO/IEC 1539-1:2018" in content
+  assert "15.4.3.4" in content
+  assert "STANDARD-COMPLIANT" in content


### PR DESCRIPTION
### **User description**
Summary

- Finalized LF-SYN-03 world-wide automatic specialization semantics in `docs/lazyfortran2025-design.md`, including world definition, specialization model, and ISO/IEC 1539-1:2018 generic resolution alignment.
- Updated the status table entry for LF-SYN-03 to DECIDED (WORLD MODEL).
- Added documentation tests in `tests/test_docs_pages.py` to lock in the world/precedence rules and ISO reference for issue #51.

Verification

- PATH="/opt/homebrew/opt/openjdk/bin:$PATH" make test
  - 460 passed, 49 xfailed, 7 warnings in 25.32s
  - docs tests: tests/test_docs_pages.py::test_world_specializations_* (pass)

Artifacts

- docs/lazyfortran2025-design.md
- tests/test_docs_pages.py


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Finalized LF-SYN-03 world-wide automatic specialization semantics

- Defined world model, specialization rules, and ISO compliance

- Added comprehensive documentation tests for issue #51

- Updated status from PROVISIONAL to DECIDED (WORLD MODEL)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue #51<br/>World-wide Specializations"] --> B["Design Documentation<br/>World Model Definition"]
  B --> C["Specialization Rules<br/>ISO/IEC 1539-1:2018"]
  C --> D["Documentation Tests<br/>Precedence & Ambiguity"]
  D --> E["Status Update<br/>DECIDED WORLD MODEL"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lazyfortran2025-design.md</strong><dd><code>Comprehensive world-wide specialization design documentation</code></dd></summary>
<hr>

docs/lazyfortran2025-design.md

<ul><li>Expanded LF-SYN-03 section with detailed world definition and <br>specialization model<br> <li> Added explicit rules for user-written procedures precedence over <br>generated specializations<br> <li> Documented ISO/IEC 1539-1:2018 compliance and generic resolution <br>alignment<br> <li> Included sections on error handling, implicit typing, and <br>caching/reproducibility<br> <li> Updated status marker from PROVISIONAL to DECIDED (WORLD MODEL)<br> <li> Updated status table entry for LF-SYN-03</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/128/files#diff-67c482242a778a777b15cc9202e48abef52f1187b63bea87d553cb962916db20">+60/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_docs_pages.py</strong><dd><code>Documentation tests for world specialization semantics</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_docs_pages.py

<ul><li>Added <br><code>test_world_specializations_doc_spells_out_precedence_and_ambiguity()</code> <br>to verify precedence rules and ambiguity handling<br> <li> Added <code>test_world_specializations_doc_mentions_iso_generic_resolution()</code> <br>to verify ISO standard compliance references<br> <li> Tests lock in world definition, specialization model, and ISO/IEC <br>1539-1:2018 section 15.4.3.4 references</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/128/files#diff-b468cdfb3629355d4d9f723e8a666785d455840c58c018ff39d8b926c08d784c">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

