### PR TITLE
fix: Fortran 2008: coarray declarations, sync statements, and image i (fixes #83)

### DIFF
--- a/grammars/Fortran2008Parser.g4
+++ b/grammars/Fortran2008Parser.g4
@@ -162,10 +162,10 @@ cosubscript_list
     ;
 
 cosubscript
-    : expr_f90                        // Expression for specific image
-    | expr_f90 COLON                  // lower bound:
-    | COLON expr_f90                  // :upper bound  
-    | expr_f90 COLON expr_f90         // lower:upper
+    : expr_f2003                      // Expression for specific image
+    | expr_f2003 COLON                // lower bound:
+    | COLON expr_f2003                // :upper bound  
+    | expr_f2003 COLON expr_f2003     // lower:upper
     | COLON                           // : (all images)
     ;
 
@@ -190,9 +190,10 @@ sync_memory_stmt
 
 image_set
     : MULTIPLY                        // * (all images)
-    | expr_f90                        // Single image or scalar expression
-    | LSQUARE expr_f90 (COMMA expr_f90)* RSQUARE  // Explicit image set [i1, i2, ...]
-    | LBRACKET expr_f90 (COMMA expr_f90)* RBRACKET
+    | expr_f2003                      // Single image or scalar expression
+    | LSQUARE expr_f2003 (COMMA expr_f2003)* RSQUARE
+      // Explicit image set [i1, i2, ...]
+    | LBRACKET expr_f2003 (COMMA expr_f2003)* RBRACKET
     ;
 
 sync_stat_list
@@ -222,19 +223,21 @@ entity_decl
 lhs_expression
     : identifier_or_keyword                 // Simple variable
       coarray_spec?
-    | identifier_or_keyword LPAREN actual_arg_list? RPAREN
-      coarray_spec?                         // Array element
+    | identifier_or_keyword LPAREN (actual_arg_list | section_subscript_list)? RPAREN
+      coarray_spec?                         // Array element or section
     | identifier_or_keyword PERCENT identifier_or_keyword
       coarray_spec?                         // Component
     | identifier_or_keyword PERCENT identifier_or_keyword
-      LPAREN actual_arg_list? RPAREN
-      coarray_spec?                         // Component array/method
-    | identifier_or_keyword LPAREN actual_arg_list? RPAREN
+      LPAREN (actual_arg_list | section_subscript_list)? RPAREN
+      coarray_spec?                         // Component array/section/method
+    | identifier_or_keyword LPAREN (actual_arg_list | section_subscript_list)? RPAREN
       PERCENT identifier_or_keyword
-      coarray_spec?                         // Array element's component
-    | identifier_or_keyword LPAREN actual_arg_list? RPAREN
-      PERCENT identifier_or_keyword LPAREN actual_arg_list? RPAREN
-      coarray_spec?                         // Array element's component method
+      coarray_spec?                         // Array element or section component
+    | identifier_or_keyword LPAREN
+      (actual_arg_list | section_subscript_list)? RPAREN
+      PERCENT identifier_or_keyword LPAREN
+      (actual_arg_list | section_subscript_list)? RPAREN
+      coarray_spec?                         // Array element/section component method
     ;
 
 // ============================================================================  

--- a/tests/Fortran2008/test_f2008_coarrays.py
+++ b/tests/Fortran2008/test_f2008_coarrays.py
@@ -110,5 +110,18 @@ class TestF2008Coarrays:
         assert tree is not None, "Comprehensive coarray failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for comprehensive coarray test, got {errors}"
 
+    def test_coarray_section_reference(self):
+        """Test coarray array section reference with image selector"""
+        code = load_fixture(
+            "Fortran2008",
+            "test_f2008_coarrays",
+            "coarray_section_reference.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "Coarray section reference failed to produce parse tree"
+        assert errors == 0, (
+            f"Expected 0 errors for coarray section reference, got {errors}"
+        )
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/fixtures/Fortran2008/test_f2008_coarrays/coarray_section_reference.f90
+++ b/tests/fixtures/Fortran2008/test_f2008_coarrays/coarray_section_reference.f90
@@ -1,0 +1,14 @@
+module coarray_section_reference
+    implicit none
+    real :: a(:)[*]
+
+contains
+
+    subroutine update_section
+        integer :: i
+
+        a(:)[this_image()] = 0.0
+    end subroutine update_section
+
+end module coarray_section_reference
+


### PR DESCRIPTION
Summary

- Extend the Fortran 2008 coarray grammar to handle array section designators with coarray codimensions such as a(:)[this_image()].
- Allow coarray cosubscripts and SYNC IMAGES image sets to use full F2003/F2008 expressions, so THIS_IMAGE and NUM_IMAGES can be used in those positions.
- Add a dedicated fixture and regression test for coarray section references to keep issue #83 covered going forward.

Verification

- PATH=/opt/homebrew/opt/openjdk/bin:$PATH make Fortran2008
- pytest tests/Fortran2008 -q
- pytest tests/Fortran2018 -q
- pytest tests -q

Relevant artifact

- tests/fixtures/Fortran2008/test_f2008_coarrays/coarray_section_reference.f90
