### PR TITLE
fix: handle FORMAT E-descriptor with repeat count in FORTRAN 1957 (fixes #141)

### DIFF
--- a/tests/xpass_fixtures.py
+++ b/tests/xpass_fixtures.py
@@ -218,60 +218,28 @@ XPASS_FIXTURES: Dict[Tuple[str, Path], str] = {
     # dialects are intentionally limited and do not yet have dedicated
     # GitHub issues for full historical coverage; the XPASS entries
     # simply document the expected rough edges.
+    #
+    # Note: Several FORTRAN 1957 fixtures (array_program_1957.f, format_stmt.f,
+    # format_tests_1957.f, historical_quadratic_program.f, io_operations_1957.f)
+    # now parse correctly after the FORMAT E-descriptor grammar fix (issue #141)
+    # and are no longer marked as XPASS.
     (
         "FORTRAN",
         Path("FORTRAN/test_comprehensive_validation/complex_program.f"),
     ): (
-        "Historical FORTRAN complex-program fixture {relpath} goes beyond the "
-        "simplified FORTRAN grammar and currently reports {errors} syntax "
-        "errors; this is a known limitation rather than a hard failure."
-    ),
-    (
-        "FORTRAN",
-        Path("FORTRAN/test_fortran_historical_stub/array_program_1957.f"),
-    ): (
-        "Historical FORTRAN 1957 array-program fixture {relpath} exercises "
-        "more of the original language than the simplified grammar accepts; "
-        "it is expected to report {errors} syntax errors here."
+        "Historical FORTRAN complex-program fixture {relpath} uses CALL "
+        "statements which were introduced in FORTRAN II (1958), not in the "
+        "1957 grammar. It is expected to report {errors} syntax errors with "
+        "the FORTRAN 1957 parser."
     ),
     (
         "FORTRAN",
         Path("FORTRAN/test_fortran_historical_stub/authentic_1957_program.f"),
     ): (
-        "Historical FORTRAN authentic-1957 program fixture {relpath} exceeds "
-        "the current stub grammar and currently yields {errors} syntax errors."
-    ),
-    (
-        "FORTRAN",
-        Path("FORTRAN/test_fortran_historical_stub/format_stmt.f"),
-    ): (
-        "Historical FORTRAN FORMAT-statement fixture {relpath} remains beyond "
-        "the scope of the simplified FORMAT grammar and reports {errors} "
-        "syntax errors."
-    ),
-    (
-        "FORTRAN",
-        Path("FORTRAN/test_fortran_historical_stub/format_tests_1957.f"),
-    ): (
-        "Historical FORTRAN 1957 FORMAT test fixture {relpath} intentionally "
-        "stretches the FORMAT grammar and still produces {errors} syntax "
-        "errors."
-    ),
-    (
-        "FORTRAN",
-        Path("FORTRAN/test_fortran_historical_stub/historical_quadratic_program.f"),
-    ): (
-        "Historical FORTRAN quadratic-program fixture {relpath} is more "
-        "complex than the stub grammar supports and is expected to yield "
-        "{errors} syntax errors."
-    ),
-    (
-        "FORTRAN",
-        Path("FORTRAN/test_fortran_historical_stub/io_operations_1957.f"),
-    ): (
-        "Historical FORTRAN I/O-operations fixture {relpath} exercises "
-        "1957-era I/O patterns beyond the simplified grammar and reports "
-        "{errors} syntax errors."
+        "Historical FORTRAN authentic-1957 program fixture {relpath} uses "
+        "column-1 C comments which are not yet supported in the layout-lenient "
+        "1957 lexer (see issue #155 for strict fixed-form mode). It currently "
+        "yields {errors} syntax errors."
     ),
     # FORTRAN II fixtures have been updated to parse correctly with the
     # enhanced grammar and fortran_program entry rule per issue #157.


### PR DESCRIPTION
## Summary

- Add `format_e_descriptor` parser rule to FORTRAN 1957 grammar to handle E-format descriptors with repeat counts (e.g., `2E15.6`)
- The lexer tokenizes sequences like `2E15` as `REAL_LITERAL` (scientific notation), which prevented parsing FORMAT statements containing E descriptors with repeat counts
- This grammar change allows the parser to correctly interpret such tokens within FORMAT specifications

## Changes

1. **grammars/src/FORTRANParser.g4**: Added `format_e_descriptor` rule that accepts `REAL_LITERAL format_decimal_part?` for E-format descriptors
2. **tests/xpass_fixtures.py**: Removed 5 XPASS entries for FORTRAN 1957 fixtures that now parse correctly:
   - `array_program_1957.f`
   - `format_stmt.f`
   - `format_tests_1957.f`
   - `historical_quadratic_program.f`
   - `io_operations_1957.f`

## Verification

```
$ make test
================= 668 passed, 1 skipped, 56 xfailed in 35.46s ==================
```

Before fix: 663 passed, 61 xfailed
After fix: 668 passed, 56 xfailed (+5 passing, -5 xfailed)

Tested parsing of affected fixtures:
```
$ python -c "..."
tests/fixtures/FORTRAN/test_fortran_historical_stub/io_operations_1957.f: 0 errors
tests/fixtures/FORTRAN/test_fortran_historical_stub/format_stmt.f: 0 errors
tests/fixtures/FORTRAN/test_fortran_historical_stub/format_tests_1957.f: 0 errors
```

## Test plan

- [x] All 668 tests pass
- [x] Previously XPASS fixtures now parse without errors
- [x] No regressions in other FORTRAN standard parsers (FORTRAN II through Fortran 2023)
