### PR TITLE
fix: add strict 1958 mode for FORTRAN II COMMON (fixes #156)

### DIFF
--- a/tests/fixtures/FORTRANII/test_strict_common/blank_common.f
+++ b/tests/fixtures/FORTRANII/test_strict_common/blank_common.f
@@ -1,0 +1,6 @@
+      SUBROUTINE CALC(A, B, C)
+      COMMON X, Y, Z
+      COMMON ARRAY(100)
+      C = A + B + X
+      RETURN
+      END

--- a/tests/fixtures/FORTRANII/test_strict_common/main_blank_common.f
+++ b/tests/fixtures/FORTRANII/test_strict_common/main_blank_common.f
@@ -1,0 +1,8 @@
+      COMMON A, B, C
+      COMMON ARR(10)
+      A = 1.0
+      B = 2.0
+      C = A + B
+      CALL OUTPUT(C)
+      STOP
+      END

--- a/tests/fixtures/FORTRANII/test_strict_common/named_common.f
+++ b/tests/fixtures/FORTRANII/test_strict_common/named_common.f
@@ -1,0 +1,6 @@
+      SUBROUTINE SHARE(A, B, C)
+      COMMON /DATA/ X, Y, Z
+      COMMON /WORK/ ARRAY(100)
+      C = A + B + X
+      RETURN
+      END


### PR DESCRIPTION
## Summary

This PR implements dual-mode COMMON handling for the FORTRAN II grammar, resolving issue #156:

- **Relaxed mode** (default): accepts both blank and named COMMON blocks for practical compatibility with later standards
- **Strict 1958 mode**: enforces blank COMMON only per C28-6000-2 specification

The 1958 IBM 704 FORTRAN II manual only defined blank COMMON (`COMMON a1, a2, ..., an`). Named COMMON blocks (`COMMON /BLOCK/ list`) were introduced in FORTRAN 66.

## Changes

### Grammar (`grammars/src/FORTRANIIParser.g4`)
- Add `common_stmt_strict` rule accepting only blank COMMON
- Add strict mode entry points: `fortran_program_strict`, `main_program_strict`, `subroutine_subprogram_strict`, `function_subprogram_strict`
- Add `statement_body_strict` and `statement_list_strict` for strict mode routing

### Tests (`tests/FORTRANII/test_fortran_ii_parser.py`)
- Add `TestStrictCommon` class with 10 tests validating:
  - Blank COMMON parses in both modes
  - Named COMMON parses in relaxed mode but fails in strict mode
  - Fixture-based tests for complete program units

### Fixtures (`tests/fixtures/FORTRANII/test_strict_common/`)
- `blank_common.f` - 1958-compliant subroutine with blank COMMON
- `named_common.f` - FORTRAN 66-style subroutine with named COMMON
- `main_blank_common.f` - Main program with blank COMMON

### Documentation (`docs/fortran_ii_audit.md`)
- Updated Section 4 with detailed dual-mode explanation
- Updated crosswalk table to show `common_stmt` and `common_stmt_strict`
- Updated summary to reflect resolved issue

## Test plan

- [x] All 658 tests pass (1 skipped, 64 expected XFAIL)
- [x] FORTRAN II tests: 26 passed including 10 new strict mode tests
- [x] Blank COMMON parses in both relaxed and strict modes
- [x] Named COMMON parses in relaxed mode only
- [x] Named COMMON fails with syntax errors in strict mode