### PR TITLE
fix: add REWIND, BACKSPACE, ENDFILE auxiliary I/O statements to FORTRAN 66 (fixes #160)

### DIFF
--- a/docs/fortran_66_audit.md
+++ b/docs/fortran_66_audit.md
@@ -222,13 +222,20 @@ Mapping these families to the current grammar:
         `format_item` and `format_descriptor`, plus the `HOLLERITH`
         token for Hollerith constants; the FORMAT grammar is shared
         with FORTRAN II.
-  - Not implemented:
+  - Implemented:
     - REWIND, BACKSPACE, ENDFILE:
-      - The standard defines these as auxiliary I/O statements
-        (7.1.3.3) with specific syntax and semantics for file
-        positioning. The current lexer/parser do not define
-        `REWIND`, `BACKSPACE` or `ENDFILE` tokens or rules.
-      - Effect: REWIND/BACKSPACE/ENDFILE in source will be rejected.
+      - Per X3.9-1966 Section 7.1.3.3, these auxiliary I/O statements
+        control sequential file positioning.
+      - Lexer: `REWIND`, `BACKSPACE`, `ENDFILE` tokens defined in
+        `FORTRAN66Lexer.g4`.
+      - Parser: `rewind_stmt`, `backspace_stmt`, `endfile_stmt` rules
+        defined in `FORTRAN66Parser.g4`, wired into `statement_body`.
+      - Syntax: `REWIND u`, `BACKSPACE u`, `ENDFILE u` where u is an
+        unsigned integer expression identifying the I/O unit.
+      - Tests: covered by `test_rewind_statement`, `test_backspace_statement`,
+        `test_endfile_statement`, `test_auxiliary_io_in_statement_body`,
+        and `test_auxiliary_io_fixture` in
+        `tests/FORTRAN66/test_fortran66_parser.py`.
 
 - **Non‑executable (declarative) statements**
   - Implemented:
@@ -341,17 +348,16 @@ The FORTRAN 66 grammar in this repository:
   80‑column semantics.
 - Implements `EXTERNAL` and `INTRINSIC` declaration statements per
   X3.9-1966 Section 7.2.
-- Does **not** yet implement several standard FORTRAN 66 statements
-  and declarations such as DATA and sequential I/O control
-  (`REWIND`, `BACKSPACE`, `ENDFILE`).
+- Implements auxiliary I/O statements (`REWIND`, `BACKSPACE`, `ENDFILE`)
+  per X3.9-1966 Section 7.1.3.3.
+- Does **not** yet implement the DATA statement for initialization.
 - Still rejects some richer, spec-inspired fixtures, which are
   tracked as XPASS in the generic fixture harness.
 
 Future work should:
 
-- Add explicit grammar rules and tests for the missing standard
-  statements (DATA, REWIND/BACKSPACE/ENDFILE) if full FORTRAN 66
-  coverage is desired.
+- Add explicit grammar rules and tests for the missing DATA statement
+  if full FORTRAN 66 coverage is desired.
 - Align the generic fixture parser entry rule and expectations for
   FORTRAN 66 with the dedicated `fortran66_program` rule.
 - Use the XPASS fixtures as a concrete checklist for closing the

--- a/grammars/FORTRAN66Lexer.g4
+++ b/grammars/FORTRAN66Lexer.g4
@@ -78,6 +78,12 @@ BLOCKDATA       : B L O C K D A T A ;  // BLOCK DATA program unit
 EXTERNAL        : E X T E R N A L ;    // External procedure declaration
 INTRINSIC       : I N T R I N S I C ;  // Intrinsic function specification
 
+// Auxiliary I/O statements (ANSI X3.9-1966 Section 7.1.3.3)
+// Sequential file positioning statements
+REWIND          : R E W I N D ;        // Position file to beginning
+BACKSPACE       : B A C K S P A C E ;  // Position file back one record
+ENDFILE         : E N D F I L E ;      // Write end-of-file mark
+
 // Standardized statement labels (1-99999, no leading zeros)
 // This was formalized in FORTRAN 66 to ensure portability
 

--- a/grammars/FORTRAN66Parser.g4
+++ b/grammars/FORTRAN66Parser.g4
@@ -223,8 +223,36 @@ statement_body
     | type_declaration  // Variable type declarations
     | external_stmt     // External procedure declaration (X3.9-1966 Section 7.2)
     | intrinsic_stmt    // Intrinsic function specification (X3.9-1966 Section 7.2)
+    | rewind_stmt       // Sequential file positioning (X3.9-1966 Section 7.1.3.3)
+    | backspace_stmt    // Sequential file positioning (X3.9-1966 Section 7.1.3.3)
+    | endfile_stmt      // Sequential file positioning (X3.9-1966 Section 7.1.3.3)
     | return_stmt       // Return from subprogram
     | call_stmt         // Call subroutine
+    ;
+
+// ====================================================================
+// FORTRAN 66 (1966) - AUXILIARY I/O STATEMENTS
+// ====================================================================
+// Per ANSI X3.9-1966 Section 7.1.3.3, auxiliary I/O statements control
+// sequential file positioning. The syntax is: statement-keyword u
+// where u is an unsigned integer expression identifying the I/O unit.
+
+// REWIND statement - position file to beginning (X3.9-1966 Section 7.1.3.3)
+// Example: REWIND 5
+rewind_stmt
+    : REWIND integer_expr
+    ;
+
+// BACKSPACE statement - position file back one record (X3.9-1966 Section 7.1.3.3)
+// Example: BACKSPACE 5
+backspace_stmt
+    : BACKSPACE integer_expr
+    ;
+
+// ENDFILE statement - write end-of-file mark (X3.9-1966 Section 7.1.3.3)
+// Example: ENDFILE 5
+endfile_stmt
+    : ENDFILE integer_expr
     ;
 
 // ====================================================================

--- a/grammars/FORTRAN77Lexer.g4
+++ b/grammars/FORTRAN77Lexer.g4
@@ -56,12 +56,11 @@ INTRINSIC       : I N T R I N S I C ;
 // ENDDO is a widely used extension and is included here for convenience.
 ENDDO           : E N D D O ;
 
-// I/O enhancements
+// I/O enhancements (OPEN, CLOSE, INQUIRE new in FORTRAN 77)
+// Note: REWIND, BACKSPACE, ENDFILE are inherited from FORTRAN 66
 OPEN            : O P E N ;
 CLOSE           : C L O S E ;
 INQUIRE         : I N Q U I R E ;
-BACKSPACE       : B A C K S P A C E ;
-REWIND          : R E W I N D ;
 
 // ====================================================================
 // FORTRAN 77 STRING PROCESSING

--- a/tests/FORTRAN66/test_fortran66_parser.py
+++ b/tests/FORTRAN66/test_fortran66_parser.py
@@ -358,6 +358,76 @@ class TestFORTRAN66Parser(unittest.TestCase):
         tree = self.parse(program, 'main_program')
         self.assertIsNotNone(tree)
 
+    # ====================================================================
+    # FORTRAN 66 AUXILIARY I/O STATEMENTS (X3.9-1966 Section 7.1.3.3)
+    # ====================================================================
+
+    def test_rewind_statement(self):
+        """Test REWIND statement (X3.9-1966 Section 7.1.3.3)"""
+        test_cases = [
+            "REWIND 5",
+            "REWIND 1",
+            "REWIND 10",
+            "REWIND I",
+        ]
+
+        for text in test_cases:
+            with self.subTest(rewind_stmt=text):
+                tree = self.parse(text, 'rewind_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_backspace_statement(self):
+        """Test BACKSPACE statement (X3.9-1966 Section 7.1.3.3)"""
+        test_cases = [
+            "BACKSPACE 5",
+            "BACKSPACE 1",
+            "BACKSPACE 10",
+            "BACKSPACE N",
+        ]
+
+        for text in test_cases:
+            with self.subTest(backspace_stmt=text):
+                tree = self.parse(text, 'backspace_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_endfile_statement(self):
+        """Test ENDFILE statement (X3.9-1966 Section 7.1.3.3)"""
+        test_cases = [
+            "ENDFILE 5",
+            "ENDFILE 1",
+            "ENDFILE 10",
+            "ENDFILE IUNIT",
+        ]
+
+        for text in test_cases:
+            with self.subTest(endfile_stmt=text):
+                tree = self.parse(text, 'endfile_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_auxiliary_io_in_statement_body(self):
+        """Test auxiliary I/O statements as statement_body alternatives"""
+        test_cases = [
+            "REWIND 5",
+            "BACKSPACE 5",
+            "ENDFILE 5",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree)
+
+    def test_auxiliary_io_fixture(self):
+        """Test program with auxiliary I/O statements"""
+        program = load_fixture(
+            "FORTRAN66",
+            "test_fortran66_parser",
+            "auxiliary_io.f",
+        )
+
+        tree = self.parse(program, 'main_program')
+        self.assertIsNotNone(tree)
+
 
 if __name__ == "__main__":
     # Run with verbose output to see which tests fail

--- a/tests/fixtures/FORTRAN66/test_fortran66_parser/auxiliary_io.f
+++ b/tests/fixtures/FORTRAN66/test_fortran66_parser/auxiliary_io.f
@@ -1,0 +1,11 @@
+      INTEGER I
+      DIMENSION DATA(100)
+      REWIND 5
+      BACKSPACE 5
+      ENDFILE 5
+      DO 10 I = 1, 10
+         DATA(I) = I * 2
+   10 CONTINUE
+      REWIND 6
+      ENDFILE 6
+      END


### PR DESCRIPTION
## Summary
- Adds REWIND, BACKSPACE, ENDFILE auxiliary I/O statements to FORTRAN 66 per ANSI X3.9-1966 Section 7.1.3.3
- Adds lexer tokens and parser rules for sequential file positioning statements
- Removes duplicate tokens from FORTRAN77Lexer.g4 (now inherited from FORTRAN 66)

## Test plan
- [ ] CI builds grammars successfully with ANTLR4
- [ ] Tests pass: `test_rewind_statement`, `test_backspace_statement`, `test_endfile_statement`
- [ ] Tests pass: `test_auxiliary_io_in_statement_body`, `test_auxiliary_io_fixture`
- [ ] FORTRAN 77 tests continue to pass (inherits auxiliary I/O from FORTRAN 66)

## Verification
Grammar changes validated via visual inspection of .g4 files. CI will rebuild Python parsers from grammar files.

Example syntax now supported:
```fortran
REWIND 5
BACKSPACE 5
ENDFILE 5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)