### PR TITLE
fix: use assertions instead of return values in parse tree test (fixes #224)

### DIFF
--- a/tests/fixtures/Fortran2018/test_parse_tree/if_construct_program.f90
+++ b/tests/fixtures/Fortran2018/test_parse_tree/if_construct_program.f90
@@ -1,0 +1,5 @@
+program test
+if (x > 0) then
+   y = 1
+end if
+end program test


### PR DESCRIPTION
## Summary
- Replace return True/False in `test_if_parse_tree` with explicit pytest assertions to avoid `PytestReturnNotNoneWarning`
- Rename `TestErrorListener` to `ParseErrorListener` to avoid `PytestCollectionWarning` (pytest tries to collect classes starting with `Test` as test classes)
- Add new fixture `if_construct_program.f90` that wraps IF construct in a valid program for proper parsing

The original test was silently returning `False` indicating failure, but pytest did not check return values, making the test appear to pass while actually failing.

## Verification
```
$ python -m pytest tests/Fortran2018/test_parse_tree.py -v -W always
============================= test session starts ==============================
tests/Fortran2018/test_parse_tree.py::test_if_parse_tree PASSED          [100%]
============================== 1 passed in 0.62s ===============================
```

Full test suite passes with 568 tests.