### PR TITLE
fix: enforce strict standard compliance for PURE/ELEMENTAL (fixes #248)

### DIFF
--- a/grammars/Fortran2003Lexer.g4
+++ b/grammars/Fortran2003Lexer.g4
@@ -235,7 +235,9 @@ CONTINUATION
 // Override inherited NEWLINE to work properly with continuations
 NEWLINE : [\r\n]+ ;
 
-// Array constructor brackets (F90+ feature)
+// Array constructor brackets (Fortran 2003 feature - ISO/IEC 1539-1:2004)
+// Square bracket array constructor syntax [ ... ] was introduced in F2003.
+// F90/F95 only support the (/ ... /) syntax.
 LSQUARE : '[' ;
 RSQUARE : ']' ;
 

--- a/grammars/Fortran90Lexer.g4
+++ b/grammars/Fortran90Lexer.g4
@@ -89,15 +89,12 @@ OPERATOR        : ('o'|'O') ('p'|'P') ('e'|'E') ('r'|'R')
 ASSIGNMENT      : ('a'|'A') ('s'|'S') ('s'|'S') ('i'|'I') ('g'|'G') 
                   ('n'|'N') ('m'|'M') ('e'|'E') ('n'|'N') ('t'|'T') ;
 
-// Procedure enhancements
-// RECURSIVE is a genuine F90 feature (ISO/IEC 1539:1991)
-// PURE and ELEMENTAL are F95 features (ISO/IEC 1539-1:1997) accepted here
-// as forward extensions for parsing mixed-standard code (see issue #182)
+// Procedure enhancements (ISO/IEC 1539:1991 Section 12.5.2)
+// RECURSIVE is a genuine F90 feature introduced in ISO/IEC 1539:1991.
+// NOTE: PURE and ELEMENTAL are Fortran 95 features (ISO/IEC 1539-1:1997),
+// defined in Fortran95Lexer.g4, NOT here.
 RECURSIVE       : ('r'|'R') ('e'|'E') ('c'|'C') ('u'|'U') ('r'|'R')
                   ('s'|'S') ('i'|'I') ('v'|'V') ('e'|'E') ;
-PURE            : ('p'|'P') ('u'|'U') ('r'|'R') ('e'|'E') ;
-ELEMENTAL       : ('e'|'E') ('l'|'L') ('e'|'E') ('m'|'M') ('e'|'E')
-                  ('n'|'N') ('t'|'T') ('a'|'A') ('l'|'L') ;
 RESULT          : ('r'|'R') ('e'|'E') ('s'|'S') ('u'|'U') ('l'|'L') ('t'|'T') ;
 
 // Derived types (F90 major innovation)  
@@ -193,9 +190,8 @@ DOUBLE_COLON    : '::' ;
 POINTER_ASSIGN  : '=>' ;
 PERCENT         : '%' ;
 SLASH           : '/' ;    // For array constructors (/ ... /)
-// Square brackets for array constructors (F2003, commonly backported)
-LSQUARE         : '[' ;
-RSQUARE         : ']' ;
+// NOTE: Square brackets for array constructors [ ... ] are a Fortran 2003
+// feature (ISO/IEC 1539-1:2004), defined in Fortran2003Lexer.g4, NOT here.
 
 // F90 array intrinsic keywords
 LBOUND          : L B O U N D ;

--- a/grammars/Fortran90Parser.g4
+++ b/grammars/Fortran90Parser.g4
@@ -28,9 +28,9 @@ options {
 // - Enhanced control flow and I/O
 // - RECURSIVE procedures
 //
-// NOTE: PURE and ELEMENTAL are Fortran 95 (ISO/IEC 1539-1:1997) features,
-// not Fortran 90 features. They are accepted here as a forward extension
-// for practical parsing of mixed-standard code. See issue #182.
+// NOTE: PURE and ELEMENTAL are Fortran 95 features (ISO/IEC 1539-1:1997),
+// NOT Fortran 90 features. They are properly defined in Fortran95Parser.g4.
+// F90 prefix_spec only supports RECURSIVE per ISO/IEC 1539:1991 Section 12.5.2.
 //
 // INHERITANCE ARCHITECTURE (IN THIS REPO):
 // FORTRAN / FORTRANII / FORTRAN66 / FORTRAN77
@@ -559,9 +559,11 @@ substring_range
 // ====================================================================
 
 // Array constructor (F90 revolutionary feature)
+// ISO/IEC 1539:1991 Section 4.5
+// NOTE: Square bracket syntax [ ... ] is Fortran 2003 (ISO/IEC 1539-1:2004),
+// defined in Fortran2003Parser.g4, NOT here.
 array_constructor_f90
     : LPAREN SLASH ac_spec SLASH RPAREN     // F90 syntax: (/ ... /)
-    | LSQUARE ac_spec RSQUARE               // F2003 syntax: [ ... ] (backported)
     ;
 
 // Array constructor specification
@@ -604,15 +606,16 @@ subroutine_stmt
     ;
 
 // Procedure prefix (F90 enhancements)
+// ISO/IEC 1539:1991 Section 12.5.2
 prefix
     : prefix_spec+
     ;
 
 prefix_spec
     : RECURSIVE                     // F90 recursive procedures
-    | PURE                          // F95 forward extension (see #182)
-    | ELEMENTAL                     // F95 forward extension (see #182)
     | type_spec_f90                 // Function return type
+    // NOTE: PURE and ELEMENTAL are Fortran 95 features, not F90.
+    // They are defined in Fortran95Parser.g4 prefix_spec_f95.
     ;
 
 // Function suffix (F90 RESULT clause)

--- a/grammars/Fortran95Lexer.g4
+++ b/grammars/Fortran95Lexer.g4
@@ -18,7 +18,7 @@ import Fortran90Lexer;  // F90 unified format support
 // MAJOR F95 ENHANCEMENTS:
 // - FORALL construct and statements (advanced array operations)
 // - Enhanced WHERE constructs with ELSEWHERE
-// - PURE and ELEMENTAL procedure enhancements
+// - PURE and ELEMENTAL procedure prefixes (NEW in F95)
 // - Derived type default initialization
 // - Pointer improvements
 // - Minor I/O enhancements
@@ -44,9 +44,12 @@ END_FORALL      : ('e'|'E') ('n'|'N') ('d'|'D') WS+
 // WHERE and END_WHERE are inherited from F90
 // ELSEWHERE is inherited from F90 but enhanced in F95
 
-// Procedure enhancements (F95 clarifications)
-// PURE and ELEMENTAL are inherited from F90 but enhanced in F95
-// RECURSIVE is inherited from F90
+// Procedure enhancements (F95 - ISO/IEC 1539-1:1997 Section 12.6)
+// PURE and ELEMENTAL are NEW in Fortran 95, NOT inherited from F90.
+// RECURSIVE is inherited from F90 (ISO/IEC 1539:1991).
+PURE            : ('p'|'P') ('u'|'U') ('r'|'R') ('e'|'E') ;
+ELEMENTAL       : ('e'|'E') ('l'|'L') ('e'|'E') ('m'|'M') ('e'|'E')
+                  ('n'|'N') ('t'|'T') ('a'|'A') ('l'|'L') ;
 
 // Default initialization keyword (F95 derived type enhancement)
 // Uses existing ASSIGN token - no new token needed
@@ -113,7 +116,7 @@ SYSTEM_CLOCK_INTRINSIC : ('s'|'S') ('y'|'Y') ('s'|'S') ('t'|'T') ('e'|'E') ('m'|
 // MAJOR F95 FEATURES TARGETED (IN THIS LEXER):
 // ✅ FORALL constructs and statements (added in F95)
 // ✅ Enhanced WHERE/ELSEWHERE constructs and nesting (F95 refinements)
-// ✅ Enhanced PURE/ELEMENTAL user procedures (F95 additions)
+// ✅ PURE/ELEMENTAL procedure prefixes (NEW in F95)
 // ✅ Modern intrinsic functions from the F90/F95 core
 //    (CEILING, FLOOR, MODULO, bit intrinsics, TRANSFER, etc.)
 // ✅ CPU_TIME intrinsic (new in F95) and related timing intrinsics

--- a/grammars/Fortran95Parser.g4
+++ b/grammars/Fortran95Parser.g4
@@ -22,7 +22,7 @@ options {
 // MAJOR F95 ENHANCEMENTS IMPLEMENTED:
 // - FORALL construct and statements (advanced array operations)
 // - Enhanced WHERE constructs with multiple ELSEWHERE
-// - Enhanced PURE and ELEMENTAL procedure semantics
+// - PURE and ELEMENTAL procedure prefixes (NEW in F95)
 // - Derived type default initialization
 // - Pointer association enhancements
 // - Extended intrinsic functions
@@ -78,12 +78,12 @@ external_subprogram_f95
     ;
 
 function_subprogram_f95
-    : function_stmt specification_part_f95? execution_part_f95?
+    : function_stmt_f95 specification_part_f95? execution_part_f95?
       internal_subprogram_part_f95? end_function_stmt
     ;
 
 subroutine_subprogram_f95
-    : subroutine_stmt specification_part_f95? execution_part_f95?
+    : subroutine_stmt_f95 specification_part_f95? execution_part_f95?
       internal_subprogram_part_f95? end_subroutine_stmt
     ;
 
@@ -327,26 +327,34 @@ component_def_stmt_f95
 // ====================================================================
 // ENHANCED PROCEDURE SPECIFICATIONS (F95 IMPROVEMENTS)
 // ====================================================================
+//
+// Fortran 95 (ISO/IEC 1539-1:1997 Section 12.6) introduces PURE and
+// ELEMENTAL procedure prefixes. These are NOT available in Fortran 90.
 
-// Enhanced PURE procedures (F95 clarifications)
-pure_function_stmt
-    : PURE (prefix_spec)* FUNCTION IDENTIFIER LPAREN dummy_arg_name_list? RPAREN 
-      (suffix)?
+// F95 procedure prefix - extends F90 prefix_spec with PURE and ELEMENTAL
+// ISO/IEC 1539-1:1997 Section 12.6
+prefix_f95
+    : prefix_spec_f95+
     ;
 
-pure_subroutine_stmt
-    : PURE (prefix_spec)* SUBROUTINE IDENTIFIER (LPAREN dummy_arg_name_list? RPAREN)?
+prefix_spec_f95
+    : RECURSIVE                     // F90 recursive procedures
+    | PURE                          // F95 pure procedures
+    | ELEMENTAL                     // F95 elemental procedures
+    | type_spec_f95                 // Function return type
     ;
 
-// Enhanced ELEMENTAL procedures (F95 clarifications)
-elemental_function_stmt
-    : ELEMENTAL (prefix_spec)* FUNCTION IDENTIFIER LPAREN dummy_arg_name_list? 
-      RPAREN (suffix)?
+// F95 function statement with PURE/ELEMENTAL support
+// ISO/IEC 1539-1:1997 Section 12.6
+function_stmt_f95
+    : (prefix_f95)? FUNCTION IDENTIFIER LPAREN dummy_arg_name_list? RPAREN (suffix)?
+        NEWLINE?
     ;
 
-elemental_subroutine_stmt
-    : ELEMENTAL (prefix_spec)* SUBROUTINE IDENTIFIER 
-      (LPAREN dummy_arg_name_list? RPAREN)?
+// F95 subroutine statement with PURE/ELEMENTAL support
+// ISO/IEC 1539-1:1997 Section 12.6
+subroutine_stmt_f95
+    : (prefix_f95)? SUBROUTINE IDENTIFIER (LPAREN dummy_arg_name_list? RPAREN)? NEWLINE?
     ;
 
 // ====================================================================
@@ -719,7 +727,7 @@ function_reference_f95
 // MAJOR F95 FEATURES TARGETED:
 // ✅ FORALL constructs and statements (advanced array operations)
 // ✅ Enhanced WHERE constructs with multiple ELSEWHERE
-// ✅ Enhanced PURE and ELEMENTAL procedure support
+// ✅ PURE and ELEMENTAL procedure prefixes (NEW in F95)
 // ✅ Derived type default initialization
 // ✅ Enhanced pointer association
 // ✅ Extended intrinsic function support
@@ -739,7 +747,7 @@ function_reference_f95
 // VALIDATION NOTES:
 // ✅ Ready for targeted testing with representative F95 code
 // ✅ FORALL and enhanced WHERE constructs are implemented
-// ✅ Default initialization and PURE/ELEMENTAL forms are supported
+// ✅ Default initialization and PURE/ELEMENTAL prefixes are supported
 //
 // This parser extends the F90 grammar with the F95 constructs listed
 // above and serves as the bridge between F90 and F2003 in the

--- a/tests/Fortran90/test_fortran_90_comprehensive.py
+++ b/tests/Fortran90/test_fortran_90_comprehensive.py
@@ -206,11 +206,14 @@ class TestFortran90Lexer:
             assert tokens[0].type == expected_token
 
     def test_procedure_enhancement_keywords(self):
-        """Test F90 procedure enhancement keywords."""
+        """Test F90 procedure enhancement keywords.
+
+        NOTE: PURE and ELEMENTAL are Fortran 95 features (ISO/IEC 1539-1:1997),
+        NOT Fortran 90 features. They are defined in Fortran95Lexer.g4.
+        """
         proc_keywords = {
             'RECURSIVE': Fortran90Lexer.RECURSIVE,
-            'PURE': Fortran90Lexer.PURE,
-            'ELEMENTAL': Fortran90Lexer.ELEMENTAL,
+            # PURE and ELEMENTAL are F95 features, NOT F90
             'RESULT': Fortran90Lexer.RESULT,
             'INTENT': Fortran90Lexer.INTENT,
             'IN': Fortran90Lexer.IN,
@@ -219,7 +222,7 @@ class TestFortran90Lexer:
             'OPTIONAL': Fortran90Lexer.OPTIONAL,
             'PRESENT': Fortran90Lexer.PRESENT
         }
-        
+
         for keyword, expected_token in proc_keywords.items():
             tokens = self.get_tokens(keyword)
             assert len(tokens) >= 1

--- a/tests/Fortran95/test_fortran_95_features.py
+++ b/tests/Fortran95/test_fortran_95_features.py
@@ -105,14 +105,19 @@ class TestFortran95Parser:
         return parser
 
     def test_pure_and_elemental_procedures(self):
-        """PURE and ELEMENTAL procedure headers parse."""
+        """PURE and ELEMENTAL procedure headers parse.
+
+        NOTE: PURE and ELEMENTAL are Fortran 95 features (ISO/IEC 1539-1:1997),
+        NOT Fortran 90 features. They are parsed via function_stmt_f95 and
+        subroutine_stmt_f95 rules with prefix_f95 including PURE/ELEMENTAL.
+        """
         pure_fun = load_fixture(
             "Fortran95",
             "test_fortran_95_features",
             "pure_function_stmt.f90",
         )
         parser = self.create_parser_for_rule(pure_fun)
-        tree = parser.pure_function_stmt()
+        tree = parser.function_stmt_f95()
         assert tree is not None
         assert parser.getNumberOfSyntaxErrors() == 0
 
@@ -122,7 +127,7 @@ class TestFortran95Parser:
             "elemental_subroutine_stmt.f90",
         )
         parser = self.create_parser_for_rule(elemental_sub)
-        tree = parser.elemental_subroutine_stmt()
+        tree = parser.subroutine_stmt_f95()
         assert tree is not None
         assert parser.getNumberOfSyntaxErrors() == 0
 


### PR DESCRIPTION
## Summary

This PR enforces strict ISO standard compliance by moving PURE and ELEMENTAL keywords from Fortran 90 grammar to Fortran 95 where they belong per ISO/IEC 1539-1:1997. It also removes the square bracket array constructor `[ ... ]` from F90 as it is a Fortran 2003 feature per ISO/IEC 1539-1:2004.

- Move PURE, ELEMENTAL tokens from Fortran90Lexer.g4 to Fortran95Lexer.g4
- Remove LSQUARE, RSQUARE tokens from Fortran90Lexer.g4 (F2003 feature)
- Remove square bracket array constructor from Fortran90Parser.g4
- Add prefix_f95, prefix_spec_f95, function_stmt_f95, subroutine_stmt_f95 to F95 grammar
- Update tests to reflect correct standard attribution

## Verification

```
$ make test
...
======================= 642 passed, 65 xfailed in 35.82s =======================
```

All 642 tests pass. The changes ensure that:
1. F90 grammar only contains features from ISO/IEC 1539:1991
2. F95 grammar contains PURE/ELEMENTAL as required by ISO/IEC 1539-1:1997
3. Square bracket array constructors are only in F2003+ grammars