### PR TITLE
fix: add FORTRAN77 file I/O parser test (fixes #233)

### DIFF
--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -284,6 +284,23 @@ END IF"""
         tree = self.parse(fixture_text, 'main_program')
         self.assertIsNotNone(tree)
 
+    def test_file_io_statements_fixture(self):
+        """Test FORTRAN 77 file I/O statements from fixture file
+
+        Per ANSI X3.9-1978, FORTRAN 77 introduces OPEN, CLOSE, and INQUIRE
+        file control statements, and wires REWIND, BACKSPACE, and ENDFILE
+        into the grammar. This fixture exercises positional and keyword-based
+        forms for all file I/O statements.
+        """
+        fixture_text = load_fixture(
+            "FORTRAN77",
+            "test_fortran77_parser",
+            "file_io_statements.f",
+        )
+
+        tree = self.parse(fixture_text, 'main_program')
+        self.assertIsNotNone(tree)
+
     def test_proper_inheritance(self):
         """Test that FORTRAN77 properly inherits from FORTRAN66"""
         # Read the grammar file


### PR DESCRIPTION
## Summary
- Adds `test_file_io_statements_fixture` to `TestFORTRAN77Parser` that loads and parses `file_io_statements.f`
- Ensures regressions in OPEN/CLOSE/INQUIRE/REWIND/BACKSPACE/ENDFILE syntax are caught
- Completes the coverage for file I/O statements implemented in PR #232

## Verification
```
$ python -m pytest tests/FORTRAN77/test_fortran77_parser.py::TestFORTRAN77Parser::test_file_io_statements_fixture -v
tests/FORTRAN77/test_fortran77_parser.py::TestFORTRAN77Parser::test_file_io_statements_fixture PASSED [100%]
============================== 1 passed in 0.14s ===============================

$ make test 2>&1 | tail -5
======================= 598 passed, 40 xfailed in 34.57s =======================
```