### PR TITLE
fix: Fortran fixed-form historical accuracy vs. modern subset (fixes #91)

### DIFF
--- a/docs/UNIFIED_ARCHITECTURE.md
+++ b/docs/UNIFIED_ARCHITECTURE.md
@@ -26,7 +26,7 @@ Each grammar:
 - **Imports from its predecessor** using ANTLR4 import mechanism
 - **Maintains historical accuracy** for each standard's era
 
-### 3. Format Detection Strategy
+### 3. Format Detection Strategy (Current Subset)
 
 The unified approach uses **dual comment handling** and **context-sensitive parsing**:
 
@@ -34,12 +34,22 @@ The unified approach uses **dual comment handling** and **context-sensitive pars
 // Free-form comments (priority - most common in F90+)
 FREE_FORM_COMMENT: '!' ~[\r\n]* -> channel(HIDDEN);
 
-// Fixed-form comments  
+// Fixed-form comments (subset – layout‑lenient, not full 80-column)
 FIXED_FORM_COMMENT: [Cc*] ~[\r\n]* -> channel(HIDDEN);
 
 // Free-form continuation
 CONTINUATION: '&' [ \t]* FREE_FORM_COMMENT? -> channel(HIDDEN);
 ```
+
+This reflects the **implemented subset** rather than full historical
+column semantics. In particular:
+
+- Classic 80‑column layout (labels in 1–5, continuation in 6, text in
+  7–72, sequence numbers in 73–80) is **not** enforced.
+- Column‑6 continuation is modeled via the F90+ `&` convention, not
+  punch‑card continuation rules.
+- Strict column‑accurate fixed-form support remains out of scope and is
+  tracked under umbrella Issue **#91** (see `docs/fixed_form_support.md`).
 
 **Format detection** is handled at the **driver/parser level** based on:
 1. **File extension** (`.f`/`.for` = fixed, `.f90+` = free)
@@ -151,7 +161,10 @@ tree = parser.program_unit_f90()
 The unified architecture provides **consistent error reporting** across formats:
 - **Lexical errors**: Invalid tokens, malformed literals
 - **Syntax errors**: Grammar rule violations, missing constructs
-- **Format errors**: Mixed format usage, column violations (fixed-form)
+- **Format errors**: Mixed format usage or layout issues within the
+  **implemented subset** of fixed-form support (see
+  `docs/fixed_form_support.md` for details). Strict column‑violation
+  checks are not currently implemented and are tracked by Issue #91.
 
 ## Performance Considerations
 

--- a/docs/fortran_2003_audit.md
+++ b/docs/fortran_2003_audit.md
@@ -191,7 +191,8 @@ Fortran 2003 support in this repository can be summarized as:
   - Full semantic validation of interoperability (beyond syntax).
   - Exact reconstruction of all Fortran 2003 edit descriptors and low-level
     FORMAT grammars.
-  - Strict historical column semantics for fixed-form source.
+  - Strict historical column semantics for fixed-form source (tracked
+    under umbrella Issue #91 and documented in `docs/fixed_form_support.md`).
 
 This audit, combined with the spec‑grounded Fortran 2003 tracking issues
 (for example Issue #90), forms the spec‑driven checklist requested in

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,10 @@ PROGRESS** view of where the language is headed.
   Short, user‑facing summary of core features (syntax, tooling, packages).
 - [Unified Grammar Architecture](UNIFIED_ARCHITECTURE.md)  
   Background on the grammar inheritance model used in this repository.
+- [Fixed-form Fortran Support](fixed_form_support.md)  
+  Explicit description of the fixed-form subset implemented for
+  historical dialects and Fortran 90/95/2003+, and the remaining gaps
+  tracked by Issue #91.
 
 For detailed discussion, see issues #51–#57 and related design issues on
 GitHub.
-

--- a/tests/test_fixed_form_docs.py
+++ b/tests/test_fixed_form_docs.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+  return Path(__file__).resolve().parents[1]
+
+
+def test_fixed_form_docs_exist() -> None:
+  """Ensure the fixed-form support documentation is present."""
+  path = _repo_root() / "docs" / "fixed_form_support.md"
+  assert path.is_file(), "docs/fixed_form_support.md must exist"
+
+
+def test_fixed_form_docs_reference_issue_91_and_subset() -> None:
+  """Fixed-form docs should describe subset and link to Issue #91."""
+  path = _repo_root() / "docs" / "fixed_form_support.md"
+  content = path.read_text(encoding="utf-8")
+
+  assert "Issue #91" in content
+  assert "layout\u2011lenient model" in content
+  assert "80-column card layout" in content
+


### PR DESCRIPTION
Summary

- Document the layout-lenient fixed-form subset across historical dialects and Fortran 90/95/2003+.
- Align the unified architecture and Fortran 2003 audit docs with the implemented fixed-form subset and umbrella Issue #91.
- Add a small regression test to ensure the fixed-form documentation stays present and mentions the subset and Issue #91.

Verification

- `python -m pytest tests -q`
  - 480 passed, 49 xfailed, 7 warnings.
  - No changes to generated ANTLR artifacts; only docs and a new test.