### PR TITLE
fix: add EXTERNAL and INTRINSIC declaration statements to FORTRAN 66 (fixes #162)

### DIFF
--- a/docs/fortran_66_audit.md
+++ b/docs/fortran_66_audit.md
@@ -261,11 +261,14 @@ Mapping these families to the current grammar:
       - Effect: any conforming DATA statements are rejected.
     - EXTERNAL / INTRINSIC:
       - Lexer: `EXTERNAL` and `INTRINSIC` tokens exist.
-      - Parser: no `external_stmt` or `intrinsic_stmt` in
-        `FORTRAN66Parser.g4`; these tokens are not used in
-        `statement_body` or in a declaration context.
-      - Effect: declarations like `EXTERNAL F` or `INTRINSIC SIN`
-        are not accepted as first‑class non‑executable statements.
+      - Parser: `external_stmt` and `intrinsic_stmt` rules are
+        implemented in `FORTRAN66Parser.g4` per X3.9-1966 Section 7.2.
+        These are wired into `statement_body` as non-executable
+        declaration statements.
+      - Syntax: `EXTERNAL name, name, ...` and `INTRINSIC name, name, ...`
+      - Tests: covered by `test_external_statement`, `test_intrinsic_statement`,
+        `test_external_intrinsic_in_program`, and `test_external_intrinsic_fixture`
+        in `tests/FORTRAN66/test_fortran66_parser.py`.
 
 ## 5. Fixed-form model
 
@@ -336,17 +339,19 @@ The FORTRAN 66 grammar in this repository:
   EQUIVALENCE, COMMON, FORMAT, and basic I/O.
 - Uses a layout‑lenient fixed-form model, without enforcing strict
   80‑column semantics.
+- Implements `EXTERNAL` and `INTRINSIC` declaration statements per
+  X3.9-1966 Section 7.2.
 - Does **not** yet implement several standard FORTRAN 66 statements
-  and declarations such as DATA, EXTERNAL, INTRINSIC, and sequential
-  I/O control (`REWIND`, `BACKSPACE`, `ENDFILE`).
+  and declarations such as DATA and sequential I/O control
+  (`REWIND`, `BACKSPACE`, `ENDFILE`).
 - Still rejects some richer, spec-inspired fixtures, which are
   tracked as XPASS in the generic fixture harness.
 
 Future work should:
 
 - Add explicit grammar rules and tests for the missing standard
-  statements (DATA, EXTERNAL, INTRINSIC, REWIND/BACKSPACE/ENDFILE) if
-  full FORTRAN 66 coverage is desired.
+  statements (DATA, REWIND/BACKSPACE/ENDFILE) if full FORTRAN 66
+  coverage is desired.
 - Align the generic fixture parser entry rule and expectations for
   FORTRAN 66 with the dedicated `fortran66_program` rule.
 - Use the XPASS fixtures as a concrete checklist for closing the

--- a/grammars/FORTRAN66Parser.g4
+++ b/grammars/FORTRAN66Parser.g4
@@ -221,8 +221,37 @@ statement_body
     | equivalence_stmt   // Variable memory overlay
     | common_stmt        // Global variable declarations
     | type_declaration  // Variable type declarations
+    | external_stmt     // External procedure declaration (X3.9-1966 Section 7.2)
+    | intrinsic_stmt    // Intrinsic function specification (X3.9-1966 Section 7.2)
     | return_stmt       // Return from subprogram
     | call_stmt         // Call subroutine
+    ;
+
+// ====================================================================
+// FORTRAN 66 (1966) - EXTERNAL AND INTRINSIC STATEMENTS
+// ====================================================================
+// Per ANSI X3.9-1966 Section 7.2, these are non-executable declaration
+// statements that classify procedure names:
+// - EXTERNAL identifies user-defined external procedures
+// - INTRINSIC identifies standard library intrinsic functions
+
+// EXTERNAL statement (X3.9-1966 Section 7.2)
+// Declares one or more external procedure names.
+// Example: EXTERNAL F, G, MYFUNC
+external_stmt
+    : EXTERNAL identifier_list
+    ;
+
+// INTRINSIC statement (X3.9-1966 Section 7.2)
+// Declares one or more intrinsic function names to use standard meanings.
+// Example: INTRINSIC SIN, COS, SQRT, ABS
+intrinsic_stmt
+    : INTRINSIC identifier_list
+    ;
+
+// Identifier list for EXTERNAL/INTRINSIC statements
+identifier_list
+    : IDENTIFIER (COMMA IDENTIFIER)*
     ;
 
 // Variable list for declarations

--- a/tests/FORTRAN66/test_fortran66_parser.py
+++ b/tests/FORTRAN66/test_fortran66_parser.py
@@ -284,23 +284,79 @@ class TestFORTRAN66Parser(unittest.TestCase):
             "READY = .TRUE.",
             "FLAG = .FALSE.",
             "RESULT = READY .AND. FLAG",
-            
+
             # Double precision literals
             "PI = 3.14159265358979D0",
-            
+
             # Complex literals
             "Z = (1.0, 2.0)",
             "IMPEDANCE = (3.0, 4.0)",
-            
+
             # Mixed mode arithmetic
             "X = I + 3.14",
         ]
-        
+
         for test_code in test_cases:
             with self.subTest(code=test_code):
                 tree = self.parse(test_code, 'assignment_stmt')
                 self.assertIsNotNone(tree)
                 self.assertTrue(len(str(tree.getText())) > 5)
+
+    # ====================================================================
+    # FORTRAN 66 EXTERNAL AND INTRINSIC STATEMENTS (X3.9-1966 Section 7.2)
+    # ====================================================================
+
+    def test_external_statement(self):
+        """Test EXTERNAL statement (X3.9-1966 Section 7.2)"""
+        test_cases = [
+            "EXTERNAL F",
+            "EXTERNAL MYFUNC",
+            "EXTERNAL F, G",
+            "EXTERNAL MYFUNC, MYSUB, HELPER",
+        ]
+
+        for text in test_cases:
+            with self.subTest(external_stmt=text):
+                tree = self.parse(text, 'external_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_intrinsic_statement(self):
+        """Test INTRINSIC statement (X3.9-1966 Section 7.2)"""
+        test_cases = [
+            "INTRINSIC SIN",
+            "INTRINSIC COS",
+            "INTRINSIC SIN, COS",
+            "INTRINSIC SIN, COS, SQRT, ABS",
+            "INTRINSIC ATAN2, MAX, MIN",
+        ]
+
+        for text in test_cases:
+            with self.subTest(intrinsic_stmt=text):
+                tree = self.parse(text, 'intrinsic_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_external_intrinsic_in_program(self):
+        """Test EXTERNAL and INTRINSIC as statement_body alternatives"""
+        test_cases = [
+            "EXTERNAL F",
+            "INTRINSIC SIN",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree)
+
+    def test_external_intrinsic_fixture(self):
+        """Test program with EXTERNAL and INTRINSIC declarations"""
+        program = load_fixture(
+            "FORTRAN66",
+            "test_fortran66_parser",
+            "external_intrinsic.f",
+        )
+
+        tree = self.parse(program, 'main_program')
+        self.assertIsNotNone(tree)
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/FORTRAN66/test_fortran66_parser/external_intrinsic.f
+++ b/tests/fixtures/FORTRAN66/test_fortran66_parser/external_intrinsic.f
@@ -1,0 +1,10 @@
+      EXTERNAL MYFUNC, MYSUB
+      INTRINSIC SIN, COS, SQRT, ABS
+      REAL X, Y, Z
+      X = 1.0
+      Y = SIN(X)
+      Z = MYFUNC(X, Y)
+      CALL MYSUB(Z)
+      PRINT 100, Z
+100   FORMAT (F10.5)
+      END


### PR DESCRIPTION
## Summary

- Add `external_stmt` and `intrinsic_stmt` parser rules to `FORTRAN66Parser.g4` per ANSI X3.9-1966 Section 7.2
- These non-executable declaration statements classify procedure names:
  - `EXTERNAL` identifies user-defined external procedures
  - `INTRINSIC` identifies standard library intrinsic functions
- Add test fixture `external_intrinsic.f` demonstrating both statements in a program
- Add comprehensive test cases in `test_fortran66_parser.py`
- Update `docs/fortran_66_audit.md` to reflect implementation status

## Verification

```bash
# Build grammars (requires Java for ANTLR)
make all

# Run FORTRAN66 tests
python -m pytest tests/FORTRAN66/test_fortran66_parser.py -v --tb=short

# Results: 18 passed (includes 4 new EXTERNAL/INTRINSIC tests)
```

Test output:
```
tests/FORTRAN66/test_fortran66_parser.py::TestFORTRAN66Parser::test_external_statement PASSED
tests/FORTRAN66/test_fortran66_parser.py::TestFORTRAN66Parser::test_intrinsic_statement PASSED
tests/FORTRAN66/test_fortran66_parser.py::TestFORTRAN66Parser::test_external_intrinsic_in_program PASSED
tests/FORTRAN66/test_fortran66_parser.py::TestFORTRAN66Parser::test_external_intrinsic_fixture PASSED
```

Full test suite: 497 passed, 43 xfailed (expected failures), 7 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)