### PR TITLE
fix: document PURE/ELEMENTAL as F95 forward extensions (fixes #182)

### DIFF
--- a/docs/fortran_90_audit.md
+++ b/docs/fortran_90_audit.md
@@ -325,9 +325,36 @@ integration gaps:
   - Unified fixed/free‑form parsing on mixed‑format sources.
 
 These fixtures collectively define the **current outer edge** of the
-Fortran 90 grammar’s practical coverage.
+Fortran 90 grammar's practical coverage.
 
-## 9. Summary
+## 9. PURE and ELEMENTAL: forward extensions from Fortran 95
+
+The F90 grammar accepts the PURE and ELEMENTAL keywords as procedure
+prefixes (via `prefix_spec` in `Fortran90Parser.g4`), even though these
+features are defined in the **Fortran 95** standard (ISO/IEC 1539‑1:1997),
+not in Fortran 90 (ISO/IEC 1539:1991).
+
+This is a **deliberate forward extension** for practical parsing of
+mixed-standard codebases. Many real‑world Fortran programs use PURE and
+ELEMENTAL procedures in code that is otherwise compatible with F90
+compilers, and accepting these keywords at the F90 grammar level avoids
+forcing users to explicitly select the F95 grammar for such programs.
+
+The grammar comments in `Fortran90Lexer.g4` and `Fortran90Parser.g4`
+explicitly document this forward extension and reference issue #182.
+The F95 grammar (`Fortran95Parser.g4`) provides additional F95‑specific
+procedure rules (`pure_function_stmt`, `elemental_subroutine_stmt`, etc.)
+that are used by targeted tests but not yet integrated into the main
+program‑unit entry points.
+
+For users who require strict historical accuracy:
+
+- A pure F90 parser (without F95 extensions) would need to remove PURE
+  and ELEMENTAL from `prefix_spec` in `Fortran90Parser.g4`.
+- The current design prioritizes practical usability over strict historical
+  conformance, which is documented in this audit and in the grammar comments.
+
+## 10. Summary
 
 The Fortran 90 grammar in this repository:
 

--- a/docs/fortran_95_audit.md
+++ b/docs/fortran_95_audit.md
@@ -218,11 +218,12 @@ Grammar implementation:
 
 Gaps and historical notes:
 
-- **Historical attribution**:
-  - PURE and ELEMENTAL are accepted already in the F90 grammar (via
-    `prefix_spec`), even though they are Fortran 95 language features.
-    This is a deliberate forward extension but historically inaccurate
-    and should be documented as such.
+- **Historical attribution** (resolved in issue #182):
+  - PURE and ELEMENTAL are accepted in the F90 grammar (via `prefix_spec`)
+    as a deliberate forward extension for practical parsing of mixed-standard
+    code, even though they are Fortran 95 language features. This is now
+    explicitly documented in the F90 grammar comments and in
+    `docs/fortran_90_audit.md` section 9.
 - **Integration into program units**:
   - The new `pure_*` and `elemental_*` rules are not used by F90’s
     `function_subprogram` / `subroutine_subprogram` rules; instead,
@@ -486,9 +487,10 @@ The Fortran 95 layer in this repository:
 - **Does not yet fully integrate** these features into the F90
   program‑unit and execution‑part structure, and does not allow F95
   intrinsics to be used as intrinsic calls.
-- **Contains historical inaccuracies**, notably:
-  - PURE/ELEMENTAL procedure support attributed to F90 in the grammar
-    even though they are language features of Fortran 95.
+- **Historical notes** (all resolved):
+  - (Resolved in #182: PURE/ELEMENTAL in F90 grammar is now documented as a
+    deliberate forward extension, with clear comments in the grammar files
+    and a dedicated section in the F90 audit.)
   - (Resolved: Square‑bracket array constructors were removed from the
     F95 grammar; only the standard `(/ ... /)` form is now accepted.)
 
@@ -508,8 +510,8 @@ cover at least:
 - Integration of F95 constructs into a proper `program_unit_f95` entry
   and the execution/specification parts.
 - Making F95 intrinsic tokens usable as function and subroutine calls.
-- Documenting the PURE/ELEMENTAL historical mismatch between the F90
-  grammar and the actual standards.
+- (Resolved in #182: PURE/ELEMENTAL historical mismatch documented in F90
+  grammar comments and F90 audit section 9.)
 - (Resolved: #181 – bracket array constructors removed from F95 grammar.)
 
 Together with the Fortran 90 audit, this document completes the

--- a/grammars/Fortran90Lexer.g4
+++ b/grammars/Fortran90Lexer.g4
@@ -90,10 +90,13 @@ ASSIGNMENT      : ('a'|'A') ('s'|'S') ('s'|'S') ('i'|'I') ('g'|'G')
                   ('n'|'N') ('m'|'M') ('e'|'E') ('n'|'N') ('t'|'T') ;
 
 // Procedure enhancements
-RECURSIVE       : ('r'|'R') ('e'|'E') ('c'|'C') ('u'|'U') ('r'|'R') 
+// RECURSIVE is a genuine F90 feature (ISO/IEC 1539:1991)
+// PURE and ELEMENTAL are F95 features (ISO/IEC 1539-1:1997) accepted here
+// as forward extensions for parsing mixed-standard code (see issue #182)
+RECURSIVE       : ('r'|'R') ('e'|'E') ('c'|'C') ('u'|'U') ('r'|'R')
                   ('s'|'S') ('i'|'I') ('v'|'V') ('e'|'E') ;
 PURE            : ('p'|'P') ('u'|'U') ('r'|'R') ('e'|'E') ;
-ELEMENTAL       : ('e'|'E') ('l'|'L') ('e'|'E') ('m'|'M') ('e'|'E') 
+ELEMENTAL       : ('e'|'E') ('l'|'L') ('e'|'E') ('m'|'M') ('e'|'E')
                   ('n'|'N') ('t'|'T') ('a'|'A') ('l'|'L') ;
 RESULT          : ('r'|'R') ('e'|'E') ('s'|'S') ('u'|'U') ('l'|'L') ('t'|'T') ;
 

--- a/grammars/Fortran90Parser.g4
+++ b/grammars/Fortran90Parser.g4
@@ -21,12 +21,16 @@ options {
 // - Free-form: .f90+ files (modern syntax)
 //
 // REVOLUTIONARY F90 FEATURES IMPLEMENTED:
-// - Module system with explicit interfaces  
+// - Module system with explicit interfaces
 // - Dynamic memory management (pointers, allocatable arrays)
 // - Derived types (user-defined structures)
-// - Array operations and constructors  
+// - Array operations and constructors
 // - Enhanced control flow and I/O
-// - Procedure enhancements (RECURSIVE, PURE, ELEMENTAL)
+// - RECURSIVE procedures
+//
+// NOTE: PURE and ELEMENTAL are Fortran 95 (ISO/IEC 1539-1:1997) features,
+// not Fortran 90 features. They are accepted here as a forward extension
+// for practical parsing of mixed-standard code. See issue #182.
 //
 // INHERITANCE ARCHITECTURE (IN THIS REPO):
 // FORTRAN / FORTRANII / FORTRAN66 / FORTRAN77
@@ -606,8 +610,8 @@ prefix
 
 prefix_spec
     : RECURSIVE                     // F90 recursive procedures
-    | PURE                          // F90 pure procedures  
-    | ELEMENTAL                     // F90 elemental procedures
+    | PURE                          // F95 forward extension (see #182)
+    | ELEMENTAL                     // F95 forward extension (see #182)
     | type_spec_f90                 // Function return type
     ;
 


### PR DESCRIPTION
## Summary
- Clarify that PURE and ELEMENTAL procedure prefixes in the F90 grammar are Fortran 95 features (ISO/IEC 1539-1:1997) accepted as deliberate forward extensions for practical parsing of mixed-standard code
- Update grammar comments in Fortran90Lexer.g4 and Fortran90Parser.g4 to document the forward extension with issue reference
- Add new section 9 to F90 audit explaining the rationale for this design decision
- Update F95 audit to mark the historical attribution as resolved

## Verification
```
make test
```

Output (639 passed, 65 xfailed):
```
======================= 639 passed, 65 xfailed in 36.53s =======================
```

All tests pass. The changes are documentation-only (grammar comments and audit docs), so no behavioral changes to the parsers.