### PR TITLE
feat: add strict fixed-form mode for FORTRAN II (fixes #143)

### DIFF
--- a/docs/fixed_form_support.md
+++ b/docs/fixed_form_support.md
@@ -65,9 +65,44 @@ every vendor implementation.
     and an optional `NEWLINE`, reflecting the punch‑card structure.
   - Layout is still **logical**, not column‑sensitive; any indentation
     that keeps tokens in the right order is accepted.
-  - Column‑1 `C`/`*` comments and strict label column ranges are not
-    enforced; code relying on those details may fall outside the
-    supported subset.
+
+#### Strict Fixed-Form Mode (tools/strict_fixed_form.py)
+
+FORTRAN II now provides an optional **strict fixed-form preprocessor** that
+validates and converts IBM 704 card-image source files according to the
+C28-6000-2 (1958) specification:
+
+- **Card layout validation** per C28-6000-2 Part I, Chapter 2:
+  - Columns 1–5: Statement labels (numeric 1–99999 or blank)
+  - Column 6: Continuation mark (non-blank = continuation)
+  - Columns 7–72: Statement text
+  - Columns 73–80: Sequence/identification field (ignored)
+  - Column 1: `C` or `*` marks a comment card
+
+- **Usage**:
+  ```python
+  from tools.strict_fixed_form import validate_strict_fixed_form, convert_to_lenient
+
+  # Validate strict card layout
+  result = validate_strict_fixed_form(source)
+  if not result.valid:
+      for error in result.errors:
+          print(f"Line {error.line_number}: {error.message}")
+
+  # Convert to layout-lenient form for parsing
+  lenient, result = convert_to_lenient(source, strip_comments=True)
+  ```
+
+- **Test fixtures** in `tests/fixtures/FORTRANII/test_strict_fixed_form/`:
+  - `valid_subroutine.f`, `valid_function.f`, `valid_main.f`: Authentic
+    80-column card layouts with sequence numbers
+  - `valid_continuation.f`: Multi-card statement continuations
+  - `invalid_label_alpha.f`, `invalid_continuation_labeled.f`: Invalid
+    layouts that strict mode correctly rejects
+
+The strict mode preprocessor enables historical audits requiring exact
+card-image conformance while keeping the lenient grammar parsing mode
+available for modern tooling.
 
 ### 2.3 FORTRAN 66 (1966) and FORTRAN 77 (1977)
 

--- a/tests/FORTRANII/test_strict_fixed_form.py
+++ b/tests/FORTRANII/test_strict_fixed_form.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+Test suite for strict fixed-form card layout semantics for FORTRAN II.
+
+Tests the StrictFixedFormProcessor against authentic IBM 704 card-image
+source files per C28-6000-2 (1958).
+
+Reference: IBM FORTRAN II for the IBM 704 Data Processing System
+           (Form C28-6000-2, 1958) Part I, Chapter 2
+"""
+
+import sys
+import os
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT.parent / "tools"))
+sys.path.insert(0, str(ROOT))
+
+try:
+    from strict_fixed_form import (
+        StrictFixedFormProcessor,
+        validate_strict_fixed_form,
+        convert_to_lenient,
+        CardType,
+        Card,
+    )
+    PROCESSOR_AVAILABLE = True
+except ImportError as e:
+    print(f"Import error: {e}")
+    PROCESSOR_AVAILABLE = False
+
+try:
+    from fixture_utils import load_fixture
+except ImportError:
+    def load_fixture(standard, test_name, fixture_name):
+        fixture_path = ROOT / "fixtures" / standard / test_name / fixture_name
+        with open(fixture_path, "r") as f:
+            return f.read()
+
+
+class TestCardParsing(unittest.TestCase):
+    """Test individual card parsing per C28-6000-2 Chapter 2."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+        self.processor = StrictFixedFormProcessor()
+
+    def test_blank_card(self):
+        """Test blank card recognition."""
+        card = self.processor.parse_card("", 1)
+        self.assertEqual(card.card_type, CardType.BLANK)
+        self.assertIsNone(card.label)
+        self.assertFalse(card.continuation)
+
+    def test_comment_card_c(self):
+        """Test C-comment card (column 1 = C)."""
+        card = self.processor.parse_card(
+            "C     THIS IS A COMMENT                                    ", 1
+        )
+        self.assertEqual(card.card_type, CardType.COMMENT)
+
+    def test_comment_card_star(self):
+        """Test *-comment card (column 1 = *)."""
+        card = self.processor.parse_card(
+            "*     THIS IS ALSO A COMMENT                               ", 1
+        )
+        self.assertEqual(card.card_type, CardType.COMMENT)
+
+    def test_statement_card_no_label(self):
+        """Test statement card without label."""
+        card = self.processor.parse_card(
+            "      X = 1.0                                               ", 1
+        )
+        self.assertEqual(card.card_type, CardType.STATEMENT)
+        self.assertIsNone(card.label)
+        self.assertFalse(card.continuation)
+        self.assertIn("X = 1.0", card.statement_text)
+
+    def test_statement_card_with_label(self):
+        """Test statement card with label in columns 1-5."""
+        card = self.processor.parse_card(
+            "  100 CONTINUE                                              ", 1
+        )
+        self.assertEqual(card.card_type, CardType.STATEMENT)
+        self.assertEqual(card.label, "100")
+        self.assertFalse(card.continuation)
+        self.assertIn("CONTINUE", card.statement_text)
+
+    def test_continuation_card(self):
+        """Test continuation card (column 6 non-blank)."""
+        card = self.processor.parse_card(
+            "     1                    G, H, I)                          ", 1
+        )
+        self.assertEqual(card.card_type, CardType.CONTINUATION)
+        self.assertTrue(card.continuation)
+        self.assertIsNone(card.label)
+
+    def test_sequence_field_extraction(self):
+        """Test extraction of sequence field (columns 73-80)."""
+        line = "      X = 1.0                                                           00000010"
+        card = self.processor.parse_card(line, 1)
+        self.assertEqual(card.sequence_field, "00000010")
+
+    def test_column_field_accessors(self):
+        """Test column field accessor properties."""
+        line = "  100 X = Y                                                             00000020"
+        card = self.processor.parse_card(line, 1)
+        self.assertEqual(card.column_1_5, "  100")
+        self.assertEqual(card.column_6, " ")
+        self.assertIn("X = Y", card.column_7_72)
+        self.assertEqual(card.column_73_80, "00000020")
+
+
+class TestValidation(unittest.TestCase):
+    """Test validation of card sequences per C28-6000-2 rules."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+        self.processor = StrictFixedFormProcessor()
+
+    def test_valid_simple_program(self):
+        """Test validation of valid simple program."""
+        source = """\
+C     SIMPLE PROGRAM
+      X = 1.0
+      END
+"""
+        result = validate_strict_fixed_form(source)
+        self.assertTrue(result.valid)
+        self.assertEqual(len(result.errors), 0)
+
+    def test_invalid_label_alphabetic(self):
+        """Test detection of alphabetic characters in label field."""
+        source = """\
+ABCDE X = 1.0
+      END
+"""
+        result = validate_strict_fixed_form(source)
+        self.assertFalse(result.valid)
+        self.assertTrue(any("label" in e.message.lower() for e in result.errors))
+
+    def test_invalid_continuation_with_label(self):
+        """Test detection of label on continuation card."""
+        # Line 2 has label 10 in cols 1-5 and 1 in col 6 (continuation mark)
+        # This is invalid: continuation cards must have blank cols 1-5
+        source = """\
+      SUBROUTINE TEST(A, B,
+   101               C, D)
+      END
+"""
+        result = validate_strict_fixed_form(source)
+        self.assertFalse(result.valid)
+        self.assertTrue(
+            any("continuation" in e.message.lower() and "label" in e.message.lower()
+                for e in result.errors)
+        )
+
+    def test_invalid_continuation_first_card(self):
+        """Test detection of continuation as first card."""
+        source = """\
+     1 X = Y
+      END
+"""
+        result = validate_strict_fixed_form(source)
+        self.assertFalse(result.valid)
+        self.assertTrue(
+            any("first" in e.message.lower() and "continuation" in e.message.lower()
+                for e in result.errors)
+        )
+
+    def test_label_range_validation(self):
+        """Test label range (1-99999) validation."""
+        valid_labels = ["1", "99999", "100", "12345"]
+        for label in valid_labels:
+            source = f"{label:>5} CONTINUE\n      END\n"
+            result = validate_strict_fixed_form(source)
+            with self.subTest(label=label):
+                self.assertTrue(result.valid, f"Label {label} should be valid")
+
+
+class TestLenientConversion(unittest.TestCase):
+    """Test conversion from strict to lenient format."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+        self.processor = StrictFixedFormProcessor()
+
+    def test_comment_conversion(self):
+        """Test C-comments converted to !-comments."""
+        source = """\
+C     THIS IS A COMMENT
+      END
+"""
+        lenient, _ = convert_to_lenient(source)
+        self.assertIn("!", lenient)
+        self.assertNotIn("C     ", lenient.split("\n")[0])
+
+    def test_label_preservation(self):
+        """Test statement labels preserved in lenient form."""
+        source = """\
+  100 CONTINUE
+      END
+"""
+        lenient, _ = convert_to_lenient(source)
+        self.assertIn("100", lenient)
+        self.assertIn("CONTINUE", lenient)
+
+    def test_continuation_joining(self):
+        """Test continuation cards joined into single statements."""
+        source = """\
+      X = A + B +
+     1    C + D
+      END
+"""
+        lenient, _ = convert_to_lenient(source)
+        lines = [l for l in lenient.split("\n") if l.strip() and not l.startswith("!")]
+        stmt_line = lines[0]
+        self.assertIn("A + B +", stmt_line)
+        self.assertIn("C + D", stmt_line)
+
+    def test_sequence_field_stripped(self):
+        """Test sequence numbers (cols 73-80) stripped."""
+        source = """\
+      X = 1.0                                                           00000010
+      END                                                               00000020
+"""
+        lenient, _ = convert_to_lenient(source)
+        self.assertNotIn("00000010", lenient)
+        self.assertNotIn("00000020", lenient)
+
+
+class TestFixtures(unittest.TestCase):
+    """Test parsing of strict fixed-form fixtures."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+
+    def test_valid_subroutine_fixture(self):
+        """Test valid_subroutine.f fixture validates."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "valid_subroutine.f"
+        )
+        result = validate_strict_fixed_form(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_valid_function_fixture(self):
+        """Test valid_function.f fixture validates."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "valid_function.f"
+        )
+        result = validate_strict_fixed_form(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_valid_main_fixture(self):
+        """Test valid_main.f fixture validates."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "valid_main.f"
+        )
+        result = validate_strict_fixed_form(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_valid_continuation_fixture(self):
+        """Test valid_continuation.f fixture validates."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "valid_continuation.f"
+        )
+        result = validate_strict_fixed_form(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_star_comment_fixture(self):
+        """Test star_comment.f fixture validates."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "star_comment.f"
+        )
+        result = validate_strict_fixed_form(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_invalid_label_alpha_fixture(self):
+        """Test invalid_label_alpha.f fixture fails validation."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "invalid_label_alpha.f"
+        )
+        result = validate_strict_fixed_form(source)
+        self.assertFalse(result.valid)
+
+    def test_invalid_continuation_labeled_fixture(self):
+        """Test invalid_continuation_labeled.f fixture fails validation."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "invalid_continuation_labeled.f"
+        )
+        result = validate_strict_fixed_form(source)
+        self.assertFalse(result.valid)
+
+
+class TestIntegrationWithParser(unittest.TestCase):
+    """Test that converted lenient output parses with FORTRANIIParser."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+
+        sys.path.insert(0, str(ROOT.parent / "grammars/generated/early"))
+        try:
+            from antlr4 import InputStream, CommonTokenStream
+            from FORTRANIILexer import FORTRANIILexer
+            from FORTRANIIParser import FORTRANIIParser
+            self.InputStream = InputStream
+            self.CommonTokenStream = CommonTokenStream
+            self.FORTRANIILexer = FORTRANIILexer
+            self.FORTRANIIParser = FORTRANIIParser
+            self.parser_available = True
+        except ImportError:
+            self.parser_available = False
+
+    def parse_lenient(self, source):
+        """Parse lenient-form source with FORTRANIIParser."""
+        if not self.parser_available:
+            self.skipTest("FORTRANIIParser not available")
+
+        input_stream = self.InputStream(source)
+        lexer = self.FORTRANIILexer(input_stream)
+        token_stream = self.CommonTokenStream(lexer)
+        parser = self.FORTRANIIParser(token_stream)
+        return parser
+
+    def test_converted_subroutine_parses(self):
+        """Test converted valid_subroutine.f parses."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "valid_subroutine.f"
+        )
+        lenient, result = convert_to_lenient(source, strip_comments=True)
+        self.assertTrue(result.valid)
+
+        if self.parser_available:
+            parser = self.parse_lenient(lenient)
+            tree = parser.subroutine_subprogram()
+            self.assertEqual(parser.getNumberOfSyntaxErrors(), 0)
+            self.assertIn("SWAP", tree.getText())
+
+    def test_converted_function_parses(self):
+        """Test converted valid_function.f parses."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "valid_function.f"
+        )
+        lenient, result = convert_to_lenient(source, strip_comments=True)
+        self.assertTrue(result.valid)
+
+        if self.parser_available:
+            parser = self.parse_lenient(lenient)
+            tree = parser.function_subprogram()
+            self.assertEqual(parser.getNumberOfSyntaxErrors(), 0)
+            self.assertIn("MAX", tree.getText())
+
+    def test_converted_main_parses(self):
+        """Test converted valid_main.f parses."""
+        source = load_fixture(
+            "FORTRANII", "test_strict_fixed_form", "valid_main.f"
+        )
+        lenient, result = convert_to_lenient(source, strip_comments=True)
+        self.assertTrue(result.valid)
+
+        if self.parser_available:
+            parser = self.parse_lenient(lenient)
+            tree = parser.main_program()
+            self.assertEqual(parser.getNumberOfSyntaxErrors(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/fixtures/FORTRANII/test_strict_fixed_form/invalid_continuation_labeled.f
+++ b/tests/fixtures/FORTRANII/test_strict_fixed_form/invalid_continuation_labeled.f
@@ -1,0 +1,5 @@
+C     INVALID: CONTINUATION CARD WITH LABEL                            00000010
+C     Per C28-6000-2: continuation cards must have blank cols 1-5      00000020
+      SUBROUTINE TEST(A, B,                                             00000030
+   101                C, D)                                             00000040
+      END                                                               00000050

--- a/tests/fixtures/FORTRANII/test_strict_fixed_form/invalid_label_alpha.f
+++ b/tests/fixtures/FORTRANII/test_strict_fixed_form/invalid_label_alpha.f
@@ -1,0 +1,3 @@
+C     INVALID: ALPHABETIC CHARACTERS IN LABEL FIELD (COLS 1-5)         00000010
+ABCDE DIMENSION X(10)                                                   00000020
+      END                                                               00000030

--- a/tests/fixtures/FORTRANII/test_strict_fixed_form/star_comment.f
+++ b/tests/fixtures/FORTRANII/test_strict_fixed_form/star_comment.f
@@ -1,0 +1,7 @@
+*     FORTRAN II STAR-COMMENT EXAMPLE                                  00000010
+*     Some implementations used * instead of C for comments            00000020
+      SUBROUTINE DEMO                                                   00000030
+*     THIS IS A COMMENT WITH ASTERISK                                  00000040
+      X = 1.0                                                           00000050
+      RETURN                                                            00000060
+      END                                                               00000070

--- a/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_continuation.f
+++ b/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_continuation.f
@@ -1,0 +1,14 @@
+C     FORTRAN II CONTINUATION CARD EXAMPLE                             00000010
+C     Column 6 non-blank marks continuation (here using digits 1-9)    00000020
+      SUBROUTINE LONGCALC(A, B, C, D, E, F,                             00000030
+     1                    G, H, I, J, K, L)                             00000040
+C     DEMONSTRATES CONTINUATION ACROSS MULTIPLE CARDS                  00000050
+      RESULT = A + B + C + D + E + F +                                  00000060
+     1         G + H + I + J + K + L                                    00000070
+C     LONG EXPRESSION WITH MULTIPLE CONTINUATIONS                      00000080
+      TOTAL = A * B * C *                                               00000090
+     1        D * E * F *                                               00000100
+     2        G * H * I *                                               00000110
+     3        J * K * L                                                 00000120
+      RETURN                                                            00000130
+      END                                                               00000140

--- a/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_function.f
+++ b/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_function.f
@@ -1,0 +1,10 @@
+C     FORTRAN II FUNCTION - STRICT 80-COLUMN CARD FORMAT               00000010
+C     Reference: IBM C28-6000-2 (1958) Part I, Chapter 3, Sec 3.3      00000020
+      FUNCTION MAX(A, B)                                                00000030
+C     RETURN THE MAXIMUM OF TWO VALUES                                 00000040
+      IF (A - B) 10, 20, 20                                             00000050
+   10 MAX = B                                                           00000060
+      RETURN                                                            00000070
+   20 MAX = A                                                           00000080
+      RETURN                                                            00000090
+      END                                                               00000100

--- a/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_main.f
+++ b/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_main.f
@@ -1,0 +1,19 @@
+C     FORTRAN II MAIN PROGRAM - STRICT 80-COLUMN CARD FORMAT           00000010
+C     Reference: IBM C28-6000-2 (1958)                                 00000020
+C     DEMONSTRATES: COMMON, ARITHMETIC IF, GOTO, FORMAT                00000030
+      COMMON A, B, RESULT                                               00000040
+      A = 1.0                                                           00000050
+      B = 2.0                                                           00000060
+C     COMPUTE SUM OF SQUARES                                           00000080
+      RESULT = A * A + B * B                                            00000090
+C     TEST ARITHMETIC IF                                               00000100
+      IF (RESULT - 5.0) 10, 20, 30                                      00000110
+   10 PRINT 100, RESULT                                                 00000120
+      GOTO 40                                                           00000130
+   20 PRINT 100, RESULT                                                 00000140
+      GOTO 40                                                           00000150
+   30 PRINT 100, RESULT                                                 00000160
+   40 CONTINUE                                                          00000170
+  100 FORMAT (6HRESULT, F10.4)                                          00000180
+      STOP                                                              00000190
+      END                                                               00000200

--- a/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_subroutine.f
+++ b/tests/fixtures/FORTRANII/test_strict_fixed_form/valid_subroutine.f
@@ -1,0 +1,11 @@
+C     FORTRAN II SUBROUTINE - STRICT 80-COLUMN CARD FORMAT             00000010
+C     Reference: IBM C28-6000-2 (1958) Part I, Chapter 2               00000020
+C     Columns: 1-5=label, 6=continuation, 7-72=statement, 73-80=seq    00000030
+      SUBROUTINE SWAP(X, Y)                                             00000040
+C     SWAP TWO REAL VALUES USING A TEMPORARY VARIABLE                  00000050
+C     Note: FORTRAN II uses implicit typing (I-N integer, else real)   00000060
+      TEMP = X                                                          00000070
+      X = Y                                                             00000080
+      Y = TEMP                                                          00000090
+      RETURN                                                            00000100
+      END                                                               00000110

--- a/tests/xpass_fixtures.py
+++ b/tests/xpass_fixtures.py
@@ -244,6 +244,74 @@ XPASS_FIXTURES: Dict[Tuple[str, Path], str] = {
     # FORTRAN II fixtures have been updated to parse correctly with the
     # enhanced grammar and fortran_program entry rule per issue #157.
     # They are no longer marked as XPASS.
+    #
+    # FORTRAN II strict fixed-form fixtures require preprocessing via
+    # tools/strict_fixed_form.py before parsing; they use authentic IBM 704
+    # card-image format which the layout-lenient grammar does not support
+    # directly. These are tested by tests/FORTRANII/test_strict_fixed_form.py.
+    (
+        "FORTRANII",
+        Path("FORTRANII/test_strict_fixed_form/valid_subroutine.f"),
+    ): (
+        "FORTRAN II strict fixed-form fixture {relpath} uses authentic "
+        "80-column IBM 704 card layout with sequence numbers in cols 73-80 and "
+        "C-comments in col 1. It requires preprocessing via "
+        "tools/strict_fixed_form.py before parsing. It produces {errors} syntax "
+        "errors when parsed directly (Issue #143)."
+    ),
+    (
+        "FORTRANII",
+        Path("FORTRANII/test_strict_fixed_form/valid_function.f"),
+    ): (
+        "FORTRAN II strict fixed-form fixture {relpath} uses authentic "
+        "80-column IBM 704 card layout. It requires preprocessing via "
+        "tools/strict_fixed_form.py. It produces {errors} syntax errors when "
+        "parsed directly (Issue #143)."
+    ),
+    (
+        "FORTRANII",
+        Path("FORTRANII/test_strict_fixed_form/valid_main.f"),
+    ): (
+        "FORTRAN II strict fixed-form fixture {relpath} uses authentic "
+        "80-column IBM 704 card layout. It requires preprocessing via "
+        "tools/strict_fixed_form.py. It produces {errors} syntax errors when "
+        "parsed directly (Issue #143)."
+    ),
+    (
+        "FORTRANII",
+        Path("FORTRANII/test_strict_fixed_form/valid_continuation.f"),
+    ): (
+        "FORTRAN II strict fixed-form fixture {relpath} demonstrates "
+        "continuation cards with col 6 marks. It requires preprocessing via "
+        "tools/strict_fixed_form.py. It produces {errors} syntax errors when "
+        "parsed directly (Issue #143)."
+    ),
+    (
+        "FORTRANII",
+        Path("FORTRANII/test_strict_fixed_form/star_comment.f"),
+    ): (
+        "FORTRAN II strict fixed-form fixture {relpath} uses *-comments in "
+        "col 1. It requires preprocessing via tools/strict_fixed_form.py. "
+        "It produces {errors} syntax errors when parsed directly (Issue #143)."
+    ),
+    (
+        "FORTRANII",
+        Path("FORTRANII/test_strict_fixed_form/invalid_label_alpha.f"),
+    ): (
+        "FORTRAN II strict fixed-form negative fixture {relpath} has "
+        "intentionally invalid alphabetic label field. It is expected to fail "
+        "both strict validation and direct parsing. It produces {errors} syntax "
+        "errors (Issue #143)."
+    ),
+    (
+        "FORTRANII",
+        Path("FORTRANII/test_strict_fixed_form/invalid_continuation_labeled.f"),
+    ): (
+        "FORTRAN II strict fixed-form negative fixture {relpath} has "
+        "intentionally invalid label on continuation card. It is expected to "
+        "fail strict validation. It produces {errors} syntax errors when parsed "
+        "directly (Issue #143)."
+    ),
     # FORTRAN 66 fixtures have been updated to parse correctly with the
     # enhanced grammar per issue #144. They are no longer marked as XPASS.
     # FORTRAN 77 multi-unit fixtures require fortran66_program entry rule

--- a/tools/strict_fixed_form.py
+++ b/tools/strict_fixed_form.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+Strict fixed-form preprocessor for FORTRAN II (1958).
+
+This module provides validation and transformation of strict IBM 704 card-image
+source files according to the FORTRAN II manual (Form C28-6000-2, 1958).
+
+Card layout per C28-6000-2 Part I, Chapter 2 (Coding for FORTRAN II):
+- Columns 1-5:  Statement labels (1-99999, right-justified)
+- Column 6:     Continuation mark (non-blank = continuation)
+- Columns 7-72: Statement text
+- Columns 73-80: Sequence/identification field (ignored)
+- Column 1:     C or * marks a comment card
+
+The preprocessor validates card layout and produces layout-lenient output
+suitable for parsing by FORTRANIIParser.
+
+Reference: IBM FORTRAN II for the IBM 704 Data Processing System
+           (Form C28-6000-2, 1958)
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, Tuple
+
+
+class CardType(Enum):
+    """Card classification per C28-6000-2."""
+    BLANK = "blank"
+    COMMENT = "comment"
+    STATEMENT = "statement"
+    CONTINUATION = "continuation"
+
+
+@dataclass
+class Card:
+    """Represents a single 80-column punch card image."""
+    line_number: int
+    raw_text: str
+    card_type: CardType
+    label: Optional[str]
+    continuation: bool
+    statement_text: str
+    sequence_field: str
+
+    @property
+    def column_1_5(self) -> str:
+        """Label field (columns 1-5)."""
+        return self.raw_text[:5] if len(self.raw_text) >= 5 else self.raw_text.ljust(5)
+
+    @property
+    def column_6(self) -> str:
+        """Continuation field (column 6)."""
+        return self.raw_text[5] if len(self.raw_text) > 5 else " "
+
+    @property
+    def column_7_72(self) -> str:
+        """Statement field (columns 7-72)."""
+        if len(self.raw_text) <= 6:
+            return ""
+        return self.raw_text[6:72] if len(self.raw_text) > 72 else self.raw_text[6:]
+
+    @property
+    def column_73_80(self) -> str:
+        """Sequence field (columns 73-80)."""
+        return self.raw_text[72:80] if len(self.raw_text) > 72 else ""
+
+
+@dataclass
+class ValidationError:
+    """Validation error with location and message."""
+    line_number: int
+    column: int
+    message: str
+    severity: str = "error"
+
+
+@dataclass
+class ValidationResult:
+    """Result of strict fixed-form validation."""
+    valid: bool
+    errors: List[ValidationError]
+    warnings: List[ValidationError]
+    cards: List[Card]
+
+
+class StrictFixedFormProcessor:
+    """
+    Validates and processes strict IBM 704 fixed-form FORTRAN II source.
+
+    C28-6000-2 Chapter 2 defines the card layout:
+    - Each card has 80 columns
+    - Labels in columns 1-5 must be numeric (1-99999) or blank
+    - Column 6 non-blank indicates continuation of previous statement
+    - Statement text occupies columns 7-72
+    - Columns 73-80 are for sequence numbers (ignored by compiler)
+    - C or * in column 1 marks the entire card as a comment
+    """
+
+    def __init__(self, strict_width: bool = True, allow_tabs: bool = False):
+        """
+        Initialize the processor.
+
+        Args:
+            strict_width: Enforce exactly 80 columns per card (pad short lines)
+            allow_tabs: Allow tab characters (not historical but common)
+        """
+        self.strict_width = strict_width
+        self.allow_tabs = allow_tabs
+
+    def parse_card(self, line: str, line_number: int) -> Card:
+        """
+        Parse a single line as an 80-column card image.
+
+        Args:
+            line: Raw text of the card
+            line_number: Line number for error reporting (1-based)
+
+        Returns:
+            Card object with parsed fields
+        """
+        raw = line.rstrip("\r\n")
+        original_empty = len(raw) == 0
+        if self.strict_width:
+            raw = raw.ljust(80)[:80]
+
+        if original_empty or raw.strip() == "":
+            return Card(
+                line_number=line_number,
+                raw_text=raw,
+                card_type=CardType.BLANK,
+                label=None,
+                continuation=False,
+                statement_text="",
+                sequence_field=""
+            )
+
+        col1 = raw[0] if raw else " "
+        if col1.upper() in ("C", "*"):
+            return Card(
+                line_number=line_number,
+                raw_text=raw,
+                card_type=CardType.COMMENT,
+                label=None,
+                continuation=False,
+                statement_text=raw,
+                sequence_field=""
+            )
+
+        label_field = raw[:5] if len(raw) >= 5 else raw.ljust(5)
+        label = label_field.strip() if label_field.strip() else None
+
+        cont_char = raw[5] if len(raw) > 5 else " "
+        is_continuation = cont_char not in (" ", "0")
+
+        stmt_text = raw[6:72] if len(raw) > 6 else ""
+        seq_field = raw[72:80] if len(raw) > 72 else ""
+
+        card_type = CardType.CONTINUATION if is_continuation else CardType.STATEMENT
+
+        return Card(
+            line_number=line_number,
+            raw_text=raw,
+            card_type=card_type,
+            label=label,
+            continuation=is_continuation,
+            statement_text=stmt_text.rstrip(),
+            sequence_field=seq_field
+        )
+
+    def validate_cards(self, cards: List[Card]) -> Tuple[List[ValidationError],
+                                                         List[ValidationError]]:
+        """
+        Validate a list of parsed cards against C28-6000-2 rules.
+
+        Args:
+            cards: List of parsed Card objects
+
+        Returns:
+            Tuple of (errors, warnings)
+        """
+        errors = []
+        warnings = []
+
+        for card in cards:
+            if card.card_type in (CardType.BLANK, CardType.COMMENT):
+                continue
+
+            if card.label is not None:
+                if not card.label.isdigit():
+                    errors.append(ValidationError(
+                        line_number=card.line_number,
+                        column=1,
+                        message=f"Invalid label in columns 1-5: "
+                                f"expected numeric (1-99999), got '{card.label}'"
+                    ))
+                elif card.label:
+                    label_val = int(card.label)
+                    if label_val < 1 or label_val > 99999:
+                        errors.append(ValidationError(
+                            line_number=card.line_number,
+                            column=1,
+                            message=f"Label {label_val} out of range (1-99999)"
+                        ))
+                if card.continuation:
+                    errors.append(ValidationError(
+                        line_number=card.line_number,
+                        column=1,
+                        message="Continuation card (col 6 non-blank) "
+                                "must not have a label"
+                    ))
+
+            if not self.allow_tabs and "\t" in card.raw_text:
+                warnings.append(ValidationError(
+                    line_number=card.line_number,
+                    column=card.raw_text.index("\t") + 1,
+                    message="Tab character found (not historical); "
+                            "use spaces for strict conformance",
+                    severity="warning"
+                ))
+
+        for i, card in enumerate(cards):
+            if card.card_type == CardType.CONTINUATION and i == 0:
+                errors.append(ValidationError(
+                    line_number=card.line_number,
+                    column=6,
+                    message="First card cannot be a continuation"
+                ))
+            elif card.card_type == CardType.CONTINUATION:
+                prev_stmt_cards = [c for c in cards[:i]
+                                   if c.card_type in (CardType.STATEMENT,
+                                                      CardType.CONTINUATION)]
+                if not prev_stmt_cards:
+                    errors.append(ValidationError(
+                        line_number=card.line_number,
+                        column=6,
+                        message="Continuation card has no preceding statement"
+                    ))
+
+        return errors, warnings
+
+    def process(self, source: str) -> ValidationResult:
+        """
+        Process source code, validating and parsing as fixed-form cards.
+
+        Args:
+            source: Complete source code text
+
+        Returns:
+            ValidationResult with validation status, errors, and parsed cards
+        """
+        lines = source.split("\n")
+        cards = []
+
+        for i, line in enumerate(lines, start=1):
+            card = self.parse_card(line, i)
+            cards.append(card)
+
+        errors, warnings = self.validate_cards(cards)
+
+        return ValidationResult(
+            valid=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+            cards=cards
+        )
+
+    def to_lenient_form(self, result: ValidationResult,
+                        strip_comments: bool = False) -> str:
+        """
+        Convert validated cards to layout-lenient source for parsing.
+
+        This joins continuation cards with their base statements and
+        produces output suitable for FORTRANIIParser.
+
+        Args:
+            result: ValidationResult from process()
+            strip_comments: If True, omit comment lines from output
+
+        Returns:
+            Layout-lenient source text
+        """
+        output_lines = []
+        current_stmt = None
+        current_label = None
+
+        for card in result.cards:
+            if card.card_type == CardType.BLANK:
+                if current_stmt is not None:
+                    if current_label:
+                        output_lines.append(f"{current_label} {current_stmt}")
+                    else:
+                        output_lines.append(current_stmt)
+                    current_stmt = None
+                    current_label = None
+                if not strip_comments:
+                    output_lines.append("")
+            elif card.card_type == CardType.COMMENT:
+                if current_stmt is not None:
+                    if current_label:
+                        output_lines.append(f"{current_label} {current_stmt}")
+                    else:
+                        output_lines.append(current_stmt)
+                    current_stmt = None
+                    current_label = None
+                if not strip_comments:
+                    comment_text = card.raw_text[1:].strip() \
+                                   if len(card.raw_text) > 1 else ""
+                    output_lines.append(f"! {comment_text}")
+            elif card.card_type == CardType.STATEMENT:
+                if current_stmt is not None:
+                    if current_label:
+                        output_lines.append(f"{current_label} {current_stmt}")
+                    else:
+                        output_lines.append(current_stmt)
+                current_stmt = card.statement_text.rstrip()
+                current_label = card.label
+            elif card.card_type == CardType.CONTINUATION:
+                if current_stmt is not None:
+                    current_stmt += " " + card.statement_text.strip()
+
+        if current_stmt is not None:
+            if current_label:
+                output_lines.append(f"{current_label} {current_stmt}")
+            else:
+                output_lines.append(current_stmt)
+
+        return "\n".join(output_lines)
+
+
+def validate_strict_fixed_form(source: str,
+                               strict_width: bool = True,
+                               allow_tabs: bool = False) -> ValidationResult:
+    """
+    Validate source code as strict IBM 704 fixed-form FORTRAN II.
+
+    Args:
+        source: Source code text
+        strict_width: Enforce 80-column cards
+        allow_tabs: Allow tab characters
+
+    Returns:
+        ValidationResult with validation status, errors, and parsed cards
+    """
+    processor = StrictFixedFormProcessor(strict_width=strict_width,
+                                          allow_tabs=allow_tabs)
+    return processor.process(source)
+
+
+def convert_to_lenient(source: str,
+                       strict_width: bool = True,
+                       allow_tabs: bool = False,
+                       strip_comments: bool = False) -> Tuple[str, ValidationResult]:
+    """
+    Validate and convert strict fixed-form source to layout-lenient form.
+
+    Args:
+        source: Source code text
+        strict_width: Enforce 80-column cards
+        allow_tabs: Allow tab characters
+        strip_comments: If True, omit comment lines from output
+
+    Returns:
+        Tuple of (lenient_source, validation_result)
+    """
+    processor = StrictFixedFormProcessor(strict_width=strict_width,
+                                          allow_tabs=allow_tabs)
+    result = processor.process(source)
+    lenient = processor.to_lenient_form(result, strip_comments=strip_comments)
+    return lenient, result
+
+
+if __name__ == "__main__":
+    sample = """\
+C     THIS IS A COMMENT CARD
+C     FORTRAN II SAMPLE PROGRAM
+      SUBROUTINE SWAP(X, Y)                                             00000010
+C     SWAP TWO VALUES
+      TEMP = X                                                          00000020
+      X = Y                                                             00000030
+      Y = TEMP                                                          00000040
+      RETURN                                                            00000050
+      END                                                               00000060
+"""
+
+    print("Strict Fixed-Form Validator for FORTRAN II")
+    print("=" * 60)
+    print("\nSample input:")
+    print(sample)
+
+    result = validate_strict_fixed_form(sample)
+
+    print(f"\nValidation result: {'VALID' if result.valid else 'INVALID'}")
+    print(f"Cards parsed: {len(result.cards)}")
+
+    if result.errors:
+        print("\nErrors:")
+        for err in result.errors:
+            print(f"  Line {err.line_number}, Col {err.column}: {err.message}")
+
+    if result.warnings:
+        print("\nWarnings:")
+        for warn in result.warnings:
+            print(f"  Line {warn.line_number}, Col {warn.column}: {warn.message}")
+
+    lenient, _ = convert_to_lenient(sample)
+    print("\nConverted to lenient form:")
+    print(lenient)


### PR DESCRIPTION
## Summary
- Adds optional strict IBM 704 card-image validation for FORTRAN II per C28-6000-2 (1958)
- Implements `tools/strict_fixed_form.py` preprocessor that validates card layout and converts to lenient form
- Provides 27 passing tests covering card parsing, validation, conversion, and parser integration

## Card Layout Validation
Per C28-6000-2 Part I, Chapter 2:
- Columns 1-5: Statement labels (1-99999, numeric only)
- Column 6: Continuation mark (non-blank continues previous statement)
- Columns 7-72: Statement text
- Columns 73-80: Sequence/identification field (stripped during conversion)
- Column 1: C or * marks comment card

## Validation Rules
- Labels must be numeric 1-99999
- Continuation cards cannot have labels
- First card cannot be a continuation
- Reports errors with line numbers and column positions

## Test Plan
- [x] Unit tests for card parsing (blank, comment, statement, continuation)
- [x] Validation tests (invalid labels, continuation errors)
- [x] Conversion tests (comment handling, continuation joining, sequence stripping)
- [x] Integration tests (converted output parses with FORTRANIIParser)
- [x] Fixture tests with authentic 80-column IBM 704 card layouts
- [x] All 695 passing tests, 63 xfailed (7 new strict fixtures correctly marked)

## Verification
```
make test
================= 695 passed, 1 skipped, 63 xfailed in 35.46s ==================
```

## Files Changed
- `tools/strict_fixed_form.py`: New preprocessor module (401 lines)
- `tests/FORTRANII/test_strict_fixed_form.py`: Test suite (27 tests)
- `tests/fixtures/FORTRANII/test_strict_fixed_form/`: 7 fixtures demonstrating card layouts
- `docs/fixed_form_support.md`: Updated with strict mode documentation
- `docs/fortran_ii_audit.md`: Updated with issue #143 resolution
- `tests/xpass_fixtures.py`: Added XPASS entries for strict fixtures