### PR TITLE
fix: add ASSIGN and assigned GOTO to FORTRAN 66 grammar (fixes #159)

### DIFF
--- a/grammars/FORTRAN66Parser.g4
+++ b/grammars/FORTRAN66Parser.g4
@@ -207,6 +207,8 @@ statement_body
     : assignment_stmt      // Variable = Expression
     | goto_stmt           // Unconditional jump to labeled statement
     | computed_goto_stmt  // Multi-way branch based on integer expression
+    | assign_stmt         // GO TO assignment: ASSIGN k TO i (X3.9-1966 7.1.1.3)
+    | assigned_goto_stmt  // Assigned GO TO: GO TO i, (k1,...) (X3.9-1966 7.1.2.1.2)
     | arithmetic_if_stmt  // Three-way branch based on expression sign
     | logical_if_stmt     // Two-way branch based on logical expression
     | do_stmt            // Counted loop with mandatory label
@@ -285,6 +287,29 @@ identifier_list
 // Variable list for declarations
 variable_list
     : variable (COMMA variable)*
+    ;
+
+// ====================================================================
+// FORTRAN 66 (1966) - GO TO ASSIGNMENT STATEMENT
+// ====================================================================
+// Per ANSI X3.9-1966 Section 7.1.1.3, the GO TO assignment statement
+// syntax is: ASSIGN k TO i
+// where k is a statement label and i is an integer variable.
+// This stores the label k in variable i for use with assigned GO TO.
+assign_stmt
+    : ASSIGN label TO variable
+    ;
+
+// ====================================================================
+// FORTRAN 66 (1966) - ASSIGNED GO TO STATEMENT
+// ====================================================================
+// Per ANSI X3.9-1966 Section 7.1.2.1.2, the assigned GO TO statement
+// syntax is: GO TO i, (k1, k2, ..., km)
+// where i is an integer variable containing a label (set by ASSIGN)
+// and (k1, k2, ..., km) is a list of valid target labels.
+// Branches to the label stored in variable i.
+assigned_goto_stmt
+    : GOTO variable COMMA LPAREN label_list RPAREN
     ;
 
 // ====================================================================

--- a/tests/FORTRAN66/test_fortran66_parser.py
+++ b/tests/FORTRAN66/test_fortran66_parser.py
@@ -428,6 +428,73 @@ class TestFORTRAN66Parser(unittest.TestCase):
         tree = self.parse(program, 'main_program')
         self.assertIsNotNone(tree)
 
+    # ====================================================================
+    # FORTRAN 66 GO TO ASSIGNMENT AND ASSIGNED GO TO (X3.9-1966 Sections 7.1.1.3/7.1.2.1.2)
+    # ====================================================================
+
+    def test_assign_statement(self):
+        """Test GO TO assignment statement (X3.9-1966 Section 7.1.1.3)"""
+        test_cases = [
+            "ASSIGN 100 TO N",
+            "ASSIGN 200 TO I",
+            "ASSIGN 10 TO LABEL",
+            "ASSIGN 99999 TO K",
+        ]
+
+        for text in test_cases:
+            with self.subTest(assign_stmt=text):
+                tree = self.parse(text, 'assign_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_assigned_goto_statement(self):
+        """Test assigned GO TO statement (X3.9-1966 Section 7.1.2.1.2)"""
+        test_cases = [
+            "GOTO N, (100, 200)",
+            "GOTO I, (10, 20, 30)",
+            "GOTO LABEL, (100)",
+            "GOTO K, (100, 200, 300, 400, 500)",
+        ]
+
+        for text in test_cases:
+            with self.subTest(assigned_goto=text):
+                tree = self.parse(text, 'assigned_goto_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_assign_in_statement_body(self):
+        """Test ASSIGN as statement_body alternative"""
+        test_cases = [
+            "ASSIGN 100 TO N",
+            "ASSIGN 200 TO I",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree)
+
+    def test_assigned_goto_in_statement_body(self):
+        """Test assigned GO TO as statement_body alternative"""
+        test_cases = [
+            "GOTO N, (100, 200)",
+            "GOTO I, (10, 20, 30)",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree)
+
+    def test_assign_goto_fixture(self):
+        """Test program with ASSIGN and assigned GO TO statements"""
+        program = load_fixture(
+            "FORTRAN66",
+            "test_fortran66_parser",
+            "assign_goto.f",
+        )
+
+        tree = self.parse(program, 'main_program')
+        self.assertIsNotNone(tree)
+
 
 if __name__ == "__main__":
     # Run with verbose output to see which tests fail

--- a/tests/fixtures/FORTRAN66/test_fortran66_parser/assign_goto.f
+++ b/tests/fixtures/FORTRAN66/test_fortran66_parser/assign_goto.f
@@ -1,0 +1,12 @@
+      INTEGER N
+      ASSIGN 100 TO N
+      GOTO N, (100, 200, 300)
+100   PRINT 1, 1
+      ASSIGN 200 TO N
+      GOTO N, (100, 200, 300)
+200   PRINT 1, 2
+      ASSIGN 300 TO N
+      GOTO N, (100, 200, 300)
+300   STOP
+1     FORMAT (I5)
+      END


### PR DESCRIPTION
## Summary
- Implement GO TO assignment statement (`ASSIGN k TO i`) per ANSI X3.9-1966 Section 7.1.1.3
- Implement assigned GO TO statement (`GOTO i, (k1, k2, ...)`) per ANSI X3.9-1966 Section 7.1.2.1.2
- Add both statement types to `statement_body` alternatives in FORTRAN66Parser.g4
- Update fortran_66_audit.md to reflect implemented status

## Test plan
- [x] `make test-fortran66` passes all 28 tests (including 5 new tests)
- [x] `make test` passes all 521 tests with no regressions
- [x] `test_assign_statement` validates ASSIGN statement parsing
- [x] `test_assigned_goto_statement` validates assigned GOTO parsing
- [x] `test_assign_in_statement_body` confirms ASSIGN is wired to statement_body
- [x] `test_assigned_goto_in_statement_body` confirms assigned GOTO is wired to statement_body
- [x] `test_assign_goto_fixture` validates complete program with ASSIGN and assigned GOTO

## Verification
```
$ make test-fortran66
Testing FORTRAN 66 (1966)...
28 passed in 0.14s

$ make test
521 passed, 43 xfailed, 7 warnings in 33.11s
```