### PR TITLE
fix: add explicit statement_function_stmt rule for FORTRAN 66/77 (fixes #168)

### DIFF
--- a/docs/fortran_66_audit.md
+++ b/docs/fortran_66_audit.md
@@ -266,9 +266,22 @@ Mapping these families to the current grammar:
     - FORMAT:
       - Implemented as described above.
     - Statement functions:
-      - Supported syntactically via `function_reference` and inherited
-        1957/II mechanisms; the grammar does not distinguish statement
-        functions from external functions at the syntax level.
+      - Parser: `statement_function_stmt` rule implemented in
+        `FORTRANIIParser.g4` (inherited by FORTRAN66Parser.g4) per
+        X3.9-1966 Section 7.2.
+      - Syntax: `name(dummy-arg-list) = expression` where dummy-arg-list
+        is a non-empty comma-separated list of identifier dummy arguments.
+      - Wired into `statement_body` as a distinct alternative from
+        `assignment_stmt`, enabling syntactic differentiation.
+      - Tests: covered by `test_statement_function_simple`,
+        `test_statement_function_multiple_args`,
+        `test_statement_function_complex_expr`,
+        `test_statement_function_in_statement_body`, and
+        `test_statement_function_fixture` in
+        `tests/FORTRAN66/test_fortran66_parser.py`.
+      - Semantic constraint: statement functions must appear in the
+        specification part (after declarations, before executable
+        statements); this constraint is not enforced syntactically.
     - DATA:
       - Lexer: `DATA` token defined in `FORTRAN66Lexer.g4`.
       - Parser: `data_stmt` rule implemented in `FORTRAN66Parser.g4`

--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -396,12 +396,23 @@ Mapping that classification to the current grammar:
     - FORMAT: via the inherited FORMAT machinery from FORTRAN 66.
 
 - **Statement functions**
-  - Partially implemented:
-    - Statement functions are handled implicitly by the combination
-      of assignment syntax and function references, but there is no
-      separate `statement_function_stmt` rule that enforces the
-      standard’s constraints. This remains an underspecified area,
-      similar to FORTRAN 66.
+  - Implemented:
+    - Parser: `statement_function_stmt` rule defined in
+      `FORTRANIIParser.g4` (inherited through the grammar chain).
+    - Syntax: `name(dummy-arg-list) = expression` where dummy-arg-list
+      is a non-empty comma-separated list of identifier dummy arguments.
+    - Wired into `statement_body` in FORTRAN77Parser.g4 as a distinct
+      alternative, enabling syntactic differentiation from array
+      element assignment.
+    - Tests: covered by `test_statement_function_simple`,
+      `test_statement_function_multiple_args`,
+      `test_statement_function_in_statement_body`, and
+      `test_statement_function_fixture` in
+      `tests/FORTRAN77/test_fortran77_parser.py`.
+    - Semantic constraint: per ANSI X3.9-1978 Section 8, statement
+      functions must appear after specification statements and before
+      executable statements; this constraint is not enforced at the
+      syntax level.
 
 ## 7. Fixed-form handling
 

--- a/grammars/FORTRAN66Parser.g4
+++ b/grammars/FORTRAN66Parser.g4
@@ -205,7 +205,8 @@ label
 // NOTE: end_stmt is NOT included here - it is handled separately as a
 // program unit terminator to enable parsing multiple program units.
 statement_body
-    : assignment_stmt      // Variable = Expression
+    : statement_function_stmt  // Statement function definition (X3.9-1966 7.2)
+    | assignment_stmt      // Variable = Expression
     | goto_stmt           // Unconditional jump to labeled statement
     | computed_goto_stmt  // Multi-way branch based on integer expression
     | assign_stmt         // GO TO assignment: ASSIGN k TO i (X3.9-1966 7.1.1.3)

--- a/grammars/FORTRAN77Parser.g4
+++ b/grammars/FORTRAN77Parser.g4
@@ -72,7 +72,8 @@ character_length
 
 // Override statement body to include structured constructs
 statement_body
-    : assignment_stmt      // Variable = Expression
+    : statement_function_stmt  // Statement function definition (F77 Section 8)
+    | assignment_stmt      // Variable = Expression
     | goto_stmt           // Unconditional jump to labeled statement
     | computed_goto_stmt  // Multi-way branch based on integer expression
     | arithmetic_if_stmt  // Three-way branch based on expression sign

--- a/grammars/FORTRANIIParser.g4
+++ b/grammars/FORTRANIIParser.g4
@@ -84,7 +84,8 @@ type_spec
 // program unit terminator in main_program, subroutine_subprogram, and
 // function_subprogram rules.
 statement_body
-    : assignment_stmt      // Variable = Expression (mathematical notation!)
+    : statement_function_stmt  // Statement function definition (spec part)
+    | assignment_stmt      // Variable = Expression (mathematical notation!)
     | goto_stmt           // Unconditional jump to labeled statement
     | computed_goto_stmt  // Multi-way branch based on integer expression
     | arithmetic_if_stmt  // Three-way branch based on expression sign
@@ -107,6 +108,43 @@ statement_body
 // CALL statement (NEW in FORTRAN II)
 call_stmt
     : CALL IDENTIFIER (LPAREN expr_list? RPAREN)?
+    ;
+
+
+// ====================================================================
+// STATEMENT FUNCTION DEFINITION
+// ====================================================================
+// Per ANSI X3.9-1966 Section 7.2 and FORTRAN 77 Section 8, a statement
+// function defines a scalar function within the specification part of a
+// program unit. It has the form:
+//
+//     name(dummy-arg-list) = scalar-expression
+//
+// where:
+// - name is the function name (follows implicit or explicit typing)
+// - dummy-arg-list is a non-empty list of identifier dummy arguments
+// - scalar-expression is any valid expression using those arguments
+//
+// Statement functions must appear after specification statements and
+// before executable statements (enforced semantically, not syntactically).
+//
+// Examples:
+//   F(X) = X * X + 2.0 * X + 1.0
+//   AREA(R) = 3.14159 * R * R
+//   DIST(X1, Y1, X2, Y2) = SQRT((X2-X1)**2 + (Y2-Y1)**2)
+//
+// Note: Statement functions are distinct from array element assignments.
+// The key syntactic difference is that statement function dummy arguments
+// are simple identifiers, not arbitrary expressions.
+// ====================================================================
+
+statement_function_stmt
+    : IDENTIFIER LPAREN statement_function_dummy_arg_list RPAREN EQUALS expr
+    ;
+
+// Dummy argument list for statement functions (identifiers only)
+statement_function_dummy_arg_list
+    : IDENTIFIER (COMMA IDENTIFIER)*
     ;
 
 

--- a/tests/FORTRAN66/test_fortran66_parser.py
+++ b/tests/FORTRAN66/test_fortran66_parser.py
@@ -615,6 +615,74 @@ class TestFORTRAN66Parser(unittest.TestCase):
                 tree = self.parse(text, 'block_data_subprogram')
                 self.assertIsNotNone(tree)
 
+    # ====================================================================
+    # FORTRAN 66 STATEMENT FUNCTION STATEMENT (X3.9-1966 Section 7.2)
+    # ====================================================================
+
+    def test_statement_function_simple(self):
+        """Test simple statement function definition (X3.9-1966 Section 7.2)"""
+        test_cases = [
+            "F(X) = X * X",
+            "AREA(R) = 3.14159 * R * R",
+            "SQUARE(N) = N ** 2",
+            "DOUBLE(X) = 2.0 * X",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt_func=text):
+                tree = self.parse(text, 'statement_function_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_multiple_args(self):
+        """Test statement function with multiple arguments"""
+        test_cases = [
+            "SUM(A, B) = A + B",
+            "AREA(L, W) = L * W",
+            "AVG(X, Y, Z) = (X + Y + Z) / 3.0",
+            "DIST(X1, Y1, X2, Y2) = SQRT((X2-X1)**2 + (Y2-Y1)**2)",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt_func=text):
+                tree = self.parse(text, 'statement_function_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_complex_expr(self):
+        """Test statement function with complex expressions"""
+        test_cases = [
+            "POLY(X) = X**3 + 2.0*X**2 + 3.0*X + 4.0",
+            "HYPOT(A, B) = SQRT(A**2 + B**2)",
+            "COMBINE(X, Y) = SIN(X) + COS(Y)",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt_func=text):
+                tree = self.parse(text, 'statement_function_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_in_statement_body(self):
+        """Test statement function as statement_body alternative"""
+        test_cases = [
+            "F(X) = X * X",
+            "AREA(L, W) = L * W",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_fixture(self):
+        """Test program with statement function definitions"""
+        program = load_fixture(
+            "FORTRAN66",
+            "test_fortran66_parser",
+            "statement_function.f",
+        )
+
+        tree = self.parse(program, 'main_program')
+        self.assertIsNotNone(tree)
+
 
 if __name__ == "__main__":
     # Run with verbose output to see which tests fail

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -323,6 +323,61 @@ END IF"""
                 self.assertIsNotNone(tree)
                 self.assertIn(expected_type, tree.getText())
 
+    # ====================================================================
+    # FORTRAN 77 STATEMENT FUNCTION STATEMENT (F77 Section 8)
+    # ====================================================================
+
+    def test_statement_function_simple(self):
+        """Test simple statement function definition (F77 Section 8)"""
+        test_cases = [
+            "F(X) = X * X",
+            "AREA(R) = 3.14159 * R * R",
+            "SQUARE(N) = N ** 2",
+            "DOUBLE(X) = 2.0 * X",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt_func=text):
+                tree = self.parse(text, 'statement_function_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_multiple_args(self):
+        """Test statement function with multiple arguments"""
+        test_cases = [
+            "SUM(A, B) = A + B",
+            "AREA(L, W) = L * W",
+            "AVG(X, Y, Z) = (X + Y + Z) / 3.0",
+            "DIST(X1, Y1, X2, Y2) = SQRT((X2-X1)**2 + (Y2-Y1)**2)",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt_func=text):
+                tree = self.parse(text, 'statement_function_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_in_statement_body(self):
+        """Test statement function as statement_body alternative"""
+        test_cases = [
+            "F(X) = X * X",
+            "AREA(L, W) = L * W",
+        ]
+
+        for text in test_cases:
+            with self.subTest(stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_fixture(self):
+        """Test program with statement function definitions"""
+        program = load_fixture(
+            "FORTRAN77",
+            "test_fortran77_parser",
+            "statement_function.f",
+        )
+
+        tree = self.parse(program, 'main_program')
+        self.assertIsNotNone(tree)
+
 
 if __name__ == "__main__":
     # Run with verbose output to see which tests fail

--- a/tests/fixtures/FORTRAN66/test_fortran66_parser/statement_function.f
+++ b/tests/fixtures/FORTRAN66/test_fortran66_parser/statement_function.f
@@ -1,0 +1,15 @@
+      REAL SQUARE, CUBE, AREA, DIST
+      SQUARE(X) = X * X
+      AREA(L, W) = L * W
+      CUBE(X) = SQUARE(X) * X
+      DIST(X1, Y1, X2, Y2) = SQRT((X2-X1)**2 + (Y2-Y1)**2)
+      REAL R, L, W
+      R = 5.0
+      L = 10.0
+      W = 4.0
+      PRINT 100, SQUARE(R)
+      PRINT 100, CUBE(R)
+      PRINT 100, AREA(L, W)
+      PRINT 100, DIST(0.0, 0.0, 3.0, 4.0)
+  100 FORMAT(F10.2)
+      END

--- a/tests/fixtures/FORTRAN77/test_fortran77_parser/statement_function.f
+++ b/tests/fixtures/FORTRAN77/test_fortran77_parser/statement_function.f
@@ -1,0 +1,22 @@
+      PROGRAM STMTFUN
+      REAL SQUARE, CUBE, AREA, DIST
+      REAL R, L, W, X1, Y1, X2, Y2
+      REAL PI
+      SQUARE(X) = X * X
+      AREA(L, W) = L * W
+      CUBE(X) = SQUARE(X) * X
+      DIST(X1, Y1, X2, Y2) = SQRT((X2-X1)**2 + (Y2-Y1)**2)
+      R = 5.0
+      L = 10.0
+      W = 4.0
+      IF (SQUARE(R) .GT. 20.0) THEN
+          PRINT *, SQUARE(R)
+      END IF
+      X1 = 0.0
+      Y1 = 0.0
+      X2 = 3.0
+      Y2 = 4.0
+      PRINT *, DIST(X1, Y1, X2, Y2)
+      PRINT *, CUBE(R)
+      PRINT *, AREA(L, W)
+      END


### PR DESCRIPTION
## Summary
- Introduces a dedicated `statement_function_stmt` rule in FORTRANIIParser.g4 that is inherited by FORTRAN66Parser.g4 and FORTRAN77Parser.g4
- Models statement function definitions per ANSI X3.9-1966 Section 7.2 and FORTRAN 77 Section 8
- Enables syntactic differentiation from array element assignments

## Changes
- Add `statement_function_stmt` and `statement_function_dummy_arg_list` rules to FORTRANIIParser.g4
- Wire `statement_function_stmt` into `statement_body` for FORTRAN II, FORTRAN 66, and FORTRAN 77 grammars
- Add fixtures demonstrating statement function usage for both standards
- Add unit tests covering simple, multi-arg, and complex expression forms
- Update audit documentation (fortran_66_audit.md, fortran_77_audit.md) to reflect full implementation status

## Verification
```
$ python -m pytest tests/ --tb=short
================= 560 passed, 40 xfailed, 7 warnings in 31.71s =================
```

All 560 tests pass. The 40 xfailed are pre-existing expected failures.

## Test plan
- [x] All existing FORTRAN66 tests pass (42 tests)
- [x] All existing FORTRAN77 tests pass (20 tests)
- [x] New statement function tests pass for both standards
- [x] Fixture parsing tests pass for new statement_function.f fixtures
- [x] Full test suite passes with no regressions