### PR TITLE
fix: resolve FORTRAN 77 nested IF fixture XPASS (fixes #166)

### DIFF
--- a/grammars/FORTRAN77Parser.g4
+++ b/grammars/FORTRAN77Parser.g4
@@ -150,6 +150,12 @@ executable_construct
 // FORTRAN 77 (1977) - ENHANCED I/O
 // ====================================================================
 
+// Enhanced PRINT statement with list-directed I/O (NEW in FORTRAN 77)
+// FORTRAN 77 added PRINT *, list form for list-directed output
+print_stmt
+    : PRINT format_identifier (COMMA output_item_list)?
+    ;
+
 // Enhanced WRITE statement (NEW in FORTRAN 77)
 write_stmt
     : WRITE LPAREN control_info_list RPAREN output_item_list?
@@ -176,6 +182,7 @@ output_item_list
 
 output_item
     : expr
+    | character_expr  // String literals in output (NEW in FORTRAN 77)
     | implied_do
     ;
 
@@ -288,6 +295,23 @@ variable_list
 // ====================================================================
 // FORTRAN 77 (1977) - ENHANCED EXPRESSIONS
 // ====================================================================
+
+// Override literal to accept LABEL tokens as integers due to lexer
+// token precedence: LABEL is defined before INTEGER_LITERAL in
+// FORTRANIILexer and matches first for 1-5 digit numbers
+literal
+    : INTEGER_LITERAL
+    | LABEL                     // Accept LABEL as integer (token precedence)
+    | REAL_LITERAL
+    | STRING_LITERAL            // NEW in FORTRAN 77
+    | logical_literal           // From FORTRAN IV via FORTRAN 66
+    ;
+
+// Logical literals from FORTRAN IV (imported via FORTRAN 66)
+logical_literal
+    : DOT_TRUE
+    | DOT_FALSE
+    ;
 
 // Character expressions (NEW in FORTRAN 77)
 character_expr

--- a/tests/test_fixture_parsing.py
+++ b/tests/test_fixture_parsing.py
@@ -489,14 +489,6 @@ XPASS_FIXTURES: Dict[Tuple[str, Path], str] = {
         "{errors} syntax errors; full historical coverage is out of scope for "
         "the simplified grammar."
     ),
-    (
-        "FORTRAN77",
-        Path("FORTRAN77/test_fortran77_parser_extra/nested_if_block.f"),
-    ): (
-        "FORTRAN 77 nested-IF fixture {relpath} exercises complex structured "
-        "programming patterns that still cause {errors} syntax errors in the "
-        "current FORTRAN 77 grammar."
-    ),
     # Fortran2003 negative / fixed-form fixtures that intentionally exercise
     # error paths or comment-handling edge cases. These are tied to specific
     # Fortran 2003 issues in the audit document.


### PR DESCRIPTION
## Summary
- Added FORTRAN 77 list-directed I/O support (`PRINT *, ...`) to the parser grammar
- Fixed integer literal vs LABEL token precedence issue in expressions
- Added STRING_LITERAL and logical_literal support to the F77 literal rule
- Removed nested_if_block.f from XPASS_FIXTURES since it now passes with main_program entry rule

## Changes
1. **grammars/FORTRAN77Parser.g4**:
   - Added `print_stmt` override using `format_identifier` which accepts `MULTIPLY` (*)
   - Added `character_expr` to `output_item` for string literals in I/O
   - Added `literal` rule override to accept LABEL tokens as integers (lexer precedence workaround)
   - Added `logical_literal` rule for .TRUE./.FALSE. support

2. **tests/test_fixture_parsing.py**:
   - Removed nested_if_block.f from XPASS_FIXTURES dict

## Test plan
- [x] All 482 tests pass (gained 1 from fixture now passing)
- [x] 48 xfailed (reduced by 1)
- [x] Verified nested IF block with `PRINT *, 'string'` parses with 0 errors using main_program entry rule

## Verification
```python
python -c "
import sys
sys.path.insert(0, 'grammars')
from antlr4 import InputStream, CommonTokenStream
from FORTRAN77Lexer import FORTRAN77Lexer
from FORTRAN77Parser import FORTRAN77Parser

code = '''IF (STATUS .EQ. 1) THEN
    PRINT *, 'HELLO'
END IF
'''
parser = FORTRAN77Parser(CommonTokenStream(FORTRAN77Lexer(InputStream(code))))
tree = parser.main_program()
print(f'Errors: {parser.getNumberOfSyntaxErrors()}')  # Outputs: Errors: 0
"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)