### PR TITLE
fix: use fortran_program entry rule for FORTRAN II fixtures (fixes #157)

### DIFF
--- a/grammars/FORTRANIIParser.g4
+++ b/grammars/FORTRANIIParser.g4
@@ -31,8 +31,9 @@ fortran_program
     ;
 
 // Main program (inherited from FORTRAN I)
+// A main program is a sequence of statements ending with END.
 main_program
-    : statement_list
+    : statement_list end_stmt NEWLINE?
     ;
 
 // Statement list allowing empty lines (punch cards could be blank)
@@ -56,14 +57,14 @@ label
 subroutine_subprogram
     : SUBROUTINE IDENTIFIER parameter_list? NEWLINE
       statement_list
-      END
+      end_stmt NEWLINE?
     ;
 
 // Function definition (NEW in FORTRAN II)
 function_subprogram
     : type_spec? FUNCTION IDENTIFIER parameter_list NEWLINE
       statement_list
-      END
+      end_stmt NEWLINE?
     ;
 
 // Parameter list for subprograms
@@ -79,6 +80,9 @@ type_spec
 
 // All statement types available in 1957 FORTRAN
 // This was a remarkably small language by today's standards!
+// NOTE: end_stmt is NOT included here - it is handled separately as a
+// program unit terminator in main_program, subroutine_subprogram, and
+// function_subprogram rules.
 statement_body
     : assignment_stmt      // Variable = Expression (mathematical notation!)
     | goto_stmt           // Unconditional jump to labeled statement
@@ -96,7 +100,6 @@ statement_body
     | equivalence_stmt   // Variable memory overlay
     | frequency_stmt     // Optimization hints (unique to 1957!)
     | common_stmt        // Global variable declarations
-    | end_stmt          // End of program
     | return_stmt       // Return from subprogram
     | call_stmt         // NEW in FORTRAN II: Call subroutine
     ;

--- a/tests/test_fixture_parsing.py
+++ b/tests/test_fixture_parsing.py
@@ -67,7 +67,7 @@ STANDARD_CONFIGS: Dict[str, StandardConfig] = {
     "FORTRANII": StandardConfig(
         lexer_name="FORTRANIILexer",
         parser_name="FORTRANIIParser",
-        entry_rule="program_unit_core",
+        entry_rule="fortran_program",
     ),
     "FORTRAN66": StandardConfig(
         lexer_name="FORTRAN66Lexer",
@@ -427,29 +427,9 @@ XPASS_FIXTURES: Dict[Tuple[str, Path], str] = {
         "strict subset accepted by the stub grammar and is expected to report "
         "{errors} syntax errors."
     ),
-    (
-        "FORTRANII",
-        Path("FORTRANII/test_fortran_ii_parser/function_text.f"),
-    ): (
-        "FORTRAN II function-text fixture {relpath} documents constructs that "
-        "are not yet fully accepted by the simplified FORTRAN II grammar and "
-        "currently produce {errors} syntax errors."
-    ),
-    (
-        "FORTRANII",
-        Path("FORTRANII/test_fortran_ii_parser/subroutine_program.f"),
-    ): (
-        "FORTRAN II subroutine-program fixture {relpath} exceeds the current "
-        "stub grammar and is expected to yield {errors} syntax errors."
-    ),
-    (
-        "FORTRANII",
-        Path("FORTRANII/test_fortran_ii_parser/subroutine_text.f"),
-    ): (
-        "FORTRAN II subroutine-text fixture {relpath} represents richer "
-        "historical usage than the simplified grammar accepts and currently "
-        "reports {errors} syntax errors."
-    ),
+    # FORTRAN II fixtures have been updated to parse correctly with the
+    # enhanced grammar and fortran_program entry rule per issue #157.
+    # They are no longer marked as XPASS.
     # FORTRAN 66 fixtures have been updated to parse correctly with the
     # enhanced grammar per issue #144. They are no longer marked as XPASS.
     # Fortran2003 negative / fixed-form fixtures that intentionally exercise


### PR DESCRIPTION
## Summary
- Fix FORTRAN II generic fixture harness to use `fortran_program` entry rule instead of `program_unit_core`
- Update FORTRANIIParser.g4 grammar to properly handle END statements by removing `end_stmt` from `statement_body` and adding explicit `end_stmt NEWLINE?` to program unit rules
- Remove XPASS_FIXTURES entries for FORTRAN II fixtures that now parse correctly

## Verification

```bash
# Build FORTRAN II grammar
$ make FORTRANII
Building FORTRAN I (1957)...
Building FORTRAN II (1958)...

# Run FORTRAN II tests
$ python -m pytest tests/FORTRANII/ -v --tb=short
17 passed

# Run FORTRAN II fixture tests (previously XPASS, now passing)
$ python -m pytest tests/test_fixture_parsing.py -v -k "FORTRANII"
3 passed

# Full test suite
$ python -m pytest tests/ -v --tb=short
536 passed, 40 xfailed
```