### PR TITLE
fix: integrate F95 constructs into program structure (fixes #179)

### DIFF
--- a/tests/fixtures/Fortran95/test_fixture_parsing/forall_module.f90
+++ b/tests/fixtures/Fortran95/test_fixture_parsing/forall_module.f90
@@ -1,0 +1,13 @@
+module array_ops_mod
+    implicit none
+contains
+    subroutine scale_array(a, n, factor)
+        integer, intent(in) :: n
+        real, intent(inout) :: a(n)
+        real, intent(in) :: factor
+        integer :: i
+        forall (i = 1:n)
+            a(i) = a(i) * factor
+        end forall
+    end subroutine scale_array
+end module array_ops_mod

--- a/tests/fixtures/Fortran95/test_fixture_parsing/forall_program.f90
+++ b/tests/fixtures/Fortran95/test_fixture_parsing/forall_program.f90
@@ -1,0 +1,10 @@
+program forall_example
+    implicit none
+    integer :: a(10), i
+    do i = 1, 10
+        a(i) = i
+    end do
+    forall (i = 1:10)
+        a(i) = a(i) * 2
+    end forall
+end program forall_example

--- a/tests/fixtures/Fortran95/test_fixture_parsing/where_program.f90
+++ b/tests/fixtures/Fortran95/test_fixture_parsing/where_program.f90
@@ -1,0 +1,13 @@
+program where_example
+    implicit none
+    real :: a(10), b(10)
+    integer :: i
+    do i = 1, 10
+        a(i) = 1.0 * i
+    end do
+    where (a > 5.0)
+        b = a * 2.0
+    elsewhere
+        b = a
+    end where
+end program where_example

--- a/tests/fixtures/Fortran95/test_fortran_95_features/forall_construct.f90
+++ b/tests/fixtures/Fortran95/test_fortran_95_features/forall_construct.f90
@@ -1,2 +1,4 @@
-FORALL (i = 1:10) x(i) = i END FORALL
+FORALL (i = 1:10)
+x(i) = i
+END FORALL
 

--- a/tests/fixtures/Fortran95/test_fortran_95_features/where_construct.f90
+++ b/tests/fixtures/Fortran95/test_fortran_95_features/where_construct.f90
@@ -1,2 +1,6 @@
-WHERE (x > 0) x = 1 ELSEWHERE x = 2 END WHERE
+WHERE (x > 0)
+x = 1
+ELSEWHERE
+x = 2
+END WHERE
 

--- a/tests/test_fixture_parsing.py
+++ b/tests/test_fixture_parsing.py
@@ -88,7 +88,7 @@ STANDARD_CONFIGS: Dict[str, StandardConfig] = {
     "Fortran95": StandardConfig(
         lexer_name="Fortran95Lexer",
         parser_name="Fortran95Parser",
-        entry_rule="program_unit_f90",
+        entry_rule="program_unit_f95",
     ),
     "Fortran2003": StandardConfig(
         lexer_name="Fortran2003Lexer",


### PR DESCRIPTION
## Summary
- Add `program_unit_f95` entry point that integrates F95 constructs (FORALL, enhanced WHERE) into program execution structure
- Wire F95-specific constructs into the execution path via `execution_part_f95` and `executable_construct_f95`
- Update FORALL and WHERE construct rules to handle newlines properly per ISO/IEC 1539-1:1997
- Update test_fixture_parsing.py to use the new `program_unit_f95` entry rule for Fortran95

## Verification
```
$ make test
...
======================= 642 passed, 65 xfailed in 37.67s =======================

$ python -m pytest tests/test_fixture_parsing.py -k "Fortran95" -v
================ 7 passed, 208 deselected, 24 xfailed in 0.96s =================
```

New test fixtures that now parse successfully:
- `tests/fixtures/Fortran95/test_fixture_parsing/forall_program.f90`
- `tests/fixtures/Fortran95/test_fixture_parsing/forall_module.f90`
- `tests/fixtures/Fortran95/test_fixture_parsing/where_program.f90`

## Test plan
- [x] All 642 tests pass
- [x] New F95 program fixtures containing FORALL and WHERE parse correctly
- [x] Existing fragment fixtures continue to pass
- [x] Code compliance (88-column limit) passes