### PR TITLE
fix: Fortran 2003: remaining PDT constructors and advanced corner cas (fixes #90)

### DIFF
--- a/docs/fortran_2003_audit.md
+++ b/docs/fortran_2003_audit.md
@@ -82,9 +82,14 @@ supports for practical use, without claiming full ISO conformance.
     - PDTs with deferred (`:`) and assumed (`*`) parameters.
 
 - **Structure constructors for PDTs**
-  - **Status:** Partially implemented; lightly tested.
-  - **Notes:** Structure constructors are handled via general array/constructor
-    rules; PDT-specific constructor corner cases are not fully exercised.
+  - **Status:** Implemented and tested for representative PDT constructor patterns.
+  - **Notes:** Structure constructors are handled via dedicated PDT rules
+    (`pdt_structure_constructor`) layered on top of the general constructor
+    and array-constructor machinery. Tests now cover:
+    - Basic PDT constructors and array-valued components.
+    - Mixed positional/keyword type parameters and component values.
+    - Nested PDT constructors and usage in modules that also exercise
+      deferred (`:`) and assumed (`*`) type parameters.
 
 ---
 

--- a/tests/Fortran2003/test_issue90_pdt_constructors.py
+++ b/tests/Fortran2003/test_issue90_pdt_constructors.py
@@ -47,6 +47,39 @@ class TestF2003PDTConstructors:
         assert tree is not None
         assert errors == 0
 
+    def test_pdt_constructor_with_mixed_type_params_and_components(self):
+        """PDT constructor: mixed positional/keyword type params and components."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue90_pdt_constructors",
+            "pdt_ctor_mixed_params_module.f90",
+        )
+        tree, errors = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_pdt_constructor_nested_in_component(self):
+        """PDT constructor: nested constructors in component position."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue90_pdt_constructors",
+            "pdt_ctor_nested_module.f90",
+        )
+        tree, errors = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_pdt_constructor_with_deferred_and_assumed_params_context(self):
+        """PDT constructor: used alongside deferred and assumed type parameters."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue90_pdt_constructors",
+            "pdt_ctor_poly_module.f90",
+        )
+        tree, errors = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
     def test_pdt_constructor_with_positional_type_params_and_components(self):
         """PDT constructor: positional type params and components."""
         code = load_fixture(

--- a/tests/fixtures/Fortran2003/test_issue90_pdt_constructors/pdt_ctor_mixed_params_module.f90
+++ b/tests/fixtures/Fortran2003/test_issue90_pdt_constructors/pdt_ctor_mixed_params_module.f90
@@ -1,0 +1,24 @@
+module pdt_ctor_mixed
+  implicit none
+
+  type :: t(k, n)
+    integer, kind :: k
+    integer, len  :: n
+    integer       :: val(n)
+  end type t
+
+contains
+
+  subroutine demo
+    type(t(8,3)) :: a
+    type(t(8,3)) :: b
+
+    ! Mixed positional and keyword type parameters with positional component
+    a = t(8, n=3)( [1,2,3] )
+
+    ! Mixed keyword and positional type parameters with named component
+    b = t(k=8, 3)( val = [1,2,3] )
+  end subroutine demo
+
+end module pdt_ctor_mixed
+

--- a/tests/fixtures/Fortran2003/test_issue90_pdt_constructors/pdt_ctor_nested_module.f90
+++ b/tests/fixtures/Fortran2003/test_issue90_pdt_constructors/pdt_ctor_nested_module.f90
@@ -1,0 +1,24 @@
+module pdt_ctor_nested
+  implicit none
+
+  type :: inner_t(k)
+    integer, kind :: k
+    integer :: value
+  end type inner_t
+
+  type :: outer_t(k)
+    integer, kind :: k
+    type(inner_t(k)) :: inner
+  end type outer_t
+
+contains
+
+  subroutine demo
+    type(outer_t(4)) :: o
+
+    ! Nested PDT structure constructors in component position
+    o = outer_t(4)( inner = inner_t(4)(42) )
+  end subroutine demo
+
+end module pdt_ctor_nested
+

--- a/tests/fixtures/Fortran2003/test_issue90_pdt_constructors/pdt_ctor_poly_module.f90
+++ b/tests/fixtures/Fortran2003/test_issue90_pdt_constructors/pdt_ctor_poly_module.f90
@@ -1,0 +1,23 @@
+module pdt_ctor_poly
+  implicit none
+
+  type :: poly_t(k, n)
+    integer, kind :: k
+    integer, len  :: n
+    real(k)       :: coeffs(0:n)
+  end type poly_t
+
+contains
+
+  subroutine demo
+    type(poly_t(8,:)), allocatable :: polys(:)
+    type(poly_t(*,10))             :: default_poly
+
+    ! PDT structure constructors in a module that also uses
+    ! deferred (:) and assumed (*) type parameters.
+    polys(1) = poly_t(8,2)( [0.0, 1.0, 0.0] )
+    default_poly = poly_t(8,10)( coeffs=[1.0, 0.0, 0.0] )
+  end subroutine demo
+
+end module pdt_ctor_poly
+


### PR DESCRIPTION
Summary:
- Add three new Fortran 2003 fixtures exercising advanced PDT structure constructor patterns.
- Extend \ to cover mixed positional/keyword type parameters, nested constructors, and constructors used alongside deferred/assumed type parameters.
- Update \ to reflect that PDT structure constructors are now exercised by dedicated tests.

Verification:
- python -m pytest tests/Fortran2003/test_issue90_pdt_constructors.py -q
  - 6 passed
- python -m pytest -q
  - 486 passed, 3 skipped, 49 xfailed
- make test
  - Fails in this environment because \"antlr4\"/Java is not available; grammar Python artifacts are already present so pytest-based validation succeeded.