### PR TITLE
fix: deduplicate FORTRAN 66/77 statement function tests (fixes #221)

### DIFF
--- a/tests/shared_fortran_tests.py
+++ b/tests/shared_fortran_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Shared test case data and helpers for FORTRAN 66 and FORTRAN 77 parser tests.
 
-This module provides reusable test case lists and helper methods for testing
+This module provides reusable test case lists and a mixin class for testing
 statement functions vs array element assignments. Both FORTRAN 66 (X3.9-1966)
 and FORTRAN 77 (X3.9-1978) share identical grammar rules for these constructs.
 """
@@ -56,3 +56,113 @@ STATEMENT_BODY_DISAMBIGUATION_CASES: List[Tuple[str, str]] = [
     ("SUM(A, B) = A + B", "Statement_function_stmt"),
     ("MAT(1, 2) = 3.0", "Assignment_stmt"),
 ]
+
+
+class StatementFunctionTestMixin:
+    """Mixin providing shared statement function vs array element tests.
+
+    Subclasses must provide:
+    - self.LexerClass: The ANTLR lexer class (e.g., FORTRAN66Lexer)
+    - self.ParserClass: The ANTLR parser class (e.g., FORTRAN66Parser)
+    - self.parse(text, rule_name): Method to parse text with a given rule
+    - self.fixture_standard: Standard name for fixture loading (e.g., FORTRAN66)
+
+    Both FORTRAN 66 (X3.9-1966 Section 7.2) and FORTRAN 77 (X3.9-1978 Section 8)
+    define identical semantics for statement functions.
+    """
+
+    def test_statement_function_simple(self):
+        """Test simple statement function definition."""
+        for text in STATEMENT_FUNCTION_SIMPLE_CASES:
+            with self.subTest(stmt_func=text):
+                tree = self.parse(text, 'statement_function_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_multiple_args(self):
+        """Test statement function with multiple arguments."""
+        for text in STATEMENT_FUNCTION_MULTI_ARG_CASES:
+            with self.subTest(stmt_func=text):
+                tree = self.parse(text, 'statement_function_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_in_statement_body(self):
+        """Test statement function as statement_body alternative."""
+        for text in STATEMENT_FUNCTION_IN_BODY_CASES:
+            with self.subTest(stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree)
+
+    def test_statement_function_fixture(self):
+        """Test program with statement function definitions."""
+        from fixture_utils import load_fixture
+        program = load_fixture(
+            self.fixture_standard,
+            f"test_{self.fixture_standard.lower()}_parser",
+            "statement_function.f",
+        )
+        tree = self.parse(program, 'main_program')
+        self.assertIsNotNone(tree)
+
+    def test_array_element_not_statement_function_literal_index(self):
+        """Verify array element with literal index is NOT a statement function."""
+        from antlr4 import InputStream, CommonTokenStream
+        for text in ARRAY_ELEMENT_LITERAL_INDEX_CASES:
+            with self.subTest(array_assignment=text):
+                input_stream = InputStream(text)
+                lexer = self.LexerClass(input_stream)
+                token_stream = CommonTokenStream(lexer)
+                parser = self.ParserClass(token_stream)
+                parser.statement_function_stmt()
+                self.assertGreater(
+                    parser.getNumberOfSyntaxErrors(), 0,
+                    f"'{text}' should NOT parse as statement_function_stmt"
+                )
+
+    def test_array_element_not_statement_function_expr_index(self):
+        """Verify array element with expression index is NOT a statement function."""
+        from antlr4 import InputStream, CommonTokenStream
+        for text in ARRAY_ELEMENT_EXPR_INDEX_CASES:
+            with self.subTest(array_assignment=text):
+                input_stream = InputStream(text)
+                lexer = self.LexerClass(input_stream)
+                token_stream = CommonTokenStream(lexer)
+                parser = self.ParserClass(token_stream)
+                parser.statement_function_stmt()
+                self.assertGreater(
+                    parser.getNumberOfSyntaxErrors(), 0,
+                    f"'{text}' should NOT parse as statement_function_stmt"
+                )
+
+    def test_array_element_parses_as_assignment_stmt(self):
+        """Verify array element assignments parse correctly as assignment_stmt."""
+        from antlr4 import InputStream, CommonTokenStream
+        for text in ARRAY_ELEMENT_ASSIGNMENT_CASES:
+            with self.subTest(array_assignment=text):
+                input_stream = InputStream(text)
+                lexer = self.LexerClass(input_stream)
+                token_stream = CommonTokenStream(lexer)
+                parser = self.ParserClass(token_stream)
+                tree = parser.assignment_stmt()
+                self.assertIsNotNone(tree)
+                self.assertEqual(
+                    parser.getNumberOfSyntaxErrors(), 0,
+                    f"'{text}' should parse as assignment_stmt without errors"
+                )
+
+    def test_statement_body_disambiguates_array_vs_function(self):
+        """Verify statement_body correctly parses array elements as assignments."""
+        from antlr4 import InputStream, CommonTokenStream
+        for text, expected_type in STATEMENT_BODY_DISAMBIGUATION_CASES:
+            with self.subTest(stmt=text, expected=expected_type):
+                input_stream = InputStream(text)
+                lexer = self.LexerClass(input_stream)
+                token_stream = CommonTokenStream(lexer)
+                parser = self.ParserClass(token_stream)
+                tree = parser.statement_body()
+                self.assertIsNotNone(tree)
+                child = tree.getChild(0)
+                child_type = type(child).__name__
+                self.assertIn(
+                    expected_type, child_type,
+                    f"'{text}' should parse as {expected_type}, got {child_type}"
+                )


### PR DESCRIPTION
## Summary
- Add `StatementFunctionTestMixin` to `tests/shared_fortran_tests.py` providing shared test methods for statement function parsing and array element disambiguation
- Refactor `TestFORTRAN66Parser` and `TestFORTRAN77Parser` to inherit from the mixin, eliminating ~90 lines of duplicated test code
- Fix `test_proper_inheritance` path resolution to use `ROOT.parent` instead of relative path

## Verification

```
$ make test 2>&1 | tail -5
tests/LazyFortran2025/test_lfmt_lflint.py::test_lflint_cli_reports_and_sets_exit_code PASSED [100%]

======================= 568 passed, 40 xfailed in 33.26s =======================

✅ All tests completed!
```

All 568 tests pass with the same coverage as before the refactoring.