### PR TITLE
fix: add PAUSE statement syntax (fixes #151)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -92,13 +92,10 @@ Mapping that Appendix‑B list to the current grammar:
     have no parser rules.
 
 - **PAUSE, STOP, CONTINUE**
-  - Status:
-    - `STOP`, `CONTINUE`: **implemented as standalone statements.**
-    - `PAUSE`: **lexer-only / partial.**
-  - Evidence: `CONTINUE` and `STOP` appear in `statement_body`.
-    `PAUSE` is a token and is tested lexically and via fixtures, but
-    there is no `pause_stmt` rule and tests do not assert zero syntax
-    errors for PAUSE fixtures.
+  - Status: **all implemented and tested.**
+  - Evidence: `CONTINUE`, `STOP` and `PAUSE` appear in `statement_body`.
+    `pause_stmt` accepts `PAUSE` or `PAUSE n` per the IBM 704 manual,
+    and tests assert `getNumberOfSyntaxErrors() == 0`.
 
 - **FREQUENCY**
   - Status: **implemented and tested.**
@@ -117,10 +114,8 @@ and the associated fixtures:
 - DO loops using labeled termination (no `END DO`).
 - STOP and CONTINUE.
 - FREQUENCY as an optimization hint.
-- PAUSE is recognized lexically and used in fixtures, but currently
-  lacks a dedicated `pause_stmt` rule; PAUSE tests focus on token
-  recognition and parse-tree construction rather than zero-error
-  parsing.
+- PAUSE is fully modeled via `pause_stmt` (accepts `PAUSE` or
+  `PAUSE n`) and tested with zero syntax errors.
 
 Out-of-scope / not yet modeled:
 
@@ -177,9 +172,7 @@ Implemented / partially implemented:
   - Fully modeled via `frequency_stmt` and tested with zero syntax
     errors.
 - `PAUSE`:
-  - Recognized by the lexer and exercised in fixtures, but there is no
-    explicit `pause_stmt` rule; tests only assert that parsing does not
-    crash and do not assert zero syntax errors.
+  - Fully modeled via `pause_stmt` and tested with zero syntax errors.
 
 Not fully implemented:
 

--- a/grammars/FORTRANParser.g4
+++ b/grammars/FORTRANParser.g4
@@ -43,9 +43,17 @@ statement_body
     | frequency_stmt
     | read_stmt_basic
     | write_stmt_basic
+    | pause_stmt
     | CONTINUE
     | STOP
     | END
+    ;
+
+// PAUSE statement (1957 operator intervention)
+// PAUSE or PAUSE n (where n is an optional integer)
+// Per IBM 704 FORTRAN manual Appendix B
+pause_stmt
+    : PAUSE (INTEGER_LITERAL)?
     ;
 
 // Assignment statement (universal since 1957)

--- a/tests/FORTRAN/test_fortran_historical_stub.py
+++ b/tests/FORTRAN/test_fortran_historical_stub.py
@@ -417,11 +417,14 @@ class TestFORTRANHistoricalAccuracy:
             "test_fortran_historical_stub",
             "pause_test_1957.f",
         )
-        
+
         parser = self.create_parser(pause_test)
         try:
             tree = parser.program_unit_core()
             assert tree is not None
+            # PAUSE is explicitly modelled in the grammar via pause_stmt,
+            # so this should parse with zero syntax errors.
+            assert parser.getNumberOfSyntaxErrors() == 0
         except Exception as e:
             pytest.fail(f"1957 PAUSE statement failed: {e}")
         


### PR DESCRIPTION
## Summary
- Add `pause_stmt` rule to FORTRANParser.g4 accepting `PAUSE` and `PAUSE n` per IBM 704 manual Appendix B
- Wire `pause_stmt` into `statement_body` for FORTRAN 1957
- Strengthen test to assert `getNumberOfSyntaxErrors() == 0` for PAUSE fixtures
- Update docs/fortran_1957_audit.md to classify PAUSE as fully implemented

## Verification
```
$ python -m pytest tests/FORTRAN/test_fortran_historical_stub.py -v -k unique
tests/.../test_1957_unique_features_accuracy PASSED
```

```
$ python -m pytest tests -q
481 passed, 49 xfailed, 7 warnings in 26.97s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)