### PR TITLE
fix: annotate FORTRAN II grammar with IBM 704 manual sections (fixes #170)

### DIFF
--- a/docs/fortran_ii_audit.md
+++ b/docs/fortran_ii_audit.md
@@ -274,7 +274,97 @@ The dedicated FORTRAN II rules (CALL, SUBROUTINE, FUNCTION, COMMON)
 work on both the targeted `test_fortran_ii_parser.py` tests and the
 generic fixture harness tests.
 
-## 8. Summary
+## 8. C28-6000-2 Appendix A Crosswalk
+
+The IBM FORTRAN II manual (Form C28-6000-2, 1958) Appendix A lists all
+FORTRAN II statements. This section provides an exhaustive crosswalk from
+each Appendix A entry to the corresponding grammar rule(s) or notes gaps.
+
+### 8.1 FORTRAN II New Statements (Chapter 3)
+
+The six new FORTRAN II statement/subprogram forms added to FORTRAN I:
+
+| Statement Form                  | Grammar Rule(s)              | Status          |
+|---------------------------------|------------------------------|-----------------|
+| SUBROUTINE name [(args)]        | `subroutine_subprogram`      | Implemented     |
+| [type] FUNCTION name (args)     | `function_subprogram`        | Implemented     |
+| CALL name [(args)]              | `call_stmt`                  | Implemented     |
+| RETURN                          | `return_stmt`                | Implemented     |
+| COMMON list                     | `common_stmt`                | Implemented*    |
+| END                             | `end_stmt`                   | Implemented     |
+
+*Note: `common_stmt` extends beyond strict FORTRAN II by accepting named
+COMMON blocks (`COMMON /name/ list`), which historically were introduced
+in FORTRAN 66. See issue #156 for design decision tracking.
+
+### 8.2 Inherited FORTRAN I Statements (C28-6003 Appendix B)
+
+All original FORTRAN (1957) statements remain available in FORTRAN II.
+These are inherited from `FORTRANParser.g4` or redefined in
+`FORTRANIIParser.g4`:
+
+| Statement Form                       | Grammar Rule(s)                | Status          |
+|--------------------------------------|--------------------------------|-----------------|
+| v = e (assignment)                   | `assignment_stmt`              | Implemented     |
+| GO TO n                              | `goto_stmt`                    | Implemented     |
+| GO TO (n1, n2, ..., nm), i           | `computed_goto_stmt`           | Implemented     |
+| IF (e) n1, n2, n3                    | `arithmetic_if_stmt`           | Implemented     |
+| DO n i = m1, m2 [, m3]               | `do_stmt`                      | Implemented     |
+| CONTINUE                             | `continue_stmt`                | Implemented     |
+| STOP [n]                             | `stop_stmt`                    | Implemented     |
+| PAUSE [n]                            | `pause_stmt`                   | Implemented     |
+| DIMENSION v, v, ...                  | `dimension_stmt`               | Implemented     |
+| EQUIVALENCE (a,b,...), ...           | `equivalence_stmt`             | Implemented     |
+| FREQUENCY n (i1, i2, ...)            | `frequency_stmt`               | Implemented     |
+| FORMAT (specification)               | `format_stmt`                  | Implemented     |
+| f(a, b, ...) = e (statement func)    | `statement_function_stmt`      | Implemented     |
+| READ n, list                         | `read_stmt`                    | Implemented     |
+| PRINT n, list                        | `print_stmt`                   | Implemented     |
+| PUNCH n, list                        | `punch_stmt`                   | Implemented     |
+
+### 8.3 FORTRAN I Features Not Yet Implemented in FORTRAN II Parser
+
+The following FORTRAN I (C28-6003) features are not directly implemented
+in the FORTRAN II parser. They are handled at the FORTRAN I level or
+remain as gaps:
+
+| Statement Form                       | Grammar Rule(s)                | Status          |
+|--------------------------------------|--------------------------------|-----------------|
+| ASSIGN i TO n                        | (FORTRAN I: `assign_stmt`)     | Gap: see #141   |
+| GO TO n, (n1, n2, ...)               | (FORTRAN I: `assigned_goto_stmt`) | Gap: see #141 |
+| IF (SENSE SWITCH i) n1, n2           | (FORTRAN I: `if_stmt_sense_switch`) | Inherited     |
+| IF (SENSE LIGHT i) n1, n2            | (FORTRAN I: `if_stmt_sense_light`) | Inherited     |
+| IF ACCUMULATOR OVERFLOW n1, n2       | (FORTRAN I: see FORTRANParser) | Inherited       |
+| IF QUOTIENT OVERFLOW n1, n2          | (FORTRAN I: see FORTRANParser) | Inherited       |
+| IF DIVIDE CHECK n1, n2               | (FORTRAN I: see FORTRANParser) | Inherited       |
+| SENSE LIGHT i                        | (FORTRAN I: `sense_light_stmt`) | Inherited      |
+| READ INPUT TAPE i, n, list           | Not implemented                | Gap: see #153   |
+| READ TAPE i, list                    | Not implemented                | Gap: see #153   |
+| READ DRUM i, j, list                 | Not implemented                | Gap: see #153   |
+| WRITE OUTPUT TAPE i, n, list         | Not implemented                | Gap: see #153   |
+| WRITE TAPE i, list                   | Not implemented                | Gap: see #153   |
+| WRITE DRUM i, j, list                | Not implemented                | Gap: see #153   |
+| END FILE i                           | Not implemented                | Gap: see #153   |
+| REWIND i                             | Not implemented                | Gap: see #153   |
+| BACKSPACE i                          | Not implemented                | Gap: see #153   |
+
+### 8.4 Gaps Requiring Follow-up Issues
+
+The following gaps have been identified during this crosswalk and are
+tracked by existing issues:
+
+- **#141**: FORTRAN 1957 historical stub promotion (general coverage,
+  includes ASSIGN/assigned GO TO)
+- **#143**: FORTRAN II strict fixed-form card layout semantics
+- **#153**: Full 704 I/O statement family (READ/WRITE/TAPE/DRUM/END FILE/
+  REWIND/BACKSPACE)
+- **#154**: FORMAT grammar and Hollerith constants
+- **#156**: Reconcile COMMON semantics with 1958 spec (no named blocks)
+
+All identified gaps have corresponding GitHub issues; no new issues
+required from this crosswalk.
+
+## 9. Summary
 
 The FORTRAN II grammar in this repository:
 
@@ -285,6 +375,8 @@ The FORTRAN II grammar in this repository:
     FORMAT.
   - SUBROUTINE and FUNCTION subprograms, CALL and RETURN, COMMON and
     END.
+- Contains inline C28-6000-2 spec references in grammar comments for
+  traceability to the original IBM FORTRAN II manual.
 - Extends COMMON to allow both blank and named forms, slightly beyond
   strictly historical FORTRAN II.
 - Uses a layout‑lenient fixed-form model with explicit LABEL tokens,
@@ -297,3 +389,6 @@ Remaining design decisions (tracked separately):
 - Issue #156 tracks whether to reconcile COMMON semantics with the
   strict 1958 spec (blank COMMON only) or continue accepting named
   COMMON blocks as a forward-compatibility extension.
+
+Further work on this standard should reference this audit together with
+the open issues for expanding FORTRAN II coverage.

--- a/grammars/FORTRANIILexer.g4
+++ b/grammars/FORTRANIILexer.g4
@@ -1,26 +1,73 @@
-// FORTRAN II (1958) - Procedural Programming Revolution
-// Introduces separately compiled subroutines and functions
+/*
+ * FORTRANIILexer.g4
+ *
+ * FORTRAN II (1958) - Procedural Programming Revolution
+ * Introduces separately compiled subroutines and functions.
+ *
+ * This lexer extends FORTRANLexer (1957) with the six new FORTRAN II
+ * statement/subprogram forms: SUBROUTINE, FUNCTION, CALL, RETURN,
+ * COMMON, and END (as a formal terminator).
+ *
+ * Reference: IBM FORTRAN II for the IBM 704 Data Processing System
+ *            (Form C28-6000-2, 1958)
+ *            - Part I, Chapter 1: Introduction and Types of Statements
+ *            - Part I, Chapter 3: The New FORTRAN II Statements
+ *            - Appendix A: Summary of FORTRAN II Statements
+ *
+ * Manual available at: Computer History Museum archive
+ *   https://archive.computerhistory.org/resources/text/Fortran/
+ */
+
 lexer grammar FORTRANIILexer;
 
-import FORTRANLexer;  // Import FORTRAN I (1957) constructs
+import FORTRANLexer;  // Import FORTRAN I (1957) constructs (C28-6003)
 
-// ====================================================================
-// FORTRAN II (1958) NEW FEATURES
-// ====================================================================
+// ============================================================================
+// FORTRAN II (1958) NEW KEYWORDS
+// C28-6000-2 Part I, Chapter 3: The New FORTRAN II Statements
+// ============================================================================
+// FORTRAN II adds six new statement/subprogram forms to the original 1957
+// FORTRAN language. These enable separate compilation of subroutines and
+// functions, shared storage via COMMON, and explicit subprogram termination.
 
-// Procedural Programming and shared storage (NEW in FORTRAN II, 1958)
-CALL         : C A L L ;             // Subroutine call
-SUBROUTINE   : S U B R O U T I N E ; // Subroutine definition
-FUNCTION     : F U N C T I O N ;     // Function definition  
-RETURN       : R E T U R N ;         // Return from subprogram
-COMMON       : C O M M O N ;         // Shared variable storage (COMMON blocks)
+// CALL statement - C28-6000-2 Part I, Chapter 3, Section 3.1
+// Transfers control to a subroutine with optional arguments
+CALL         : C A L L ;
 
-// Statement labels: 1-5 digits, cannot start with 0
+// SUBROUTINE definition - C28-6000-2 Part I, Chapter 3, Section 3.2
+// Defines a separately compiled subroutine subprogram
+SUBROUTINE   : S U B R O U T I N E ;
+
+// FUNCTION definition - C28-6000-2 Part I, Chapter 3, Section 3.3
+// Defines a separately compiled function subprogram
+FUNCTION     : F U N C T I O N ;
+
+// RETURN statement - C28-6000-2 Part I, Chapter 3, Section 3.4
+// Returns control from a subroutine or function to the caller
+RETURN       : R E T U R N ;
+
+// COMMON statement - C28-6000-2 Part I, Chapter 3, Section 3.5
+// Declares shared storage between program units
+COMMON       : C O M M O N ;
+
+// ============================================================================
+// STATEMENT LABELS
+// C28-6000-2 Part I, Chapter 2: Coding for FORTRAN II (columns 1-5)
+// ============================================================================
+// Statement labels are 1-5 digit integers (1-99999) placed in columns 1-5
 LABEL : [1-9] ([0-9] ([0-9] ([0-9] [0-9]?)?)?)? ;
 
-// Hollerith constants (string literals)
+// ============================================================================
+// HOLLERITH CONSTANTS
+// C28-6000-2 Part I, Chapter 2 and Appendix A (FORMAT specification)
+// ============================================================================
 // Format: nHcharacters where n = number of characters following H
+// Used in FORMAT statements and I/O lists for literal text
 HOLLERITH : [1-9] [0-9]* H ~[\r\n]*? ;
 
-// Fixed-form newlines
+// ============================================================================
+// SOURCE FORMAT
+// C28-6000-2 Part I, Chapter 2: Coding for FORTRAN II
+// ============================================================================
+// Newlines are significant (statement terminators in fixed-form source)
 NEWLINE : '\r'? '\n' ;

--- a/grammars/FORTRANIIParser.g4
+++ b/grammars/FORTRANIIParser.g4
@@ -1,142 +1,178 @@
-// FORTRAN II (1958) - Parser for Procedural Programming Revolution
-// Introduces separately compiled subroutines and functions
+/*
+ * FORTRANIIParser.g4
+ *
+ * FORTRAN II (1958) - Parser for Procedural Programming Revolution
+ * Introduces separately compiled subroutines and functions.
+ *
+ * This parser extends FORTRANParser (1957) with the six new FORTRAN II
+ * statement/subprogram forms and redefines the complete statement set
+ * to include CALL, RETURN, and COMMON.
+ *
+ * Reference: IBM FORTRAN II for the IBM 704 Data Processing System
+ *            (Form C28-6000-2, 1958)
+ *            - Part I, Chapter 1: Introduction and Types of Statements
+ *            - Part I, Chapter 2: Coding for FORTRAN II
+ *            - Part I, Chapter 3: The New FORTRAN II Statements
+ *            - Part I, Chapter 4: Expressions (inherited from FORTRAN I)
+ *            - Appendix A: Summary of FORTRAN II Statements
+ *
+ * Manual available at: Computer History Museum archive
+ *   https://archive.computerhistory.org/resources/text/Fortran/
+ */
+
 parser grammar FORTRANIIParser;
 
-import FORTRANParser;  // Import FORTRAN I (1957) constructs
+import FORTRANParser;  // Import FORTRAN I (1957) constructs (C28-6003)
 
 options {
     tokenVocab = FORTRANIILexer;
 }
 
-// ====================================================================
-// FORTRAN II (1958) NEW PARSER RULES
-// ====================================================================
-// - No file system: Magnetic tapes and card decks were the "files"
+// ============================================================================
+// FORTRAN II (1958) PROGRAM STRUCTURE
+// C28-6000-2 Part I, Chapter 1: Introduction
+// ============================================================================
+// FORTRAN II introduces separately compiled program units:
+// - Main program: sequence of statements ending with END
+// - Subroutine subprogram: SUBROUTINE definition with END
+// - Function subprogram: FUNCTION definition with END
 //
-// MATHEMATICAL FOCUS (1957):
-// - Primary purpose: Scientific computation and engineering calculations
-// - Expression evaluation: Full precedence with parentheses override
-// - Built-in functions: Mathematical functions (SIN, COS, SQRT, LOG, etc.)
-// - Optimization: Compiler focused on mathematical expression efficiency
-//
-// ====================================================================
+// Historical context:
+// - No file system: magnetic tapes and card decks were the "files"
+// - Primary purpose: scientific computation and engineering calculations
+// - Separate compilation enabled modular programming and code reuse
+// ============================================================================
 
-// ====================================================================
-// FORTRAN II (1958) - SUBROUTINE AND FUNCTION DEFINITIONS
-// ====================================================================
+// ============================================================================
+// PROGRAM UNIT RULES
+// C28-6000-2 Part I, Chapter 1 and Chapter 3
+// ============================================================================
 
 // FORTRAN II program with separately compiled units
+// C28-6000-2 Part I, Chapter 1: A source deck consists of one program unit
 fortran_program
     : (main_program | subroutine_subprogram | function_subprogram) EOF
     ;
 
-// Main program (inherited from FORTRAN I)
-// A main program is a sequence of statements ending with END.
+// Main program - C28-6000-2 Part I, Chapter 1
+// A main program is a sequence of statements ending with END
 main_program
     : statement_list end_stmt NEWLINE?
     ;
 
-// Statement list allowing empty lines (punch cards could be blank)
+// Statement list - C28-6000-2 Part I, Chapter 2
+// Allows empty lines (blank punch cards were valid)
 statement_list
     : statement*
     ;
 
-// Individual statement with optional label and newline handling
+// Individual statement - C28-6000-2 Part I, Chapter 2
 // Labels were punched in columns 1-5, statements in columns 7-72
 statement
     : label? statement_body NEWLINE?
     | NEWLINE  // Blank punch card (allowed)
     ;
 
-// Statement label (1957: 1-99999, punched in columns 1-5)
+// Statement label - C28-6000-2 Part I, Chapter 2
+// 1-5 digit integer (1-99999), punched in columns 1-5
 label
     : LABEL
     ;
 
-// Subroutine definition (NEW in FORTRAN II)
+// Subroutine definition - C28-6000-2 Part I, Chapter 3, Section 3.2
+// Defines a separately compiled subroutine subprogram
+// Form: SUBROUTINE name (a1, a2, ..., an) or SUBROUTINE name
 subroutine_subprogram
     : SUBROUTINE IDENTIFIER parameter_list? NEWLINE
       statement_list
       end_stmt NEWLINE?
     ;
 
-// Function definition (NEW in FORTRAN II)
+// Function definition - C28-6000-2 Part I, Chapter 3, Section 3.3
+// Defines a separately compiled function subprogram
+// Form: [type] FUNCTION name (a1, a2, ..., an)
 function_subprogram
     : type_spec? FUNCTION IDENTIFIER parameter_list NEWLINE
       statement_list
       end_stmt NEWLINE?
     ;
 
-// Parameter list for subprograms
+// Parameter list for subprograms - C28-6000-2 Part I, Chapter 3
+// Dummy arguments for subroutines and functions
 parameter_list
     : LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN
     ;
 
-// Type specification for functions
+// Type specification - C28-6000-2 Part I, Chapter 3, Section 3.3
+// Optional type prefix for FUNCTION definitions
 type_spec
     : INTEGER
     | REAL
     ;
 
-// All statement types available in 1957 FORTRAN
-// This was a remarkably small language by today's standards!
+// ============================================================================
+// STATEMENT TYPES
+// C28-6000-2 Part I, Chapter 1 and Appendix A: Summary of FORTRAN II Statements
+// ============================================================================
+// FORTRAN II includes all original FORTRAN I (1957) statements plus six new
+// forms: SUBROUTINE, FUNCTION, CALL, RETURN, COMMON, and END.
+//
 // NOTE: end_stmt is NOT included here - it is handled separately as a
 // program unit terminator in main_program, subroutine_subprogram, and
 // function_subprogram rules.
+// ============================================================================
+
 statement_body
-    : statement_function_stmt  // Statement function definition (spec part)
-    | assignment_stmt      // Variable = Expression (mathematical notation!)
-    | goto_stmt           // Unconditional jump to labeled statement
-    | computed_goto_stmt  // Multi-way branch based on integer expression
-    | arithmetic_if_stmt  // Three-way branch based on expression sign
-    | do_stmt            // Counted loop with mandatory label
-    | continue_stmt      // Loop termination and jump target
-    | stop_stmt          // Program termination
-    | pause_stmt         // Operator intervention (unique to 1957!)
-    | read_stmt          // Input from cards/tape
-    | print_stmt         // Output to line printer
-    | punch_stmt         // Output to card punch (data storage!)
-    | format_stmt        // I/O formatting specification
-    | dimension_stmt     // Array dimension declarations
-    | equivalence_stmt   // Variable memory overlay
-    | frequency_stmt     // Optimization hints (unique to 1957!)
-    | common_stmt        // Global variable declarations
-    | return_stmt       // Return from subprogram
-    | call_stmt         // NEW in FORTRAN II: Call subroutine
+    : statement_function_stmt  // Appendix A: Statement function definition
+    | assignment_stmt      // Appendix A: v = e (assignment)
+    | goto_stmt           // Appendix A: GO TO n
+    | computed_goto_stmt  // Appendix A: GO TO (n1, n2, ...), i
+    | arithmetic_if_stmt  // Appendix A: IF (e) n1, n2, n3
+    | do_stmt            // Appendix A: DO n i = m1, m2 [, m3]
+    | continue_stmt      // Appendix A: CONTINUE
+    | stop_stmt          // Appendix A: STOP [n]
+    | pause_stmt         // Appendix A: PAUSE [n]
+    | read_stmt          // Appendix A: READ forms
+    | print_stmt         // Appendix A: PRINT n, list
+    | punch_stmt         // Appendix A: PUNCH n, list
+    | format_stmt        // Appendix A: FORMAT (specification)
+    | dimension_stmt     // Appendix A: DIMENSION v, v, ...
+    | equivalence_stmt   // Appendix A: EQUIVALENCE (a,b,...), ...
+    | frequency_stmt     // Appendix A: FREQUENCY n (i1, i2, ...)
+    | common_stmt        // Appendix A: COMMON list (NEW in FORTRAN II)
+    | return_stmt        // Appendix A: RETURN (NEW in FORTRAN II)
+    | call_stmt          // Appendix A: CALL name (args) (NEW in FORTRAN II)
     ;
 
-// CALL statement (NEW in FORTRAN II)
+// ============================================================================
+// FORTRAN II NEW STATEMENTS
+// C28-6000-2 Part I, Chapter 3: The New FORTRAN II Statements
+// ============================================================================
+
+// CALL statement - C28-6000-2 Part I, Chapter 3, Section 3.1
+// Form: CALL name or CALL name (a1, a2, ..., an)
+// Transfers control to a subroutine, passing arguments by reference
 call_stmt
     : CALL IDENTIFIER (LPAREN expr_list? RPAREN)?
     ;
 
 
-// ====================================================================
+// ============================================================================
 // STATEMENT FUNCTION DEFINITION
-// ====================================================================
-// Per ANSI X3.9-1966 Section 7.2 and FORTRAN 77 Section 8, a statement
-// function defines a scalar function within the specification part of a
-// program unit. It has the form:
+// C28-6000-2 Part I, Chapter 4: Expressions (inherited from FORTRAN I)
+// ============================================================================
+// Statement functions define inline functions within a program unit.
+// Form: name(dummy-arg-list) = expression
 //
-//     name(dummy-arg-list) = scalar-expression
-//
-// where:
-// - name is the function name (follows implicit or explicit typing)
-// - dummy-arg-list is a non-empty list of identifier dummy arguments
-// - scalar-expression is any valid expression using those arguments
-//
-// Statement functions must appear after specification statements and
-// before executable statements (enforced semantically, not syntactically).
+// Note: Statement functions were present in FORTRAN I and continue in
+// FORTRAN II. They must appear after specification statements and before
+// executable statements (enforced semantically, not syntactically).
 //
 // Examples:
 //   F(X) = X * X + 2.0 * X + 1.0
 //   AREA(R) = 3.14159 * R * R
 //   DIST(X1, Y1, X2, Y2) = SQRT((X2-X1)**2 + (Y2-Y1)**2)
-//
-// Note: Statement functions are distinct from array element assignments.
-// The key syntactic difference is that statement function dummy arguments
-// are simple identifiers, not arbitrary expressions.
-// ====================================================================
+// ============================================================================
 
 statement_function_stmt
     : IDENTIFIER LPAREN statement_function_dummy_arg_list RPAREN EQUALS expr
@@ -148,98 +184,99 @@ statement_function_dummy_arg_list
     ;
 
 
-// Assignment statement (1957 revolutionary syntax!)
-// This natural mathematical notation was groundbreaking in 1957
-// Before FORTRAN, programmers wrote: STO A, ADD B, STO C
-// FORTRAN allowed: C = A + B (revolutionary!)
+// ============================================================================
+// INHERITED FORTRAN I (1957) STATEMENTS
+// C28-6000-2 Part I, Chapter 1: All original FORTRAN statements remain valid
+// See also C28-6003 (FORTRAN I manual) Appendix B for statement forms
+// ============================================================================
+
+// Assignment statement - Appendix A: v = e
+// The natural mathematical notation that made FORTRAN revolutionary
 assignment_stmt
     : variable EQUALS expr
     ;
 
-
-// Unconditional GOTO (1957 primary control flow)
-// Example: GO TO 100 (jump to statement labeled 100)
+// Unconditional GO TO - Appendix A: GO TO n
+// Transfers control to the statement with label n
 goto_stmt
     : GOTO label
     ;
 
-// Computed GOTO (1957 multi-way branch)
-// Example: GO TO (10, 20, 30), I
-// If I=1 go to 10, I=2 go to 20, I=3 go to 30
+// Computed GO TO - Appendix A: GO TO (n1, n2, ..., nm), i
+// Transfers to n1 if i=1, n2 if i=2, etc.
 computed_goto_stmt
     : GOTO LPAREN label_list RPAREN COMMA expr
     ;
 
-// Arithmetic IF (1957 three-way branch - revolutionary!)
-// Example: IF (X-Y) 10, 20, 30
-// If X-Y < 0 go to 10, if X-Y = 0 go to 20, if X-Y > 0 go to 30
-// This was the ONLY conditional statement in 1957!
+// Arithmetic IF - Appendix A: IF (e) n1, n2, n3
+// Three-way branch: n1 if e<0, n2 if e=0, n3 if e>0
 arithmetic_if_stmt
     : IF LPAREN expr RPAREN label COMMA label COMMA label
     ;
 
-// DO statement (1957 - counted loops with labels)
-// Example: DO 100 I = 1, 10, 2 (loop I from 1 to 10 step 2, end at label 100)
-// The label was MANDATORY - no END DO in 1957!
+// DO statement - Appendix A: DO n i = m1, m2 [, m3]
+// Counted loop from m1 to m2 with optional step m3, ends at label n
 do_stmt
     : DO label variable ASSIGN expr COMMA expr (COMMA expr)?
     ;
 
-
-// CONTINUE statement (DO loop termination and general jump target)
+// CONTINUE statement - Appendix A: CONTINUE
+// DO loop termination and general jump target
 continue_stmt : CONTINUE ;
 
-// STOP statement (program termination with optional numeric code)
+// STOP statement - Appendix A: STOP [n]
+// Program termination with optional numeric code
 stop_stmt : STOP integer_expr? ;
 
-// PAUSE statement (unique to 1957 - operator intervention!)
-// Halted program and displayed message to computer operator
-// Operator could then examine memory, modify settings, and continue
-// Example: PAUSE 1234 (display code 1234 and wait for operator)
+// PAUSE statement - Appendix A: PAUSE [n]
+// Operator intervention: halts and displays message to operator
 pause_stmt : PAUSE integer_expr? ;
 
-// RETURN statement (NEW in FORTRAN II for separate compilation)
+// RETURN statement - C28-6000-2 Part I, Chapter 3, Section 3.4
+// Returns control from subroutine or function to caller (NEW in FORTRAN II)
 return_stmt : RETURN ;
 
-// END statement (end of main program or subprogram)
+// END statement - C28-6000-2 Part I, Chapter 3, Section 3.6
+// Terminates a program unit (formalized in FORTRAN II)
 end_stmt : END ;
 
 
-// READ statement (input from punch cards or magnetic tape)
-// Example: READ 100, A, B, C (read using format 100)
-// Example: READ 5, 200, X, Y (read from unit 5 using format 200)
+// ============================================================================
+// I/O STATEMENTS
+// C28-6000-2 Appendix A: Input/Output statements (inherited from FORTRAN I)
+// ============================================================================
+
+// READ statement - Appendix A: READ forms
+// Input from punch cards or magnetic tape
 read_stmt
     : READ integer_expr COMMA input_list                    // READ unit, list
     | READ integer_expr COMMA label COMMA input_list       // READ unit, format, list
     ;
 
-// PRINT statement (output to line printer - primary 1957 output)
-// Example: PRINT 100, A, B, C (print using format 100)
+// PRINT statement - Appendix A: PRINT n, list
+// Output to line printer (primary 1957 output device)
 print_stmt
-    : PRINT integer_expr COMMA output_list   // PRINT format, list
+    : PRINT integer_expr COMMA output_list
     ;
 
-// PUNCH statement (output to card punch - 1957 data storage!)
-// This was how FORTRAN programs created data files in 1957
-// Example: PUNCH 200, X, Y, Z (punch variables to cards using format 200)
+// PUNCH statement - Appendix A: PUNCH n, list
+// Output to card punch (1957 data storage mechanism)
 punch_stmt
-    : PUNCH integer_expr COMMA output_list   // PUNCH format, list
+    : PUNCH integer_expr COMMA output_list
     ;
 
-
-// FORMAT statement (I/O formatting - revolutionary feature!)
-// Example: 100 FORMAT (I5, F10.2, E15.6, 5HHELLO)
-// Allowed precise control over input/output layout
+// FORMAT statement - Appendix A: FORMAT (specification)
+// Defines I/O formatting layout
 format_stmt
     : FORMAT LPAREN format_specification RPAREN
     ;
 
-// Format specification items
+// Format specification items - Appendix A
 format_specification
     : format_item (COMMA format_item)*
     ;
 
-// Individual format items
+// Individual format items - Appendix A
 format_item
     : INTEGER_LITERAL? format_descriptor  // e.g., I5, F10.2, E15.6
     | HOLLERITH                          // e.g., 5HHELLO (literal text)
@@ -247,13 +284,17 @@ format_item
 
 // Format descriptors (I, E, F, G, A, H, X, etc.)
 format_descriptor
-    : IDENTIFIER  // Format codes like I, E, F, G, A, H, X
+    : IDENTIFIER
     ;
 
 
-// DIMENSION statement (array declarations - arrays were revolutionary!)
-// Example: DIMENSION A(100), B(10,20), C(5,5,5)
-// Multi-dimensional arrays in a high-level language were unprecedented in 1957
+// ============================================================================
+// SPECIFICATION STATEMENTS
+// C28-6000-2 Appendix A: Specification statements
+// ============================================================================
+
+// DIMENSION statement - Appendix A: DIMENSION v, v, ...
+// Array dimension declarations (up to 3 dimensions in 1957)
 dimension_stmt
     : DIMENSION array_declarator (COMMA array_declarator)*
     ;
@@ -263,14 +304,13 @@ array_declarator
     : IDENTIFIER LPAREN dimension_list RPAREN
     ;
 
-// Dimension list (compile-time constants only in 1957)
+// Dimension list (compile-time constants in original FORTRAN)
 dimension_list
     : integer_expr (COMMA integer_expr)*
     ;
 
-// EQUIVALENCE statement (memory overlay - memory was precious!)
-// Example: EQUIVALENCE (A, B(1)), (X, Y, Z)
-// Allowed variables to share the same memory location
+// EQUIVALENCE statement - Appendix A: EQUIVALENCE (a,b,...), ...
+// Memory overlay: allows variables to share the same memory location
 equivalence_stmt
     : EQUIVALENCE equivalence_set (COMMA equivalence_set)*
     ;
@@ -280,47 +320,45 @@ equivalence_set
     : LPAREN variable COMMA variable (COMMA variable)* RPAREN
     ;
 
-// FREQUENCY statement (1957 optimization hint - unique to original FORTRAN!)
-// Example: FREQUENCY 10 (25, 3, 1)
-// Told compiler statement 10 executed 25 times out of 29 (optimization hint)
-// This feature was removed in later FORTRAN versions
+// FREQUENCY statement - Appendix A: FREQUENCY n (i1, i2, ...)
+// Optimization hint for branch prediction (unique to 1957 FORTRAN)
+// Removed in later standards
 frequency_stmt
     : FREQUENCY label LPAREN integer_expr (COMMA integer_expr)* RPAREN
     ;
 
-// COMMON statement (global variable storage)
-// Example: COMMON A, B, C
-// Example: COMMON /BLOCK1/ X, Y, Z
-// Shared variables between main program and subprograms
+// COMMON statement - C28-6000-2 Part I, Chapter 3, Section 3.5
+// Shared storage between program units (NEW in FORTRAN II)
+// Form: COMMON list or COMMON /name/ list
+// Note: Named COMMON blocks (/name/) are a forward-compatibility extension;
+// historically FORTRAN II only provided blank COMMON. See issue #156.
 common_stmt
     : COMMON (SLASH IDENTIFIER SLASH)? variable_list
     ;
 
 
-// ====================================================================
-// EXPRESSION EVALUATION - Proper Precedence Hierarchy
-// ====================================================================
+// ============================================================================
+// EXPRESSION EVALUATION
+// C28-6000-2 Part I, Chapter 4: Expressions (inherited from FORTRAN I)
+// ============================================================================
 // FORTRAN II implements proper operator precedence (highest to lowest):
 //   1. ** (power) - RIGHT ASSOCIATIVE
 //   2. unary +, - (unary operators)
 //   3. *, / (multiplication, division) - left associative
 //   4. binary +, - (addition, subtraction) - left associative
 //
-// Per IBM FORTRAN II manual (Form C28-6000-2, 1958), expression syntax
-// matches 1957 FORTRAN mathematical expressions. The hierarchy ensures:
+// Per C28-6000-2, expression syntax matches 1957 FORTRAN mathematical
+// expressions. The hierarchy ensures:
 // - 2**3**4 parses as 2**(3**4) per right-associativity of **
 // - -2**2 parses as -(2**2) = -4, not (-2)**2 = 4
 // - 2+3*4 parses as 2+(3*4) = 14, not (2+3)*4 = 20
 //
 // Note: FORTRAN II does not include relational_expr at the top of expr.
 // Relational expressions (.EQ., .NE., etc.) were primarily used with
-// arithmetic IF in early FORTRAN; FORTRAN 66 introduces logical types
-// where relational expressions appear in logical_expr context instead.
-// ====================================================================
+// arithmetic IF; FORTRAN 66 introduces logical types for these.
+// ============================================================================
 
-// Arithmetic expression - top of the precedence hierarchy for FORTRAN II
-// Does not include relational operators (those are added in FORTRAN 66
-// within the logical expression context)
+// Arithmetic expression - top of the precedence hierarchy
 expr
     : additive_expr
     ;
@@ -356,8 +394,7 @@ unary_op
     ;
 
 // Exponentiation - highest precedence, RIGHT ASSOCIATIVE
-// 2**3**4 = 2**(3**4) = 2**81 = 2417851639229258349412352
-// NOT (2**3)**4 = 8**4 = 4096
+// 2**3**4 = 2**(3**4), NOT (2**3)**4
 power_expr
     : primary POWER power_expr    // Right associative: a**b**c = a**(b**c)
     | primary
@@ -370,16 +407,15 @@ primary
     | LPAREN expr RPAREN
     ;
 
-// Literals (integers and reals)
-// Note: LABEL tokens (1-5 digit integers starting with 1-9) are lexically
-// identical to integer literals in expression context, so we accept both.
+// Literals - C28-6000-2 Part I, Chapter 4
+// Fixed-point (integer) and floating-point (real) constants
 literal
     : INTEGER_LITERAL
     | LABEL              // LABEL tokens are valid integer literals in expressions
     | REAL_LITERAL
     ;
 
-// Variables and array/function references
+// Variables and array/function references - C28-6000-2 Part I, Chapter 4
 // In FORTRAN II, SIN(X) and A(I) are syntactically identical;
 // semantic analysis distinguishes functions from arrays
 variable
@@ -387,7 +423,11 @@ variable
     ;
 
 
-// Various lists used throughout the grammar
+// ============================================================================
+// UTILITY RULES
+// Helper patterns for labels, lists, and I/O
+// ============================================================================
+
 label_list
     : label (COMMA label)*
     ;
@@ -411,16 +451,3 @@ expr_list
 integer_expr
     : expr  // Expression that must evaluate to integer (semantic constraint)
     ;
-
-// ====================================================================
-// IMPLEMENTATION STATUS
-// ====================================================================
-//
-// CURRENT STATUS: Complete FORTRAN II procedural programming implementation
-// COMPILATION: Compiles with ANTLR4, integrates with FORTRAN I base
-// FUNCTIONALITY: Full subroutine and function support with CALL statements
-//
-// HISTORICAL ACCURACY: Based on IBM 704 FORTRAN II Operator's Manual (1958)
-// EDUCATIONAL VALUE: Complete record of procedural programming revolution
-// RESEARCH VALUE: Foundation for modern subroutine-based programming
-// ====================================================================


### PR DESCRIPTION
## Summary

- Add spec-section comments throughout FORTRANIILexer.g4 and FORTRANIIParser.g4 referencing IBM C28-6000-2 (1958) chapters and Appendix A entries
- Add header blocks with manual reference and Computer History Museum archive URL to both grammar files
- Add exhaustive C28-6000-2 Appendix A crosswalk table to docs/fortran_ii_audit.md mapping all FORTRAN II and inherited FORTRAN I statements to grammar rules or gap issues

## Verification

```
$ python -m pytest tests/FORTRANII/ -v
17 passed in 0.07s

$ python -m pytest tests/test_fixture_parsing.py -k FORTRANII -v
3 passed in 1.15s

$ python -m pytest tests/ -v
622 passed, 65 xfailed in 34.26s
```

All FORTRAN II tests pass and the grammar compiles correctly with ANTLR4.