### PR TITLE
fix: Refactor: split _normalize_inline_if function in lazyfortran_too (fixes #130)

### DIFF
--- a/tests/LazyFortran2025/test_lfmt_lflint.py
+++ b/tests/LazyFortran2025/test_lfmt_lflint.py
@@ -49,6 +49,21 @@ def test_format_inline_if_to_block_is_idempotent() -> None:
 
 
 @pytest.mark.skipif(not PARSER_AVAILABLE, reason="LazyFortran2025 parser not available")
+def test_format_inline_if_with_relational_operator() -> None:
+    """lfmt handles >= inside inline IF conditions."""
+    source = 'if(x>=0)print*,"ok"\n'
+    expected = (
+        "if (x >= 0) then\n"
+        '  print *, "ok"\n'
+        "end if\n"
+    )
+
+    formatted = format_lazy_code(source)
+    assert formatted == expected
+    assert format_lazy_code(formatted) == expected
+
+
+@pytest.mark.skipif(not PARSER_AVAILABLE, reason="LazyFortran2025 parser not available")
 def test_lint_reports_missing_implicit_none() -> None:
     """lflint reports missing IMPLICIT NONE."""
     code = (
@@ -127,4 +142,3 @@ def test_lflint_cli_reports_and_sets_exit_code(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "LF001" in result.stdout
     assert str(path) in result.stdout
-


### PR DESCRIPTION
### **User description**
Summary
- Refactor `_normalize_inline_if` into helpers for condition parsing and spacing.
- Fix inline IF formatting when the condition uses `>=` / `<=` so the formatted code parses successfully.

Verification
- `OMP_NUM_THREADS=24 pytest tests/LazyFortran2025/test_lfmt_lflint.py::test_format_inline_if_with_relational_operator -q`
  - New test passes and round-trips formatted code.
- `OMP_NUM_THREADS=24 pytest tests/LazyFortran2025 -q`
  - 16 passed.
- `OMP_NUM_THREADS=24 make test`
  - Fails early because Java runtime is not available ("Unable to locate a Java Runtime").

Artifacts
- `lazyfortran_tooling.py`
- `tests/LazyFortran2025/test_lfmt_lflint.py`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactor `_normalize_inline_if` into two helper functions for better maintainability

- Fix inline IF formatting with `>=` and `<=` operators using regex-based normalization

- Add test case for inline IF with relational operators to prevent regression


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_normalize_inline_if"] -->|extract condition| B["_extract_inline_if_condition_and_remainder"]
  A -->|normalize spacing| C["_normalize_condition_spacing"]
  B -->|parse structure| D["condition + remainder"]
  C -->|regex substitution| E["normalized condition"]
  D --> F["block IF transformation"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lazyfortran_tooling.py</strong><dd><code>Split inline IF normalization into helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lazyfortran_tooling.py

<ul><li>Extract condition parsing logic into <br><code>_extract_inline_if_condition_and_remainder</code> helper function<br> <li> Create <code>_normalize_condition_spacing</code> helper using regex to handle <code>>=</code>, <code><=</code>, <br><code>></code>, <code><</code> operators<br> <li> Replace manual string replacements with regex-based normalization to <br>fix operator spacing issues<br> <li> Add <code>import re</code> for regex functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/131/files#diff-2983b59ef29cfd4d9bb3a52a99e59c99f583a15377409c4007b2037d2296e44f">+41/-26</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_lfmt_lflint.py</strong><dd><code>Add test for relational operator in inline IF</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/LazyFortran2025/test_lfmt_lflint.py

<ul><li>Add new test <code>test_format_inline_if_with_relational_operator</code> to verify <br><code>>=</code> operator handling<br> <li> Test verifies formatting and round-trip idempotency for inline IF with <br><code>>=</code> condition<br> <li> Remove trailing blank line at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/131/files#diff-fc089b6f18a55730cded5b30d6da4f4b54f3f11f7f1ec0df18a733ff93bb5253">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

