### PR TITLE
fix: FORTRAN 77 ENTRY statement and program_stmt documentation (fixes #164)

### DIFF
--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -357,18 +357,23 @@ Mapping that classification to the current grammar:
       wired into `statement_body`.
 
 - **PROGRAM, FUNCTION, SUBROUTINE, ENTRY, BLOCK DATA**
-  - Implemented / partially implemented:
+  - Implemented:
     - FUNCTION, SUBROUTINE and BLOCK DATA are supported through the
       imported FORTRAN II/66 rules (`function_subprogram`,
       `subroutine_subprogram`, `block_data_subprogram`).
-    - `PROGRAM` exists as a token in `FORTRAN77Lexer.g4`, but there
-      is no `program_stmt` rule and no explicit program‑unit wrapper
-      for “PROGRAM name … END”.
-    - ENTRY is not modeled at all: no `ENTRY` token or `entry_stmt`
-      rule.
-    - The top‑level entry rule remains the FORTRAN 66 main program
-      (`main_program : statement_list`).
-    - These gaps are tracked by issue #164.
+    - PROGRAM statement:
+      - Grammar: `program_stmt : PROGRAM IDENTIFIER NEWLINE`
+      - The `main_program` rule is overridden to accept an optional
+        `program_stmt` followed by statements and `end_stmt`.
+      - Syntax: `PROGRAM name` at the start of a main program unit.
+    - ENTRY statement:
+      - Grammar: `entry_stmt : ENTRY IDENTIFIER entry_dummy_arg_list?`
+      - Per ISO 1539:1980 Section 15.7, provides alternate entry points
+        into FUNCTION or SUBROUTINE subprograms.
+      - Supports dummy argument lists and alternate return specifiers (*).
+      - Tests: `test_entry_statement` and `test_entry_statement_in_subroutine_fixture`
+        exercise various ENTRY forms including no-argument, with arguments,
+        and alternate return specifiers.
 
 - **DIMENSION, COMMON, EQUIVALENCE, IMPLICIT, PARAMETER, EXTERNAL, INTRINSIC, SAVE**
   - Implemented:

--- a/grammars/FORTRAN77Lexer.g4
+++ b/grammars/FORTRAN77Lexer.g4
@@ -31,6 +31,9 @@ import FORTRAN66Lexer;  // Import FORTRAN 66 (1966) constructs
 // Program unit identification (added in FORTRAN 77, 1977)
 PROGRAM         : P R O G R A M ;
 
+// Entry point in subprograms (FORTRAN 77 Section 15.7)
+ENTRY           : E N T R Y ;
+
 // CHARACTER data type (added in FORTRAN 77, 1977)
 CHARACTER       : C H A R A C T E R ;
 

--- a/grammars/FORTRAN77Parser.g4
+++ b/grammars/FORTRAN77Parser.g4
@@ -44,6 +44,42 @@ program_stmt
     ;
 
 // ====================================================================
+// FORTRAN 77 (1977) - ENTRY STATEMENT
+// ====================================================================
+// Per ISO 1539:1980 Section 15.7, the ENTRY statement provides an
+// alternate entry point into a FUNCTION or SUBROUTINE subprogram.
+//
+// Syntax: ENTRY entry-name [ ( [ dummy-arg-list ] ) ]
+//
+// Constraints:
+// - ENTRY may only appear in a FUNCTION or SUBROUTINE subprogram
+// - ENTRY must not appear within a DO loop, IF block, or ELSE block
+// - The entry-name is a separate procedure name for the entry point
+// - Dummy arguments may differ from the main subprogram arguments
+//
+// Example:
+//   SUBROUTINE CALC(A, B, C)
+//   ...
+//   ENTRY SETVAL(X, Y)      ! Alternate entry point
+//   ...
+//   ENTRY RESET             ! Entry point with no arguments
+//   ...
+//   END
+
+entry_stmt
+    : ENTRY IDENTIFIER entry_dummy_arg_list?
+    ;
+
+entry_dummy_arg_list
+    : LPAREN entry_dummy_arg? (COMMA entry_dummy_arg)* RPAREN
+    ;
+
+entry_dummy_arg
+    : IDENTIFIER
+    | MULTIPLY                // Alternate return specifier (*)
+    ;
+
+// ====================================================================
 // FORTRAN 77 (1977) - ENHANCED TYPE SYSTEM
 // ====================================================================
 
@@ -96,6 +132,7 @@ statement_body
     | end_stmt          // End of program
     | return_stmt       // Return from subprogram
     | call_stmt         // Call subroutine
+    | entry_stmt        // NEW: ENTRY statement (F77 Section 15.7)
     | save_stmt         // NEW: SAVE statement
     | intrinsic_stmt    // NEW: INTRINSIC statement
     | external_stmt     // NEW: EXTERNAL statement

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -146,6 +146,47 @@ END IF"""
                 tree = self.parse(text, 'external_stmt')
                 self.assertIsNotNone(tree)
 
+    def test_entry_statement(self):
+        """Test ENTRY statement (NEW in FORTRAN 77)
+
+        Per ISO 1539:1980 Section 15.7, the ENTRY statement provides an
+        alternate entry point into a FUNCTION or SUBROUTINE subprogram.
+
+        Syntax: ENTRY entry-name [ ( [ dummy-arg-list ] ) ]
+
+        The dummy-arg-list may include:
+        - Regular dummy argument names
+        - Alternate return specifiers (*) for subroutines
+        """
+        test_cases = [
+            "ENTRY SETVAL",
+            "ENTRY COMPUTE(X, Y)",
+            "ENTRY RESET()",
+            "ENTRY PROCESS(A, B, C)",
+            "ENTRY ALTRET(*)",
+            "ENTRY MIXARG(X, *, Y)",
+        ]
+
+        for text in test_cases:
+            with self.subTest(entry_stmt=text):
+                tree = self.parse(text, 'entry_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_entry_statement_in_subroutine_fixture(self):
+        """Test ENTRY statement in subroutine context (FORTRAN 77)
+
+        Per ISO 1539:1980 Section 15.7, ENTRY statements may appear in
+        FUNCTION or SUBROUTINE subprograms to define alternate entry points.
+        """
+        fixture_text = load_fixture(
+            "FORTRAN77",
+            "test_fortran77_parser_extra",
+            "entry_statements.f",
+        )
+
+        tree = self.parse(fixture_text, 'fortran66_program')
+        self.assertIsNotNone(tree)
+
     def test_implicit_statement(self):
         """Test IMPLICIT statement (NEW in FORTRAN 77)
 

--- a/tests/fixtures/FORTRAN77/test_fortran77_parser_extra/entry_statements.f
+++ b/tests/fixtures/FORTRAN77/test_fortran77_parser_extra/entry_statements.f
@@ -1,0 +1,40 @@
+C     ENTRY statement examples per ISO 1539:1980 Section 15.7
+C     ENTRY provides alternate entry points into subprograms
+      SUBROUTINE CALC(A, B, RESULT)
+      REAL A, B, RESULT
+      RESULT = A + B
+      RETURN
+C
+C     Alternate entry point with different arguments
+      ENTRY MULT(X, Y, RESULT)
+      RESULT = X * Y
+      RETURN
+C
+C     Entry point with no arguments
+      ENTRY RESET
+      RESULT = 0.0
+      RETURN
+C
+C     Entry point with alternate return specifier
+      ENTRY SAFEDIV(A, B, RESULT, *)
+      IF (B .EQ. 0.0) RETURN 1
+      RESULT = A / B
+      RETURN
+      END
+C
+C     Function with ENTRY statements
+      REAL FUNCTION COMPUTE(X)
+      REAL X
+      COMPUTE = X * X
+      RETURN
+C
+C     Alternate entry for cube calculation
+      ENTRY CUBE(X)
+      CUBE = X * X * X
+      RETURN
+C
+C     Entry with empty argument list
+      ENTRY GETPI()
+      GETPI = 3.14159
+      RETURN
+      END

--- a/tests/test_fixture_parsing.py
+++ b/tests/test_fixture_parsing.py
@@ -432,6 +432,19 @@ XPASS_FIXTURES: Dict[Tuple[str, Path], str] = {
     # They are no longer marked as XPASS.
     # FORTRAN 66 fixtures have been updated to parse correctly with the
     # enhanced grammar per issue #144. They are no longer marked as XPASS.
+    # FORTRAN 77 multi-unit fixtures require fortran66_program entry rule
+    # (not main_program). These are tested via dedicated test methods.
+    (
+        "FORTRAN77",
+        Path("FORTRAN77/test_fortran77_parser_extra/entry_statements.f"),
+    ): (
+        "FORTRAN 77 ENTRY statement fixture {relpath} contains multiple "
+        "program units (subroutines and functions) that require the "
+        "fortran66_program entry rule; with main_program entry rule it "
+        "produces {errors} syntax errors. The fixture is tested via "
+        "test_entry_statement_in_subroutine_fixture in "
+        "tests/FORTRAN77/test_fortran77_parser.py."
+    ),
     # Fortran2003 negative / fixed-form fixtures that intentionally exercise
     # error paths or comment-handling edge cases. These are tied to specific
     # Fortran 2003 issues in the audit document.


### PR DESCRIPTION
## Summary
- Implement ENTRY statement for FORTRAN 77 per ISO 1539:1980 Section 15.7
- Add ENTRY token to FORTRAN77Lexer.g4
- Add entry_stmt parser rule supporting dummy arguments and alternate return specifiers (*)
- Wire entry_stmt into statement_body
- Correct fortran_77_audit.md which incorrectly claimed program_stmt was not implemented
- Add comprehensive tests and fixture for ENTRY statement

## Verification
```
$ make test
...
tests/FORTRAN77/test_fortran77_parser.py::TestFORTRAN77Parser::test_entry_statement PASSED
tests/FORTRAN77/test_fortran77_parser.py::TestFORTRAN77Parser::test_entry_statement_in_subroutine_fixture PASSED
...
======================= 605 passed, 41 xfailed in 34.75s =======================
```

## Test plan
- [x] All 605 tests pass (41 expected failures)
- [x] New tests verify ENTRY statement parsing with various forms:
  - Entry with no arguments: `ENTRY SETVAL`
  - Entry with arguments: `ENTRY COMPUTE(X, Y)`
  - Entry with empty parens: `ENTRY RESET()`
  - Entry with alternate return: `ENTRY ALTRET(*)`
  - Entry with mixed args: `ENTRY MIXARG(X, *, Y)`
- [x] Fixture tests ENTRY in context of subroutine and function subprograms
