### PR TITLE
polish: align FORTRAN II parse helper default entry rule (fixes #268)

### DIFF
--- a/tests/FORTRANII/test_fortran_ii_parser.py
+++ b/tests/FORTRANII/test_fortran_ii_parser.py
@@ -34,7 +34,7 @@ class TestFORTRANIIParser(unittest.TestCase):
         if FORTRANIIParser is None:
             self.skipTest("FORTRANIIParser not available - grammar not yet implemented")
     
-    def parse(self, text, rule_name='program_unit_core'):
+    def parse(self, text, rule_name):
         """Helper to parse text using specified rule"""
         input_stream = InputStream(text)
         lexer = FORTRANIILexer(input_stream)


### PR DESCRIPTION
## Summary

- Removed the obsolete default `rule_name='program_unit_core'` from the `parse` helper in `TestFORTRANIIParser`
- The grammar no longer defines `program_unit_core`; all callers already pass explicit rule names
- Aligns with `TestStrictCommon` which already requires explicit rule specification

## Verification

```
$ python -m pytest tests/FORTRANII/test_fortran_ii_parser.py -v
============================= test session starts ==============================
collected 26 items

tests/FORTRANII/test_fortran_ii_parser.py ... 26 passed in 0.07s
==============================

$ make test
================= 658 passed, 1 skipped, 64 xfailed in 35.21s ==================
```

All tests pass with no regressions.