### PR TITLE
fix: add DIMENSION and EQUIVALENCE to FORTRAN 1957 (fixes #149)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -37,12 +37,12 @@ REWIND / BACKSPACE, PAUSE, STOP / CONTINUE and FREQUENCY.
 Mapping that Appendix‑B list to the current grammar:
 
 - **DIMENSION, EQUIVALENCE**
-  - Status: lexer-only; **no statement rules**.
-  - Evidence: tokens exist in `FORTRANLexer.g4`, but
-    `FORTRANParser.g4` has no `dimension_stmt` or `equivalence_stmt`
-    and `statement_body` never references these keywords. Fixtures like
-    `array_program_1957.f` are XPASS and documented as exercising more
-    of the original language than the simplified grammar accepts.
+  - Status: **implemented and tested**.
+  - Evidence: `dimension_stmt` and `equivalence_stmt` rules exist in
+    `FORTRANParser.g4` and are wired into `statement_body`. Dedicated
+    tests in `tests/FORTRAN/test_fortran_historical_stub.py` validate
+    parsing of single/multi-dimensional arrays and multi-variable
+    equivalence sets with zero syntax errors.
 
 - **Assignment**
   - Status: **implemented and tested.**
@@ -164,10 +164,9 @@ Known limitations (from fixtures and comments):
 Implemented / partially implemented:
 
 - `DIMENSION` and `EQUIVALENCE`:
-  - Tokens are present in `FORTRANLexer.g4` and appear in historical
-    fixtures (for example `array_program_1957.f`), but the parser has
-    no corresponding statement rules; fixtures using DIMENSION are
-    XPASS and documented as beyond the simplified grammar.
+  - **Fully implemented** via `dimension_stmt` and `equivalence_stmt`
+    rules in `FORTRANParser.g4`. Both statements now parse with zero
+    syntax errors and are validated by dedicated tests.
 - `FREQUENCY`:
   - Fully modeled via `frequency_stmt` and tested with zero syntax
     errors.

--- a/grammars/FORTRANParser.g4
+++ b/grammars/FORTRANParser.g4
@@ -44,6 +44,8 @@ statement_body
     | read_stmt_basic
     | write_stmt_basic
     | pause_stmt
+    | dimension_stmt
+    | equivalence_stmt
     | CONTINUE
     | STOP
     | END
@@ -54,6 +56,39 @@ statement_body
 // Per IBM 704 FORTRAN manual Appendix B
 pause_stmt
     : PAUSE (INTEGER_LITERAL)?
+    ;
+
+// DIMENSION statement (array declarations)
+// Per IBM 704 FORTRAN manual (Form C28-6003, Oct 1958) Appendix B
+// Syntax: DIMENSION v, v, v, ... where v is an array declarator
+// Example: DIMENSION A(100), B(10,20), C(5,5,5)
+dimension_stmt
+    : DIMENSION array_declarator (COMMA array_declarator)*
+    ;
+
+// Array declarator specifies array name and dimensions
+// In 1957 FORTRAN, dimensions were compile-time constants
+array_declarator
+    : IDENTIFIER LPAREN dimension_list RPAREN
+    ;
+
+// Dimension list contains one or more dimension bounds
+dimension_list
+    : expr (COMMA expr)*
+    ;
+
+// EQUIVALENCE statement (memory overlay)
+// Per IBM 704 FORTRAN manual (Form C28-6003, Oct 1958) Appendix B
+// Syntax: EQUIVALENCE (a,b,c,...), (d,e,f,...), ...
+// Example: EQUIVALENCE (A, B(1)), (X, Y, Z)
+// Allows variables to share the same memory location
+equivalence_stmt
+    : EQUIVALENCE equivalence_set (COMMA equivalence_set)*
+    ;
+
+// Equivalence set is a parenthesized list of variables sharing memory
+equivalence_set
+    : LPAREN variable (COMMA variable)+ RPAREN
     ;
 
 // Assignment statement (universal since 1957)

--- a/tests/FORTRAN/test_fortran_historical_stub.py
+++ b/tests/FORTRAN/test_fortran_historical_stub.py
@@ -223,7 +223,7 @@ class TestFORTRANHistoricalStub:
             "test_fortran_historical_stub",
             "frequency_stmt.f",
         )
-        
+
         parser = self.create_parser(test_input)
 
         try:
@@ -234,6 +234,70 @@ class TestFORTRANHistoricalStub:
             assert parser.getNumberOfSyntaxErrors() == 0
         except Exception as e:
             pytest.fail(f"FREQUENCY statement parsing failed: {e}")
+
+    def test_dimension_statement(self):
+        """Test parsing of DIMENSION statement (array declarations).
+
+        Per IBM 704 FORTRAN manual (Form C28-6003, Oct 1958) Appendix B,
+        DIMENSION declares array names and their dimensions.
+        Syntax: DIMENSION v, v, v, ... where v is IDENTIFIER(dimensions)
+        """
+        test_input = """        DIMENSION A(100), B(10,20), C(5,5,5)
+        END
+"""
+        parser = self.create_parser(test_input)
+        tree = parser.program_unit_core()
+        assert tree is not None
+        assert parser.getNumberOfSyntaxErrors() == 0
+
+    def test_dimension_statement_expressions(self):
+        """Test DIMENSION with expression bounds (1957 supported variables)."""
+        test_input = """        DIMENSION X(N), Y(M,N), Z(I+1)
+        END
+"""
+        parser = self.create_parser(test_input)
+        tree = parser.program_unit_core()
+        assert tree is not None
+        assert parser.getNumberOfSyntaxErrors() == 0
+
+    def test_equivalence_statement(self):
+        """Test parsing of EQUIVALENCE statement (memory overlay).
+
+        Per IBM 704 FORTRAN manual (Form C28-6003, Oct 1958) Appendix B,
+        EQUIVALENCE allows variables to share the same memory location.
+        Syntax: EQUIVALENCE (a,b,c,...), (d,e,f,...), ...
+        """
+        test_input = """        EQUIVALENCE (X, Y, Z), (A, B)
+        END
+"""
+        parser = self.create_parser(test_input)
+        tree = parser.program_unit_core()
+        assert tree is not None
+        assert parser.getNumberOfSyntaxErrors() == 0
+
+    def test_equivalence_with_array_elements(self):
+        """Test EQUIVALENCE with array subscripts (memory overlay at specific indices)."""
+        test_input = """        DIMENSION A(100), B(10,20)
+        EQUIVALENCE (A(1), B(1,1)), (X, Y)
+        END
+"""
+        parser = self.create_parser(test_input)
+        tree = parser.program_unit_core()
+        assert tree is not None
+        assert parser.getNumberOfSyntaxErrors() == 0
+
+    def test_dimension_and_equivalence_combined(self):
+        """Test DIMENSION and EQUIVALENCE used together in typical 1957 pattern."""
+        test_input = """        DIMENSION A(100), B(10,20), C(5,5,5)
+        EQUIVALENCE (A(1), B(1,1)), (X, Y, Z)
+        A(1) = 1.0
+        X = 2.0
+        END
+"""
+        parser = self.create_parser(test_input)
+        tree = parser.program_unit_core()
+        assert tree is not None
+        assert parser.getNumberOfSyntaxErrors() == 0
 
     def test_mathematical_expressions(self):
         """Test parsing of mathematical expressions (core FORTRAN innovation)."""


### PR DESCRIPTION
## Summary
- Add `dimension_stmt` and `equivalence_stmt` parser rules to `FORTRANParser.g4` per IBM 704 FORTRAN manual (Form C28-6003, Oct 1958) Appendix B
- Add 5 focused tests validating zero syntax errors for various DIMENSION/EQUIVALENCE patterns
- Update `docs/fortran_1957_audit.md` to reflect implemented status

## Test plan
- [x] `python -m pytest tests/ -q` passes 487 tests (0 failures)
- [x] New DIMENSION/EQUIVALENCE tests validate:
  - Basic multi-dimensional arrays: `DIMENSION A(100), B(10,20), C(5,5,5)`
  - Expression bounds: `DIMENSION X(N), Y(M,N)`
  - Memory overlay: `EQUIVALENCE (X, Y, Z), (A, B)`
  - Array element overlay: `EQUIVALENCE (A(1), B(1,1))`
  - Combined usage pattern

## Verification
```
$ python -m pytest tests/FORTRAN/test_fortran_historical_stub.py -k "dimension or equivalence" -v
tests/.../test_dimension_statement PASSED
tests/.../test_dimension_statement_expressions PASSED
tests/.../test_equivalence_statement PASSED
tests/.../test_equivalence_with_array_elements PASSED
tests/.../test_dimension_and_equivalence_combined PASSED
5 passed in 0.03s

$ python -m pytest tests/ -q
487 passed, 48 xfailed, 7 warnings in 27.07s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)