### PR TITLE
polish: add READ n (format-only) to FORTRAN 1957 grammar (fixes #271)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -92,16 +92,17 @@ Mapping that Appendix‑B list to the current grammar:
 
 - **Formatted I/O (FORMAT, READ/WRITE variants, PRINT, PUNCH)**
   - Status:
-    - `READ n, list` and `READ list`: **implemented and tested.**
+    - `READ n, list`, `READ n`, and `READ list`: **implemented and tested.**
     - `PRINT n` and `PRINT n, list`: **implemented and tested.**
     - `PUNCH n` and `PUNCH n, list`: **implemented and tested.**
     - `FORMAT` statement: **token only, parser rule not implemented.**
     - Tape-specific forms: **not implemented.**
-  - Evidence: `read_stmt_basic` accepts both `READ label COMMA input_list`
-    (formatted) and `READ input_list` (simple). `print_stmt` and
-    `punch_stmt` rules implement `PRINT/PUNCH n [, list]` forms per
-    C28-6003 rows 28-29. `write_stmt_basic` accepts `WRITE output_list`.
-    The fixture `io_statements.f` now parses with zero errors.
+  - Evidence: `read_stmt_basic` accepts `READ label COMMA input_list`
+    (formatted with list), `READ label` (format-only per C28-6003 row 24),
+    and `READ input_list` (simple). `print_stmt` and `punch_stmt` rules
+    implement `PRINT/PUNCH n [, list]` forms per C28-6003 rows 28-29.
+    `write_stmt_basic` accepts `WRITE output_list`. The fixture
+    `io_statements.f` now parses with zero errors.
 
 - **Unformatted I/O (`READ TAPE`, `READ DRUM`, `WRITE TAPE`, `WRITE DRUM`)**
   - Status: **not implemented.**
@@ -175,8 +176,8 @@ Out-of-scope / not explicitly audited:
 
 Implemented (core subset):
 
-- `READ n, list` (formatted read) and `READ list` (simple read) via
-  `read_stmt_basic` rule.
+- `READ n, list` (formatted read with list), `READ n` (format-only read
+  per C28-6003 row 24), and `READ list` (simple read) via `read_stmt_basic`.
 - `PRINT n` and `PRINT n, list` (line printer output) via `print_stmt`.
 - `PUNCH n` and `PUNCH n, list` (card punch output) via `punch_stmt`.
 - `WRITE output_list` (simple output) via `write_stmt_basic`.
@@ -282,7 +283,7 @@ each Appendix B entry to the corresponding grammar rule(s) or notes gaps.
 | 21  | READ INPUT TAPE i, n, list    | Not implemented                | Gap: see #153   |
 | 22  | READ TAPE i, list             | Not implemented                | Gap: see #153   |
 | 23  | READ DRUM i, j, list          | Not implemented                | Gap: see #153   |
-| 24  | READ n                        | `read_stmt_basic` (via row 20) | Implemented     |
+| 24  | READ n                        | `read_stmt_basic`              | Implemented     |
 | 25  | WRITE OUTPUT TAPE i, n, list  | Not implemented                | Gap: see #153   |
 | 26  | WRITE TAPE i, list            | Not implemented                | Gap: see #153   |
 | 27  | WRITE DRUM i, j, list         | Not implemented                | Gap: see #153   |

--- a/grammars/src/FORTRANParser.g4
+++ b/grammars/src/FORTRANParser.g4
@@ -253,9 +253,12 @@ frequency_stmt
 
 // READ statement - Appendix B rows 20-24
 // C28-6003 Chapter III.A: READ n, list - read using format n
+// Row 20: READ n, list - formatted input with variable list
+// Row 24: READ n - formatted input with FORMAT-implied list
 // Simple form (READ list) also accepted for compatibility
 read_stmt_basic
-    : READ label COMMA input_list       // READ n, list (formatted)
+    : READ label COMMA input_list       // READ n, list (row 20, formatted)
+    | READ label                        // READ n (row 24, format-only)
     | READ input_list                   // READ list (simple form)
     ;
 

--- a/tests/FORTRAN/test_fortran_historical_stub.py
+++ b/tests/FORTRAN/test_fortran_historical_stub.py
@@ -273,14 +273,31 @@ class TestFORTRANHistoricalStub:
             "test_fortran_historical_stub",
             "io_statements.f",
         )
-        
+
         parser = self.create_parser(test_input)
-        
+
         try:
             tree = parser.program_unit_core()
             assert tree is not None
+            assert parser.getNumberOfSyntaxErrors() == 0
         except Exception as e:
             pytest.fail(f"I/O statement parsing failed: {e}")
+
+    def test_read_format_only_statement(self):
+        """Test parsing of READ n (format label only, no list).
+
+        Per IBM 704 FORTRAN manual (Form C28-6003, Oct 1958) Appendix B
+        row 24, READ n reads input using FORMAT statement n with
+        FORMAT-implied list of variables.
+        """
+        test_input = """        READ 100
+        READ 200
+        END
+"""
+        parser = self.create_parser(test_input)
+        tree = parser.program_unit_core()
+        assert tree is not None
+        assert parser.getNumberOfSyntaxErrors() == 0
 
     def test_frequency_statement(self):
         """Test parsing of FREQUENCY statement (unique optimization hint)."""

--- a/tests/fixtures/FORTRAN/test_fortran_historical_stub/io_statements.f
+++ b/tests/fixtures/FORTRAN/test_fortran_historical_stub/io_statements.f
@@ -1,5 +1,8 @@
         READ 100, A, B, C
+        READ 101
         PRINT 200, X, Y, Z
+        PRINT 201
         PUNCH 300, RESULT
+        PUNCH 301
         END
 


### PR DESCRIPTION
## Summary

- Add explicit `READ n` (format-only) alternative to `read_stmt_basic` per IBM C28-6003 Appendix B row 24
- Previously row 24 was claimed implemented via row 20, but the grammar only accepted `READ n, list`
- This adds the format-only form where the variable list is implied by the FORMAT statement

## Changes

- `grammars/src/FORTRANParser.g4`: Add `READ label` alternative to `read_stmt_basic`
- `tests/FORTRAN/test_fortran_historical_stub.py`: Add `test_read_format_only_statement` test
- `tests/fixtures/FORTRAN/test_fortran_historical_stub/io_statements.f`: Add format-only examples
- `docs/fortran_1957_audit.md`: Update documentation to reflect explicit implementation

## Verification

```
$ python -m pytest tests/FORTRAN/test_fortran_historical_stub.py -v
================= 41 passed in 0.06s =================

$ python -m pytest tests/ -v
================= 662 passed, 1 skipped, 61 xfailed in 33.98s ==================
```