### PR TITLE
fix: remove duplicate data_stmt in FORTRAN77 (fixes #200)

### DIFF
--- a/grammars/FORTRAN77Parser.g4
+++ b/grammars/FORTRAN77Parser.g4
@@ -98,7 +98,6 @@ statement_body
     | save_stmt         // NEW: SAVE statement
     | intrinsic_stmt    // NEW: INTRINSIC statement
     | external_stmt     // NEW: EXTERNAL statement
-    | data_stmt         // NEW: DATA statement
     ;
 
 // Block IF construct (NEW in FORTRAN 77)


### PR DESCRIPTION
## Summary

- Removed duplicate `data_stmt` alternative from `statement_body` rule in `FORTRAN77Parser.g4`
- The rule previously had `data_stmt` listed twice (at lines 93 and 101)
- Kept the first occurrence with comment "Variable initialization"
- Grammar behavior unchanged; ANTLR4 harmlessly accepted duplicates, but this improves clarity

## Verification

```bash
# All tests pass (492 passed, 43 xfailed)
python -m pytest tests/ -v --tb=short

# FORTRAN 77 specific tests: 11 passed
python -m pytest tests/FORTRAN77/ -v

# DATA statement parsing verified:
# data_stmt parses: DATA X, Y, Z /1.0, 2.0, 3.0/
# Parse tree: (data_stmt DATA (data_stmt_set (variable_list ...) / (data_constant_list ...) /))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)