### PR TITLE
fix: Lazy Fortran: implicit type inference from usage (fixes #53)

### DIFF
--- a/tests/test_docs_pages.py
+++ b/tests/test_docs_pages.py
@@ -36,6 +36,28 @@ def test_design_doc_covers_all_lazy_feature_issues() -> None:
     ), f"Design document should reference Lazy Fortran issue #{issue}"
 
 
+def test_type_inference_doc_spells_out_numeric_kinds() -> None:
+  design_path = _repo_root() / "docs" / "lazyfortran2025-design.md"
+  content = design_path.read_text(encoding="utf-8")
+
+  assert "Kinds represent **bytes per numeric component**" in content
+  assert "double precision => real(8)" in content
+  assert "double complex => complex(8)" in content
+
+
+def test_type_inference_doc_covers_implicit_modes_and_promotion() -> None:
+  design_path = _repo_root() / "docs" / "lazyfortran2025-design.md"
+  content = design_path.read_text(encoding="utf-8")
+
+  assert (
+    "In plain `.lf` without `implicit`, undeclared names are allowed"
+    in content
+  )
+  assert "With `implicit none`, undeclared names are errors" in content
+  assert "integer division stays integer" in content
+  assert "complex dominates real" in content
+
+
 def test_world_specializations_doc_spells_out_precedence_and_ambiguity() -> None:
   design_path = _repo_root() / "docs" / "lazyfortran2025-design.md"
   content = design_path.read_text(encoding="utf-8")


### PR DESCRIPTION
### **User description**
Summary:
- Document LF‑SYN‑02 Lazy Fortran type inference and implicit rules, including numeric kinds and legacy specifiers.
- Add documentation tests to lock in the decided semantics from issue #53.

Verification:
- make test
  - fails in this environment: antlr4 Java invocation reports "Unable to locate a Java Runtime" when building grammars.
- pytest -q
  - 476 passed, 3 skipped, 49 xfailed, 274 subtests passed.

Artifacts:
- docs/lazyfortran2025-design.md
- tests/test_docs_pages.py


___

### **PR Type**
Documentation, Tests


___

### **Description**
- Document Lazy Fortran type inference semantics and implicit rules

- Specify numeric kinds and legacy specifier mappings

- Define expression typing and promotion rules

- Add documentation tests to verify design decisions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Design Document"] -->|"documents type inference"| B["Numeric Kinds & Promotions"]
  A -->|"documents implicit modes"| C["Inference Rules"]
  D["Test Suite"] -->|"validates"| A
  D -->|"verifies content"| B
  D -->|"verifies content"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lazyfortran2025-design.md</strong><dd><code>Document type inference semantics and promotion rules</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/lazyfortran2025-design.md

<ul><li>Added clarification that type inference is local and predictable<br> <li> Documented numeric kinds convention (real(4), real(8), etc.)<br> <li> Specified legacy specifier mappings (double precision => real(8))<br> <li> Detailed expression typing and standard Fortran promotion rules<br> <li> Explained where inference is encouraged vs. explicit types required</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/132/files#diff-67c482242a778a777b15cc9202e48abef52f1187b63bea87d553cb962916db20">+33/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_docs_pages.py</strong><dd><code>Add documentation validation tests for type inference</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_docs_pages.py

<ul><li>Added test to verify numeric kinds documentation (bytes per component)<br> <li> Added test to verify implicit modes and promotion rules coverage<br> <li> Tests ensure design document contains specific semantic guarantees</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/132/files#diff-b468cdfb3629355d4d9f723e8a666785d455840c58c018ff39d8b926c08d784c">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

