### PR TITLE
fix: add FORMAT grammar and Hollerith constants to FORTRAN 1957 (fixes #154)

### DIFF
--- a/grammars/src/FORTRANIILexer.g4
+++ b/grammars/src/FORTRANIILexer.g4
@@ -57,13 +57,8 @@ COMMON       : C O M M O N ;
 // Statement labels are 1-5 digit integers (1-99999) placed in columns 1-5
 LABEL : [1-9] ([0-9] ([0-9] ([0-9] [0-9]?)?)?)? ;
 
-// ============================================================================
-// HOLLERITH CONSTANTS
-// C28-6000-2 Part I, Chapter 2 and Appendix A (FORMAT specification)
-// ============================================================================
-// Format: nHcharacters where n = number of characters following H
-// Used in FORMAT statements and I/O lists for literal text
-HOLLERITH : [1-9] [0-9]* H ~[\r\n]*? ;
+// Note: HOLLERITH constants are inherited from FORTRANLexer (1957).
+// Per IBM 704 manual C28-6003, Hollerith was present in original FORTRAN.
 
 // ============================================================================
 // SOURCE FORMAT

--- a/grammars/src/FORTRANIIParser.g4
+++ b/grammars/src/FORTRANIIParser.g4
@@ -339,27 +339,11 @@ punch_stmt
     : PUNCH integer_expr COMMA output_list
     ;
 
-// FORMAT statement - Appendix A: FORMAT (specification)
-// Defines I/O formatting layout
-format_stmt
-    : FORMAT LPAREN format_specification RPAREN
-    ;
-
-// Format specification items - Appendix A
-format_specification
-    : format_item (COMMA format_item)*
-    ;
-
-// Individual format items - Appendix A
-format_item
-    : INTEGER_LITERAL? format_descriptor  // e.g., I5, F10.2, E15.6
-    | HOLLERITH                          // e.g., 5HHELLO (literal text)
-    ;
-
-// Format descriptors (I, E, F, G, A, H, X, etc.)
-format_descriptor
-    : IDENTIFIER
-    ;
+// Note: FORMAT statement (format_stmt) is inherited from FORTRANParser.
+// The 1957 FORTRAN grammar includes FORMAT statements per C28-6003 Appendix B
+// row 16. FORMAT was part of the original IBM 704 FORTRAN specification.
+// See FORTRANParser.g4 for format_stmt, format_specification, format_item,
+// format_repeat_count, format_descriptor, and format_decimal_part rules.
 
 
 // ============================================================================

--- a/grammars/src/FORTRANLexer.g4
+++ b/grammars/src/FORTRANLexer.g4
@@ -121,6 +121,19 @@ COMMA        : ',' ;    // List separator - C28-6003 throughout
 COLON        : ':' ;    // Array slice notation (later standards)
 
 // ============================================================================
+// HOLLERITH CONSTANTS
+// C28-6003 Chapter III (Input-Output) and Appendix B row 16: FORMAT
+// ============================================================================
+// Format: nHcharacters where n = number of characters following H
+// Hollerith constants (nHtext) were the ONLY string-literal mechanism in 1957.
+// Used in FORMAT statements for literal text output.
+// Example: 5HHELLO, 10HRESULT IS:
+// Note: This pattern greedily matches nH followed by any characters up to
+// a comma, right paren, or end of line - the typical delimiters in FORMAT
+// specifications. Strict length-count semantics would require a semantic check.
+HOLLERITH : [1-9] [0-9]* H ~[,)\r\n]* ;
+
+// ============================================================================
 // LITERALS: Numbers and identifiers
 // C28-6003 Chapter II.A (Constants) and Chapter II.B (Variables)
 // ============================================================================

--- a/grammars/src/FORTRANParser.g4
+++ b/grammars/src/FORTRANParser.g4
@@ -69,6 +69,7 @@ statement_body
     | sense_light_stmt              // Appendix B row 11: SENSE LIGHT i
     | do_stmt_basic                 // Appendix B row 18: DO n i = m1,m2,m3
     | frequency_stmt                // Appendix B row 13: FREQUENCY n(i,j,...)
+    | format_stmt                   // Appendix B row 16: FORMAT (specification)
     | read_stmt_basic               // Appendix B rows 20-24: READ forms
     | write_stmt_basic              // Appendix B rows 25-27: WRITE forms
     | print_stmt                    // Appendix B row 28: PRINT n, list
@@ -280,6 +281,59 @@ print_stmt
 // List may be omitted per manual row 29 variant
 punch_stmt
     : PUNCH label (COMMA output_list)?
+    ;
+
+// ============================================================================
+// FORMAT STATEMENT
+// C28-6003 Chapter III (Input-Output) and Appendix B row 16
+// ============================================================================
+// The FORMAT statement defines the layout for formatted I/O operations.
+// Form: FORMAT (format-specification)
+// Edit descriptors include:
+//   Iw       - Integer (w = field width)
+//   Fw.d     - Real fixed-point (w = width, d = decimal places)
+//   Ew.d     - Real exponential (w = width, d = decimal places)
+//   nX       - Skip n positions
+//   nHtext   - Hollerith literal (n characters of text)
+//
+// FORMAT statements are non-executable and must have a statement label
+// so they can be referenced by READ, PRINT, PUNCH statements.
+// ============================================================================
+
+format_stmt
+    : FORMAT LPAREN format_specification RPAREN
+    ;
+
+// Format specification items - C28-6003 Chapter III
+format_specification
+    : format_item (COMMA format_item)*
+    ;
+
+// Individual format items - C28-6003 Chapter III
+// Note: This grammar accepts a simplified form where format descriptors
+// are matched as IDENTIFIER tokens (e.g., I5, F10) and Hollerith constants
+// are matched as HOLLERITH tokens.
+format_item
+    : format_repeat_count? format_descriptor  // e.g., 3I5, F10.2, E15.6
+    | HOLLERITH                               // e.g., 5HHELLO (literal text)
+    ;
+
+// Optional repeat count before format descriptor
+format_repeat_count
+    : INTEGER_LITERAL
+    ;
+
+// Format descriptor with optional decimal specification
+// C28-6003: I, F, E descriptors with field width and decimal places
+// Note: The lexer tokenizes F10.2 as IDENTIFIER (F10) followed by
+// REAL_LITERAL (.2). This rule matches both forms.
+format_descriptor
+    : IDENTIFIER format_decimal_part?
+    ;
+
+// Decimal part of format descriptor (e.g., .d in Fw.d)
+format_decimal_part
+    : REAL_LITERAL
     ;
 
 


### PR DESCRIPTION
## Summary
- Add `HOLLERITH` token to FORTRANLexer.g4 to recognize `nHtext` format string literals
- Add `format_stmt` parser rule with support for edit descriptors (Iw, Fw.d, Ew.d), repeat counts, and Hollerith constants
- Remove duplicate rules from FORTRAN II grammars (now inherited from FORTRAN I)
- Update tests to assert zero syntax errors for FORMAT statement parsing
- Update docs/fortran_1957_audit.md to reflect implementation status

## Verification
```
$ python -m pytest tests/ -v 2>&1 | tail -3
================= 663 passed, 1 skipped, 61 xfailed in 35.88s ==================
```

FORMAT parsing test:
```python
>>> code = '''100     FORMAT (I5, F10.2, E15.6, 5HHELLO)
        END
'''
>>> parser.getNumberOfSyntaxErrors()
0
```

## Test plan
- [x] All 663 tests pass
- [x] FORMAT statements parse with zero syntax errors
- [x] HOLLERITH tokens are correctly recognized by lexer
- [x] Grammars regenerate without errors (only warnings)
- [x] Audit documentation updated to reflect implementation