### PR TITLE
fix: document ASSIGN/assigned GOTO as non-compliant (fixes #207)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -67,6 +67,17 @@ Mapping that Appendix‑B list to the current grammar:
     zero-error assertions in `tests/FORTRAN/test_fortran_historical_stub.py`
     using fixtures `assign_stmt.f`, `assigned_goto_stmt.f` and
     `assign_goto_combined.f`.
+  - **NON-COMPLIANT with ISO/IEC 1539-1:2018 (Fortran 2018):**
+    - ASSIGN and assigned GO TO are deleted features in Fortran 2018.
+    - Per ISO/IEC 1539-1:2018 Annex B.2 (Deleted features), ASSIGN,
+      assigned GO TO, and assigned FORMAT specifiers were removed from
+      the standard as of Fortran 95 (obsolescent) and deleted in
+      Fortran 2018.
+    - These constructs are historically accurate for IBM 704 FORTRAN
+      (1957) and are retained in this grammar for educational and
+      archival purposes only.
+    - Modern Fortran 2018/2023 grammars in this repository correctly
+      reject these constructs.
 
 - **DO loops**
   - Status: **implemented (basic 1957 form) and tested.**
@@ -113,8 +124,10 @@ and the associated fixtures:
 - Computed GOTO: `GO TO (n1, n2, n3), i`.
 - Unconditional GOTO: `GO TO n`.
 - ASSIGN: `ASSIGN i TO n` stores label `i` in variable `n`.
+  (NON-COMPLIANT: deleted feature per ISO/IEC 1539-1:2018 Annex B.2)
 - Assigned GOTO: `GO TO n, (l1, l2, ..., lm)` branches to the label
   stored in variable `n`.
+  (NON-COMPLIANT: deleted feature per ISO/IEC 1539-1:2018 Annex B.2)
 - DO loops using labeled termination (no `END DO`).
 - STOP and CONTINUE.
 - FREQUENCY as an optimization hint.

--- a/docs/fortran_66_audit.md
+++ b/docs/fortran_66_audit.md
@@ -186,6 +186,9 @@ Mapping these families to the current grammar:
       - Tests: `test_assign_statement`, `test_assign_in_statement_body`,
         and `test_assign_goto_fixture` in
         `tests/FORTRAN66/test_fortran66_parser.py`.
+    - **NON-COMPLIANT with ISO/IEC 1539-1:2018 (Fortran 2018):**
+      - ASSIGN is a deleted feature per Annex B.2.
+      - Retained for historical FORTRAN 66 accuracy only.
 
 - **Control statements**
   - Implemented:
@@ -198,6 +201,9 @@ Mapping these families to the current grammar:
       - Tests: `test_assigned_goto_statement`, `test_assigned_goto_in_statement_body`,
         and `test_assign_goto_fixture` in
         `tests/FORTRAN66/test_fortran66_parser.py`.
+      - **NON-COMPLIANT with ISO/IEC 1539-1:2018 (Fortran 2018):**
+        - Assigned GO TO is a deleted feature per Annex B.2.
+        - Retained for historical FORTRAN 66 accuracy only.
     - Arithmetic IF: `arithmetic_if_stmt : IF (expr) l1, l2, l3`.
     - Logical IF: `logical_if_stmt : IF (logical_expr) statement_body`.
     - CALL: `call_stmt : CALL IDENTIFIER (LPAREN expr_list? RPAREN)?`.
@@ -357,6 +363,7 @@ The FORTRAN 66 grammar in this repository:
   per X3.9-1966 Section 7.1.3.3.
 - Implements GO TO assignment (`ASSIGN k TO i`) and assigned GO TO
   (`GO TO i, (k1, k2, ...)`) per X3.9-1966 Sections 7.1.1.3 and 7.1.2.1.2.
+  (NON-COMPLIANT: both are deleted features per ISO/IEC 1539-1:2018 Annex B.2)
 - Does **not** yet implement the DATA statement for initialization.
 - Still rejects some richer, spec-inspired fixtures, which are
   tracked as XPASS in the generic fixture harness.

--- a/grammars/FORTRAN66Parser.g4
+++ b/grammars/FORTRAN66Parser.g4
@@ -296,6 +296,10 @@ variable_list
 // syntax is: ASSIGN k TO i
 // where k is a statement label and i is an integer variable.
 // This stores the label k in variable i for use with assigned GO TO.
+//
+// NON-COMPLIANT: ASSIGN is a deleted feature per ISO/IEC 1539-1:2018
+// Annex B.2. Retained for historical FORTRAN 66 accuracy only.
+// See docs/fortran_66_audit.md for compliance details.
 assign_stmt
     : ASSIGN label TO variable
     ;
@@ -308,6 +312,10 @@ assign_stmt
 // where i is an integer variable containing a label (set by ASSIGN)
 // and (k1, k2, ..., km) is a list of valid target labels.
 // Branches to the label stored in variable i.
+//
+// NON-COMPLIANT: Assigned GO TO is a deleted feature per ISO/IEC
+// 1539-1:2018 Annex B.2. Retained for historical FORTRAN 66 accuracy only.
+// See docs/fortran_66_audit.md for compliance details.
 assigned_goto_stmt
     : GOTO variable COMMA LPAREN label_list RPAREN
     ;

--- a/grammars/FORTRANParser.g4
+++ b/grammars/FORTRANParser.g4
@@ -114,6 +114,10 @@ computed_goto_stmt
 // Syntax: ASSIGN i TO n
 // Where i is a statement label and n is an integer variable
 // This stores the label i in variable n for later use with assigned GOTO
+//
+// NON-COMPLIANT: ASSIGN is a deleted feature per ISO/IEC 1539-1:2018
+// Annex B.2. Retained for historical accuracy only.
+// See docs/fortran_1957_audit.md for compliance details.
 assign_stmt
     : ASSIGN label TO variable
     ;
@@ -124,6 +128,10 @@ assign_stmt
 // Where n is an integer variable containing a label (set by ASSIGN)
 // and (l1, l2, ..., lm) is a list of valid target labels
 // Branches to the label stored in variable n
+//
+// NON-COMPLIANT: Assigned GO TO is a deleted feature per ISO/IEC
+// 1539-1:2018 Annex B.2. Retained for historical accuracy only.
+// See docs/fortran_1957_audit.md for compliance details.
 assigned_goto_stmt
     : GOTO variable COMMA LPAREN label_list RPAREN
     ;


### PR DESCRIPTION
## Summary

- Add NON-COMPLIANT documentation for ASSIGN and assigned GO TO constructs in historical FORTRAN grammars
- Per ISO/IEC 1539-1:2018 Annex B.2, these constructs are deleted features in modern Fortran
- Retained in FORTRAN 1957 and FORTRAN 66 grammars for educational and archival purposes only

## Changes

- **docs/fortran_1957_audit.md**: Add NON-COMPLIANT markers with ISO references in Section 2 (spec-based statement coverage) and Section 3 (control flow)
- **docs/fortran_66_audit.md**: Add NON-COMPLIANT markers in assignment statements, control statements, and summary sections
- **grammars/FORTRANParser.g4**: Add compliance comments to assign_stmt and assigned_goto_stmt rules
- **grammars/FORTRAN66Parser.g4**: Add compliance comments to assign_stmt and assigned_goto_stmt rules

## Verification

```
$ make test 2>&1 | tail -5
...
================= 533 passed, 43 xfailed, 7 warnings in 32.94s =================

All tests completed!
```

All 533 tests pass with no regressions. The changes are documentation-only (audit docs and grammar comments) and do not affect parser behavior.