### PR TITLE
docs: annotate Fortran 90 grammar with ISO/IEC 1539:1991 refs (fixes #173)

### DIFF
--- a/docs/fortran_90_audit.md
+++ b/docs/fortran_90_audit.md
@@ -362,7 +362,42 @@ For users who require strict historical accuracy:
 - The current design prioritizes practical usability over strict historical
   conformance, which is documented in this audit and in the grammar comments.
 
-## 10. Summary
+## 10. ISO/IEC 1539:1991 Spec-Grammar Cross-Walk
+
+The grammar files now include inline ISO/IEC 1539:1991 (WG5 N692) section
+references. This table summarizes the mapping between ISO sections and grammar
+rules:
+
+| ISO Section | Topic | Grammar Files and Rules |
+|-------------|-------|-------------------------|
+| Section 2 | Fortran Terms and Concepts | `Fortran90Parser.g4`: `program_unit_f90` |
+| Section 3.3 | Fixed Source Form | `Fortran90Lexer.g4`: `FIXED_FORM_COMMENT`, `STAR_COMMENT` |
+| Section 3.4 | Free Source Form | `Fortran90Lexer.g4`: `FREE_FORM_COMMENT`, `CONTINUATION`, `SEMICOLON` |
+| Section 4.3 | Intrinsic Types | `F90TypesParser.g4`: `intrinsic_type_spec_f90`, `kind_selector`, `char_selector` |
+| Section 4.4 | Derived Types | `F90TypesParser.g4`: `derived_type_def`, `derived_type_stmt`, `end_type_stmt` |
+| Section 4.4.4 | Structure Constructors | `F90TypesParser.g4`: `structure_constructor`, `component_spec` |
+| Section 4.5 | Array Constructors | `F90ExprsParser.g4`: `array_constructor_f90`, `ac_value_list` |
+| Section 5.1 | Type Declarations | `F90TypesParser.g4`: `type_declaration_stmt_f90`, `attr_spec_f90` |
+| Section 5.1.2.3 | INTENT Attribute | `F90TypesParser.g4`: `intent_spec`; Lexer: `INTENT`, `IN`, `OUT`, `INOUT` |
+| Section 5.1.2.4 | Array Specifications | `F90TypesParser.g4`: `array_spec_f90`, `deferred_shape_spec_list` |
+| Section 5.3 | IMPLICIT Statement | `Fortran90Lexer.g4`: `IMPLICIT`, `NONE` |
+| Section 5.4 | NAMELIST Statement | `F90IOParser.g4`: `namelist_stmt` |
+| Section 6.3 | Dynamic Allocation | `F90MemoryParser.g4`: `allocate_stmt`, `deallocate_stmt`, `nullify_stmt` |
+| Section 7 | Expressions | `F90ExprsParser.g4`: `expr_f90`, `primary_f90` |
+| Section 7.2.2 | Relational Operators | `Fortran90Lexer.g4`: `EQ_OP`, `NE_OP`, `LT_OP`, `LE_OP`, `GT_OP`, `GE_OP` |
+| Section 7.5.2 | Pointer Assignment | `Fortran90Lexer.g4`: `POINTER_ASSIGN`; Parser: `pointer_assignment_stmt` |
+| Section 7.5.3 | WHERE Construct | `F90ControlParser.g4`: `where_construct`, `where_stmt`, `elsewhere_stmt` |
+| Section 8.1.1 | IF Construct | `F90ControlParser.g4`: `if_construct`, `if_then_stmt`, `else_if_stmt` |
+| Section 8.1.3 | CASE Construct | `F90ControlParser.g4`: `select_case_construct`, `case_stmt`, `case_selector` |
+| Section 8.1.4 | DO Construct | `F90ControlParser.g4`: `do_construct_f90`, `loop_control`, `cycle_stmt`, `exit_stmt` |
+| Section 9 | Input/Output | `F90IOParser.g4`: `read_stmt_f90`, `write_stmt_f90`, `io_control_spec` |
+| Section 11.1 | Main Program | `Fortran90Parser.g4`: `main_program`, `program_stmt`, `end_program_stmt` |
+| Section 11.3 | Modules | `F90ModulesParser.g4`: `module`, `module_stmt`, `use_stmt` |
+| Section 12.3 | Interface Blocks | `F90ModulesParser.g4`: `interface_block`, `interface_stmt`, `generic_spec` |
+| Section 12.5 | Procedures | `F90ProcsParser.g4`: `function_stmt`, `subroutine_stmt`, `prefix`, `suffix` |
+| Section 13.8 | Intrinsic Procedures | `F90ExprsParser.g4`: `intrinsic_function_f90`; Lexer: `*_INTRINSIC` tokens |
+
+## 11. Summary
 
 The Fortran 90 grammar in this repository:
 

--- a/grammars/src/F90ControlParser.g4
+++ b/grammars/src/F90ControlParser.g4
@@ -1,40 +1,53 @@
 // Fortran 90 Control Structures
+// Reference: ISO/IEC 1539:1991 Section 7.5.3 (WHERE) and Section 8 (Execution Control)
 // Delegate grammar for SELECT CASE, WHERE, DO, and IF constructs
 // Extracted from Fortran90Parser.g4 per issue #252
 parser grammar F90ControlParser;
 
 // ====================================================================
-// SELECT CASE CONSTRUCT (F90 MAJOR INNOVATION)
+// SELECT CASE CONSTRUCT - ISO/IEC 1539:1991 Section 8.1.3
 // ====================================================================
-// ISO/IEC 1539:1991 Section 8.1.3
-// Multi-way branching based on expression value.
+//
+// ISO/IEC 1539:1991 Section 8.1.3 defines the CASE construct:
+// - R808 (case-construct) -> select-case-stmt [case-stmt block]...
+//                            end-select-stmt
+// - R809 (select-case-stmt) -> [case-construct-name :] SELECT CASE (case-expr)
+// - R811 (case-stmt) -> CASE case-selector [case-construct-name]
+// - R812 (case-selector) -> (case-value-range-list) | DEFAULT
+// - R813 (end-select-stmt) -> END SELECT [case-construct-name]
 
-// SELECT CASE construct (F90 major innovation)
+// SELECT CASE construct - ISO/IEC 1539:1991 Section 8.1.3, R808
 select_case_construct
     : select_case_stmt NEWLINE (NEWLINE* case_construct)* NEWLINE* end_select_stmt
     ;
 
+// SELECT CASE statement - ISO/IEC 1539:1991 Section 8.1.3, R809
 select_case_stmt
     : (IDENTIFIER COLON)? SELECT CASE LPAREN expr_f90 RPAREN
     ;
 
+// Case body - ISO/IEC 1539:1991 Section 8.1.3
 case_construct
     : case_stmt NEWLINE execution_part?
     ;
 
+// CASE statement - ISO/IEC 1539:1991 Section 8.1.3.2, R811
 case_stmt
     : CASE case_selector (IDENTIFIER)?
     ;
 
+// Case selector - ISO/IEC 1539:1991 Section 8.1.3.2, R812
 case_selector
     : LPAREN case_value_range_list RPAREN
     | DEFAULT
     ;
 
+// Case value range list - ISO/IEC 1539:1991 Section 8.1.3.2
 case_value_range_list
     : case_value_range (COMMA case_value_range)*
     ;
 
+// Case value range - ISO/IEC 1539:1991 Section 8.1.3.2, R814
 case_value_range
     : expr_f90                      // Single value
     | expr_f90 COLON                // Lower bound only
@@ -42,84 +55,120 @@ case_value_range
     | expr_f90 COLON expr_f90       // Range
     ;
 
+// END SELECT statement - ISO/IEC 1539:1991 Section 8.1.3, R813
 end_select_stmt
     : END_SELECT (IDENTIFIER)? NEWLINE?
     ;
 
 // ====================================================================
-// WHERE CONSTRUCT (F90 ARRAY-ORIENTED CONDITIONAL)
+// WHERE CONSTRUCT - ISO/IEC 1539:1991 Section 7.5.3
 // ====================================================================
-// ISO/IEC 1539:1991 Section 7.5.3
-// Array assignment with masking conditions.
+//
+// ISO/IEC 1539:1991 Section 7.5.3 defines the WHERE construct:
+// - R738 (where-construct) -> where-construct-stmt [where-body-construct]...
+//                             [elsewhere-stmt [where-body-construct]...]...
+//                             end-where-stmt
+// - R739 (where-construct-stmt) -> [where-construct-name :]
+//                                  WHERE (mask-expr)
+// - R741 (elsewhere-stmt) -> ELSEWHERE [(mask-expr)] [where-construct-name]
+// - R743 (end-where-stmt) -> END WHERE [where-construct-name]
+//
+// WHERE provides array assignment with masking conditions.
 
-// WHERE construct (F90 array-oriented conditional)
+// WHERE construct - ISO/IEC 1539:1991 Section 7.5.3, R738
 where_construct
     : where_construct_stmt execution_part?
       (elsewhere_stmt execution_part?)* end_where_stmt
     ;
 
+// WHERE construct statement - ISO/IEC 1539:1991 Section 7.5.3, R739
 where_construct_stmt
     : (IDENTIFIER COLON)? WHERE LPAREN logical_expr_f90 RPAREN
     ;
 
+// ELSEWHERE statement - ISO/IEC 1539:1991 Section 7.5.3, R741
 elsewhere_stmt
     : ELSEWHERE (LPAREN logical_expr_f90 RPAREN)? (IDENTIFIER)?
     ;
 
+// END WHERE statement - ISO/IEC 1539:1991 Section 7.5.3, R743
 end_where_stmt
     : END_WHERE (IDENTIFIER)?
     ;
 
+// Logical expression (mask-expr) - ISO/IEC 1539:1991 Section 7.5.3
 logical_expr_f90
     : expr_f90                      // Must be logical array expression
     ;
 
-// Simple WHERE statement (F90 array conditional)
+// WHERE statement - ISO/IEC 1539:1991 Section 7.5.3, R737
 where_stmt
     : WHERE LPAREN logical_expr_f90 RPAREN assignment_stmt_f90
     ;
 
 // ====================================================================
-// ENHANCED DO CONSTRUCT (F90 IMPROVEMENTS)
+// DO CONSTRUCT - ISO/IEC 1539:1991 Section 8.1.4
 // ====================================================================
-// ISO/IEC 1539:1991 Section 8.1.4
-// Loop construct with optional WHILE clause.
+//
+// ISO/IEC 1539:1991 Section 8.1.4 defines the DO construct:
+// - R816 (do-construct) -> do-stmt do-block end-do
+// - R817 (do-stmt) -> [do-construct-name :] DO [label] [loop-control]
+// - R820 (loop-control) -> [,] do-variable = scalar-int-expr,
+//                          scalar-int-expr [, scalar-int-expr]
+//                        | [,] WHILE (scalar-logical-expr)
+// - R823 (end-do) -> end-do-stmt | do-terminal-stmt
 
-// Enhanced DO construct (F90 improvements)
+// DO construct - ISO/IEC 1539:1991 Section 8.1.4, R816
 do_construct_f90
     : do_stmt_f90 execution_part? end_do_stmt
     ;
 
+// DO statement - ISO/IEC 1539:1991 Section 8.1.4.1, R817
 do_stmt_f90
     : (IDENTIFIER COLON)? DO (loop_control)?
     ;
 
+// Loop control - ISO/IEC 1539:1991 Section 8.1.4.1.1, R820
 loop_control
     : (COMMA)? variable_f90 EQUALS expr_f90 COMMA expr_f90 (COMMA expr_f90)?
-        // Counted loop
+        // Counted loop (Section 8.1.4.1.1)
     | (COMMA)? WHILE LPAREN logical_expr_f90 RPAREN
-        // WHILE loop
+        // WHILE loop (Section 8.1.4.1.1)
     ;
 
+// END DO statement - ISO/IEC 1539:1991 Section 8.1.4.2, R824
 end_do_stmt
     : END DO (IDENTIFIER)?
     ;
 
-// Enhanced loop control statements (F90)
+// ====================================================================
+// LOOP CONTROL STATEMENTS - ISO/IEC 1539:1991 Section 8.1.4.4
+// ====================================================================
+
+// CYCLE statement - ISO/IEC 1539:1991 Section 8.1.4.4.1, R834
 cycle_stmt
     : CYCLE (IDENTIFIER)?
     ;
 
+// EXIT statement - ISO/IEC 1539:1991 Section 8.1.4.4.2, R835
 exit_stmt
     : EXIT (IDENTIFIER)?
     ;
 
 // ====================================================================
-// IF CONSTRUCT (F90 ENHANCED)
+// IF CONSTRUCT - ISO/IEC 1539:1991 Section 8.1.1
 // ====================================================================
-// ISO/IEC 1539:1991 Section 8.1.1
-// Conditional execution with optional named constructs.
+//
+// ISO/IEC 1539:1991 Section 8.1.1 defines the IF construct:
+// - R802 (if-construct) -> if-then-stmt block [else-if-stmt block]...
+//                          [else-stmt block] end-if-stmt
+// - R803 (if-then-stmt) -> [if-construct-name :]
+//                          IF (scalar-logical-expr) THEN
+// - R804 (else-if-stmt) -> ELSE IF (scalar-logical-expr) THEN [if-construct-name]
+// - R805 (else-stmt) -> ELSE [if-construct-name]
+// - R806 (end-if-stmt) -> END IF [if-construct-name]
 
+// IF construct - ISO/IEC 1539:1991 Section 8.1.1, R802
 if_construct
     : if_then_stmt ENDIF (IDENTIFIER)? // Empty IF with ENDIF
     | if_then_stmt END IF (IDENTIFIER)? // Empty IF with END IF
@@ -129,44 +178,55 @@ if_construct
       (else_stmt execution_part?)? end_if_stmt // IF with else/elseif
     ;
 
+// IF-THEN statement - ISO/IEC 1539:1991 Section 8.1.1.1, R803
 if_then_stmt
     : (IDENTIFIER COLON)? IF LPAREN expr_f90 RPAREN THEN (IDENTIFIER)?
     ;
 
+// ELSE IF statement - ISO/IEC 1539:1991 Section 8.1.1.2, R804
 else_if_stmt
     : ELSE IF LPAREN expr_f90 RPAREN THEN (IDENTIFIER)?
     ;
 
+// ELSE statement - ISO/IEC 1539:1991 Section 8.1.1.2, R805
 else_stmt
     : ELSE (IDENTIFIER)?
     ;
 
+// END IF statement - ISO/IEC 1539:1991 Section 8.1.1.2, R806
 end_if_stmt
     : END IF (IDENTIFIER)?
     | ENDIF (IDENTIFIER)?
     ;
 
 // ====================================================================
-// INHERITED CONTROL STATEMENTS
+// INHERITED CONTROL STATEMENTS - ISO/IEC 1539:1991 Section 8
 // ====================================================================
-// From FORTRAN 77 and earlier - maintained for compatibility.
+//
+// From FORTRAN 77 and earlier - maintained for F90 compatibility.
+// Some are marked obsolescent in ISO/IEC 1539:1991 Annex B.1.
 
+// Arithmetic IF statement - ISO/IEC 1539:1991 Section 8.1.1.2 (obsolescent)
 arithmetic_if_stmt
     : IF LPAREN expr_f90 RPAREN label COMMA label COMMA label
     ;
 
+// CONTINUE statement - ISO/IEC 1539:1991 Section 8.2
 continue_stmt
     : CONTINUE
     ;
 
+// GOTO statement - ISO/IEC 1539:1991 Section 8.2
 goto_stmt
     : GOTO label
     ;
 
+// STOP statement - ISO/IEC 1539:1991 Section 8.3, R841
 stop_stmt
     : STOP (expr_f90)?
     ;
 
+// RETURN statement - ISO/IEC 1539:1991 Section 12.4.3
 return_stmt
     : RETURN (expr_f90)?
     ;

--- a/grammars/src/F90ExprsParser.g4
+++ b/grammars/src/F90ExprsParser.g4
@@ -1,12 +1,20 @@
 // Fortran 90 Expressions and Array Operations
+// Reference: ISO/IEC 1539:1991 Section 4.5 (Arrays) and Section 7 (Expressions)
 // Delegate grammar for expressions, primaries, and array constructors
 // Extracted from Fortran90Parser.g4 per issue #252
 parser grammar F90ExprsParser;
 
 // ====================================================================
-// ENHANCED EXPRESSIONS (F90 EXTENSIONS)
+// EXPRESSIONS - ISO/IEC 1539:1991 Section 7
 // ====================================================================
-// ISO/IEC 1539:1991 Section 7
+//
+// ISO/IEC 1539:1991 Section 7 defines expressions:
+// - R701 (primary) -> constant | designator | array-constructor |
+//                     structure-constructor | function-reference | (expr)
+// - R702 (level-1-expr) -> [defined-unary-op] primary
+// - R703-R713: Operator precedence and expression formation
+// - R714 (logical-expr) -> level-5-expr
+//
 // Expressions with new operators and array operations.
 
 // F90 expressions (enhanced with new operators and array operations)

--- a/grammars/src/F90IOParser.g4
+++ b/grammars/src/F90IOParser.g4
@@ -1,12 +1,16 @@
 // Fortran 90 Input/Output Statements
+// Reference: ISO/IEC 1539:1991 Section 5.4 (NAMELIST) and Section 9 (I/O)
 // Delegate grammar for READ, WRITE, PRINT, and NAMELIST
 // Extracted from Fortran90Parser.g4 per issue #252
 parser grammar F90IOParser;
 
 // ====================================================================
-// NAMELIST (F90 STRUCTURED I/O)
+// NAMELIST STATEMENT - ISO/IEC 1539:1991 Section 5.4
 // ====================================================================
-// ISO/IEC 1539:1991 Section 5.4
+//
+// ISO/IEC 1539:1991 Section 5.4 defines the NAMELIST statement:
+// - R527 (namelist-stmt) -> NAMELIST / namelist-group-name / namelist-group-object-list
+//                           [[,] / namelist-group-name / namelist-group-object-list]...
 // Named groups of variables for structured I/O.
 
 // NAMELIST declaration (F90 structured I/O)

--- a/grammars/src/F90MemoryParser.g4
+++ b/grammars/src/F90MemoryParser.g4
@@ -1,12 +1,18 @@
 // Fortran 90 Dynamic Memory Management
+// Reference: ISO/IEC 1539:1991 Section 6.3 (Dynamic allocation)
 // Delegate grammar for ALLOCATE, DEALLOCATE, and NULLIFY
 // Extracted from Fortran90Parser.g4 per issue #252
 parser grammar F90MemoryParser;
 
 // ====================================================================
-// DYNAMIC MEMORY MANAGEMENT (F90 MAJOR INNOVATION)
+// DYNAMIC MEMORY MANAGEMENT - ISO/IEC 1539:1991 Section 6.3
 // ====================================================================
-// ISO/IEC 1539:1991 Section 6.3
+//
+// ISO/IEC 1539:1991 Section 6.3 defines dynamic memory management:
+// - R620 (allocate-stmt) -> ALLOCATE (allocation-list [, STAT=stat-variable])
+// - R624 (nullify-stmt) -> NULLIFY (pointer-object-list)
+// - R626 (deallocate-stmt) -> DEALLOCATE (allocate-object-list [, STAT=stat-variable])
+//
 // Dynamic allocation and deallocation of arrays and pointers.
 
 // ALLOCATE statement (F90 dynamic memory allocation)

--- a/grammars/src/F90ModulesParser.g4
+++ b/grammars/src/F90ModulesParser.g4
@@ -1,69 +1,96 @@
 // Fortran 90 Module System and Interface Blocks
+// Reference: ISO/IEC 1539:1991 Section 11.3 (Modules) and Section 12.3 (Interfaces)
 // Delegate grammar for MODULE, USE, and INTERFACE constructs
 // Extracted from Fortran90Parser.g4 per issue #252
 parser grammar F90ModulesParser;
 
 // ====================================================================
-// MODULE SYSTEM (F90 MAJOR INNOVATION)
+// MODULE SYSTEM - ISO/IEC 1539:1991 Section 11.3
 // ====================================================================
-// ISO/IEC 1539:1991 Section 11 - Program Units
+//
+// ISO/IEC 1539:1991 Section 11.3 defines the module system:
+// - R1104 (module) -> module-stmt [specification-part]
+//                     [module-subprogram-part] end-module-stmt
+// - R1105 (module-stmt) -> MODULE module-name
+// - R1106 (end-module-stmt) -> END [MODULE [module-name]]
+// - R1107 (use-stmt) -> USE module-name [, rename-list] |
+//                       USE module-name, ONLY: [only-list]
+//
 // Modules provide a mechanism for data sharing and procedure grouping.
 
-// Module definition (revolutionary F90 feature)
+// Module definition - ISO/IEC 1539:1991 Section 11.3, R1104
 module
     : module_stmt specification_part? module_subprogram_part? end_module_stmt
     ;
 
+// MODULE statement - ISO/IEC 1539:1991 Section 11.3, R1105
 module_stmt
     : MODULE IDENTIFIER NEWLINE*
     ;
 
+// END MODULE statement - ISO/IEC 1539:1991 Section 11.3, R1106
 end_module_stmt
     : END_MODULE (IDENTIFIER)? NEWLINE*
     ;
 
-// Module subprogram section
+// Module subprogram part - ISO/IEC 1539:1991 Section 11.3, R1108
 module_subprogram_part
     : contains_stmt NEWLINE* (module_subprogram NEWLINE*)*
     ;
 
+// Module subprogram - ISO/IEC 1539:1991 Section 11.3, R1109
 module_subprogram
     : function_subprogram
     | subroutine_subprogram
     ;
 
+// CONTAINS statement - ISO/IEC 1539:1991 Section 12.5.1
 contains_stmt
     : CONTAINS NEWLINE?
     ;
 
-// USE statement (F90 module import)
-// ISO/IEC 1539:1991 Section 11.3
+// ====================================================================
+// USE STATEMENT - ISO/IEC 1539:1991 Section 11.3.2
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 11.3.2 defines module use:
+// - R1107 (use-stmt) -> USE module-name [, rename-list] |
+//                       USE module-name, ONLY: [only-list]
+// - R1110 (rename) -> local-name => use-name
+// - R1111 (only) -> generic-spec | only-use-name | rename
+
+// USE statement - ISO/IEC 1539:1991 Section 11.3.2, R1107
 use_stmt
     : USE module_name (COMMA rename_list | COMMA ONLY COLON only_list)?
     ;
 
+// Module name - ISO/IEC 1539:1991 Section 11.3
 module_name
     : IDENTIFIER
     ;
 
-// Module renaming and selective import
+// Rename list - ISO/IEC 1539:1991 Section 11.3.2, R1107
 rename_list
     : rename (COMMA rename)*
     ;
 
+// Rename - ISO/IEC 1539:1991 Section 11.3.2, R1110
 rename
     : IDENTIFIER POINTER_ASSIGN IDENTIFIER       // local_name => module_name
     ;
 
+// Only list - ISO/IEC 1539:1991 Section 11.3.2, R1107
 only_list
     : only_item (COMMA only_item)*
     ;
 
+// Only item - ISO/IEC 1539:1991 Section 11.3.2, R1111
 only_item
     : IDENTIFIER (POINTER_ASSIGN IDENTIFIER)?    // local_name => module_name
     | OPERATOR LPAREN operator_token RPAREN
     ;
 
+// Operator token - ISO/IEC 1539:1991 Section 7.1.2
 operator_token
     : PLUS | MINUS | MULTIPLY | SLASH | POWER
     | EQ_OP | NE_OP | LT_OP | LE_OP | GT_OP | GE_OP
@@ -72,49 +99,70 @@ operator_token
     ;
 
 // ====================================================================
-// INTERFACE BLOCKS (F90 MAJOR INNOVATION)
+// INTERFACE BLOCKS - ISO/IEC 1539:1991 Section 12.3
 // ====================================================================
-// ISO/IEC 1539:1991 Section 12.3
+//
+// ISO/IEC 1539:1991 Section 12.3 defines interface blocks:
+// - R1201 (interface-block) -> interface-stmt [interface-specification]...
+//                              end-interface-stmt
+// - R1202 (interface-stmt) -> INTERFACE [generic-spec]
+// - R1203 (generic-spec) -> generic-name | OPERATOR(defined-operator) |
+//                           ASSIGNMENT(=)
+// - R1204 (interface-specification) -> interface-body | procedure-stmt
+// - R1205 (interface-body) -> function-stmt ... end-function-stmt |
+//                             subroutine-stmt ... end-subroutine-stmt
+// - R1206 (end-interface-stmt) -> END INTERFACE [generic-spec]
+//
 // Interfaces provide explicit procedure declarations and generic overloading.
 
-// Interface block (explicit interfaces and generic procedures)
+// Interface block - ISO/IEC 1539:1991 Section 12.3, R1201
 interface_block
     : interface_stmt interface_specification* end_interface_stmt
     ;
 
+// INTERFACE statement - ISO/IEC 1539:1991 Section 12.3, R1202
 interface_stmt
     : INTERFACE (generic_spec)?
     ;
 
+// Generic spec - ISO/IEC 1539:1991 Section 12.3, R1203
 generic_spec
     : IDENTIFIER                            // Generic procedure name
     | OPERATOR LPAREN operator_token RPAREN // Operator overloading
     | ASSIGNMENT LPAREN EQUALS RPAREN       // Assignment overloading
     ;
 
+// Interface specification - ISO/IEC 1539:1991 Section 12.3, R1204
 interface_specification
     : interface_body
     | procedure_stmt
     ;
 
+// Interface body - ISO/IEC 1539:1991 Section 12.3, R1205
 interface_body
     : function_stmt specification_part? end_function_stmt
     | subroutine_stmt specification_part? end_subroutine_stmt
     ;
 
+// END INTERFACE statement - ISO/IEC 1539:1991 Section 12.3, R1206
 end_interface_stmt
     : END_INTERFACE (generic_spec)?
     ;
 
 // ====================================================================
-// IMPORT STATEMENT (F90)
+// IMPORT STATEMENT - ISO/IEC 1539:1991 Section 12.3.2.2
 // ====================================================================
-// ISO/IEC 1539:1991 Section 12.4.1
+//
+// NOTE: Full IMPORT statement is a Fortran 2003 feature.
+// F90 relies on implicit host association (Section 14.6.1.3).
+// This rule provides forward compatibility.
 
+// IMPORT statement (F2003, included for forward compatibility)
 import_stmt
     : IMPORT (DOUBLE_COLON import_name_list)?
     ;
 
+// Import name list
 import_name_list
     : IDENTIFIER (COMMA IDENTIFIER)*
     ;

--- a/grammars/src/F90ProcsParser.g4
+++ b/grammars/src/F90ProcsParser.g4
@@ -1,12 +1,21 @@
 // Fortran 90 Procedures and Subprograms
+// Reference: ISO/IEC 1539:1991 Section 12 (Procedures)
 // Delegate grammar for functions, subroutines, and procedure calls
 // Extracted from Fortran90Parser.g4 per issue #252
 parser grammar F90ProcsParser;
 
 // ====================================================================
-// ENHANCED PROCEDURES (F90 IMPROVEMENTS)
+// PROCEDURES - ISO/IEC 1539:1991 Section 12
 // ====================================================================
-// ISO/IEC 1539:1991 Section 12
+//
+// ISO/IEC 1539:1991 Section 12 defines procedures:
+// - Section 12.5.2: Function subprograms (R1213-R1218)
+// - Section 12.5.3: Subroutine subprograms (R1219-R1222)
+// - Section 12.4: Procedure references (R1208-R1212)
+// - R1214 (prefix) -> prefix-spec [prefix-spec]...
+// - R1215 (prefix-spec) -> type-spec | RECURSIVE
+// - R1216 (suffix) -> RESULT (result-name)
+//
 // Procedures with RECURSIVE prefix and RESULT clause.
 
 // Function statement (F90 enhancements)

--- a/grammars/src/F90TypesParser.g4
+++ b/grammars/src/F90TypesParser.g4
@@ -1,187 +1,251 @@
 // Fortran 90 Type System and Derived Types
+// Reference: ISO/IEC 1539:1991 Section 4 (Types) and Section 5 (Declarations)
 // Delegate grammar for type declarations, derived types, and kind selectors
 // Extracted from Fortran90Parser.g4 per issue #252
 parser grammar F90TypesParser;
 
 // ====================================================================
-// DERIVED TYPES (F90 MAJOR INNOVATION)
+// DERIVED TYPES - ISO/IEC 1539:1991 Section 4.4
 // ====================================================================
-// ISO/IEC 1539:1991 Section 4.4
-// User-defined data structures (similar to C structs).
+//
+// ISO/IEC 1539:1991 Section 4.4 defines derived types:
+// - R422 (derived-type-def) -> derived-type-stmt [private-sequence-stmt]...
+//                              component-def-stmt... end-type-stmt
+// - R423 (derived-type-stmt) -> TYPE [[, access-spec] ::] type-name
+// - R424 (private-sequence-stmt) -> PRIVATE | SEQUENCE
+// - R425 (component-def-stmt) -> type-spec [[, component-attr-spec-list] ::]
+//                                component-decl-list
+// - R429 (end-type-stmt) -> END TYPE [type-name]
+//
+// Derived types provide user-defined data structures.
 
-// Derived type definition (user-defined structures)
+// Derived type definition - ISO/IEC 1539:1991 Section 4.4, R422
 derived_type_def
     : derived_type_stmt NEWLINE* (component_def_stmt NEWLINE*)* end_type_stmt
     ;
 
+// Derived type statement - ISO/IEC 1539:1991 Section 4.4, R423
 derived_type_stmt
     : TYPE type_name NEWLINE?
     | TYPE DOUBLE_COLON type_name NEWLINE?
     ;
 
+// Type name - ISO/IEC 1539:1991 Section 4.4
 type_name
     : IDENTIFIER
     ;
 
+// Component definition statement - ISO/IEC 1539:1991 Section 4.4, R425
 component_def_stmt
     : type_declaration_stmt_f90     // Component declarations
     | private_sequence_stmt         // PRIVATE or SEQUENCE
     ;
 
+// Private/sequence statement - ISO/IEC 1539:1991 Section 4.4.1, R424
 private_sequence_stmt
     : PRIVATE NEWLINE?
     | SEQUENCE NEWLINE?
     ;
 
+// END TYPE statement - ISO/IEC 1539:1991 Section 4.4, R429
 end_type_stmt
     : END_TYPE (type_name)? NEWLINE?
     ;
 
-// Structure constructor (F90 derived type initialization)
-// ISO/IEC 1539:1991 Section 4.4.4
+// ====================================================================
+// STRUCTURE CONSTRUCTOR - ISO/IEC 1539:1991 Section 4.4.4
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 4.4.4 defines structure constructors:
+// - R430 (structure-constructor) -> type-name (component-spec-list)
+// - R431 (component-spec) -> [keyword =] component-data-source
+
+// Structure constructor - ISO/IEC 1539:1991 Section 4.4.4, R430
 structure_constructor
     : type_name LPAREN component_spec_list? RPAREN
     ;
 
+// Component spec list - ISO/IEC 1539:1991 Section 4.4.4
 component_spec_list
     : component_spec (COMMA component_spec)*
     ;
 
+// Component spec - ISO/IEC 1539:1991 Section 4.4.4, R431
 component_spec
     : IDENTIFIER EQUALS expr_f90    // Named component
     | expr_f90                      // Positional component
     ;
 
 // ====================================================================
-// ENHANCED TYPE DECLARATIONS (F90 EXTENSIONS)
+// TYPE DECLARATIONS - ISO/IEC 1539:1991 Section 5.1
 // ====================================================================
-// ISO/IEC 1539:1991 Section 5.1
+//
+// ISO/IEC 1539:1991 Section 5.1 defines type declaration statements:
+// - R501 (type-declaration-stmt) -> type-spec [[, attr-spec]... ::]
+//                                   entity-decl-list
+// - R502 (type-spec) -> intrinsic-type-spec | derived-type-spec
+// - R503 (attr-spec) -> PARAMETER | access-spec | ALLOCATABLE | ...
+// - R504 (entity-decl) -> object-name [(array-spec)] [*char-length]
+//                         [= initialization-expr]
 
-// F90 type declaration statement (major enhancements)
+// Type declaration statement - ISO/IEC 1539:1991 Section 5.1, R501
 type_declaration_stmt_f90
     : type_spec_f90 (COMMA attr_spec_f90)* DOUBLE_COLON? entity_decl_list_f90 NEWLINE?
     ;
 
-// Type specification (enhanced for F90)
+// Type specification - ISO/IEC 1539:1991 Section 5.1, R502
 type_spec_f90
     : intrinsic_type_spec_f90
     | derived_type_spec_f90
     ;
 
-// Intrinsic type specification with F90 enhancements
-// ISO/IEC 1539:1991 Section 4.3
+// ====================================================================
+// INTRINSIC TYPE SPECIFICATION - ISO/IEC 1539:1991 Section 4.3
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 4.3 defines intrinsic types:
+// - R502 (intrinsic-type-spec) -> INTEGER [kind-selector] |
+//                                  REAL [kind-selector] |
+//                                  DOUBLE PRECISION | COMPLEX [kind-selector] |
+//                                  LOGICAL [kind-selector] |
+//                                  CHARACTER [char-selector]
+
+// Intrinsic type specification - ISO/IEC 1539:1991 Section 4.3
 intrinsic_type_spec_f90
-    : INTEGER (kind_selector)?
-    | REAL (kind_selector)?
-    | DOUBLE PRECISION             // F77 compatibility
-    | COMPLEX (kind_selector)?
-    | LOGICAL (kind_selector)?
-    | CHARACTER (char_selector)?
+    : INTEGER (kind_selector)?      // Section 4.3.1.1
+    | REAL (kind_selector)?         // Section 4.3.1.2
+    | DOUBLE PRECISION              // F77 compatibility (Section 4.3.1.3)
+    | COMPLEX (kind_selector)?      // Section 4.3.1.4
+    | LOGICAL (kind_selector)?      // Section 4.3.4
+    | CHARACTER (char_selector)?    // Section 4.3.2
     ;
 
-// Derived type specification (F90 feature)
+// Derived type specification - ISO/IEC 1539:1991 Section 5.1, R502
 derived_type_spec_f90
     : TYPE LPAREN type_name RPAREN
     ;
 
-// Kind selector for type parameters (F90 innovation)
-// ISO/IEC 1539:1991 Section 4.3.1
+// Kind selector - ISO/IEC 1539:1991 Section 4.3.1, R404
 kind_selector
     : LPAREN (KIND EQUALS)? expr_f90 RPAREN
     ;
 
-// Character length and kind selector (F90 enhancement)
-// ISO/IEC 1539:1991 Section 4.3.2
+// Character selector - ISO/IEC 1539:1991 Section 4.3.2, R406
 char_selector
     : LPAREN (LEN EQUALS)? expr_f90 (COMMA (KIND EQUALS)? expr_f90)? RPAREN
     | LPAREN expr_f90 RPAREN        // Legacy F77 style
     ;
 
-// Attribute specifications (F90 major extensions)
-// ISO/IEC 1539:1991 Section 5.1.2
+// ====================================================================
+// ATTRIBUTE SPECIFICATIONS - ISO/IEC 1539:1991 Section 5.1.2
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 5.1.2 defines declaration attributes:
+// - R503 (attr-spec) -> PARAMETER | access-spec | ALLOCATABLE |
+//                       DIMENSION (array-spec) | EXTERNAL |
+//                       INTENT (intent-spec) | INTRINSIC |
+//                       OPTIONAL | POINTER | SAVE | TARGET
+
+// Attribute specification - ISO/IEC 1539:1991 Section 5.1.2, R503
 attr_spec_f90
-    : PARAMETER                     // Inherited from shared core
-    | DIMENSION LPAREN array_spec_f90 RPAREN
-    | ALLOCATABLE                   // F90 dynamic arrays
-    | POINTER                       // F90 pointers
-    | TARGET                        // F90 pointer targets
-    | PUBLIC                        // F90 module visibility
-    | PRIVATE                       // F90 module visibility
-    | INTENT LPAREN intent_spec RPAREN  // F90 procedure arguments
-    | OPTIONAL                      // F90 optional arguments
-    | EXTERNAL                      // External procedure
-    | INTRINSIC                     // Intrinsic procedure
-    | SAVE                          // Variable persistence
+    : PARAMETER                     // Section 5.1.2.11
+    | DIMENSION LPAREN array_spec_f90 RPAREN  // Section 5.1.2.4.1
+    | ALLOCATABLE                   // Section 5.1.2.4.3
+    | POINTER                       // Section 5.1.2.4.4
+    | TARGET                        // Section 5.1.2.4.5
+    | PUBLIC                        // Section 5.1.2.1
+    | PRIVATE                       // Section 5.1.2.1
+    | INTENT LPAREN intent_spec RPAREN  // Section 5.1.2.3
+    | OPTIONAL                      // Section 5.1.2.6
+    | EXTERNAL                      // Section 5.1.2.7
+    | INTRINSIC                     // Section 5.1.2.8
+    | SAVE                          // Section 5.1.2.5
     ;
 
-// Intent specification (F90 procedure interface)
-// ISO/IEC 1539:1991 Section 5.1.2.3
+// Intent specification - ISO/IEC 1539:1991 Section 5.1.2.3, R519
 intent_spec
     : IN | OUT | INOUT
     ;
 
 // ====================================================================
-// ARRAY SPECIFICATIONS (F90 ENHANCEMENTS)
+// ARRAY SPECIFICATIONS - ISO/IEC 1539:1991 Section 5.1.2.4
 // ====================================================================
-// ISO/IEC 1539:1991 Section 5.1.2.4
+//
+// ISO/IEC 1539:1991 Section 5.1.2.4 defines array specifications:
+// - R509 (array-spec) -> explicit-shape-spec-list | assumed-shape-spec-list |
+//                        deferred-shape-spec-list | assumed-size-spec
+// - R510 (explicit-shape-spec) -> [lower-bound :] upper-bound
+// - R512 (assumed-shape-spec) -> [lower-bound] :
+// - R514 (deferred-shape-spec) -> :
+// - R516 (assumed-size-spec) -> [explicit-shape-spec ,]... [lower-bound :] *
 
-// Array specification (F90 enhancements)
+// Array specification - ISO/IEC 1539:1991 Section 5.1.2.4, R509
 array_spec_f90
-    : explicit_shape_spec_list
-    | assumed_shape_spec_list       // F90: dummy arguments (:,:)
-    | deferred_shape_spec_list      // F90: ALLOCATABLE/POINTER (:,:)
-    | assumed_size_spec             // F77 compatibility: (*)
+    : explicit_shape_spec_list       // Section 5.1.2.4.1
+    | assumed_shape_spec_list        // Section 5.1.2.4.2 - F90 dummy arguments
+    | deferred_shape_spec_list       // Section 5.1.2.4.3 - F90 ALLOCATABLE/POINTER
+    | assumed_size_spec              // Section 5.1.2.4.4 - F77 compatibility
     ;
 
-// Explicit shape specification
+// Explicit shape specification list - ISO/IEC 1539:1991 Section 5.1.2.4.1
 explicit_shape_spec_list
     : explicit_shape_spec (COMMA explicit_shape_spec)*
     ;
 
+// Explicit shape spec - ISO/IEC 1539:1991 Section 5.1.2.4.1, R510
 explicit_shape_spec
     : expr_f90 (COLON expr_f90)?    // lower:upper or just upper
     ;
 
-// Assumed shape specification (F90 dummy arguments)
+// Assumed shape specification list - ISO/IEC 1539:1991 Section 5.1.2.4.2
 assumed_shape_spec_list
     : assumed_shape_spec (COMMA assumed_shape_spec)*
     ;
 
+// Assumed shape spec - ISO/IEC 1539:1991 Section 5.1.2.4.2, R512
 assumed_shape_spec
     : COLON                         // Just :
     | expr_f90 COLON                // lower:
     ;
 
-// Deferred shape specification (F90 ALLOCATABLE/POINTER)
+// Deferred shape specification list - ISO/IEC 1539:1991 Section 5.1.2.4.3
 deferred_shape_spec_list
     : deferred_shape_spec (COMMA deferred_shape_spec)*
     ;
 
+// Deferred shape spec - ISO/IEC 1539:1991 Section 5.1.2.4.3, R514
 deferred_shape_spec
     : COLON                         // Just :
     ;
 
-// Assumed size specification (F77 compatibility)
+// Assumed size specification - ISO/IEC 1539:1991 Section 5.1.2.4.4, R516
 assumed_size_spec
     : (explicit_shape_spec COMMA)* MULTIPLY    // ..., *
     ;
 
-// Entity declaration list (F90 enhancements)
+// ====================================================================
+// ENTITY DECLARATIONS - ISO/IEC 1539:1991 Section 5.1
+// ====================================================================
+
+// Entity declaration list - ISO/IEC 1539:1991 Section 5.1, R504
 entity_decl_list_f90
     : entity_decl_f90 (COMMA entity_decl_f90)*
     ;
 
+// Entity declaration - ISO/IEC 1539:1991 Section 5.1, R504
 entity_decl_f90
     : identifier_or_keyword (LPAREN array_spec_f90 RPAREN)? (MULTIPLY char_length)?
       (EQUALS expr_f90)?
     ;
 
+// Character length - ISO/IEC 1539:1991 Section 5.1.1.5
 char_length
     : expr_f90
     | MULTIPLY                      // Assumed length character
     ;
 
 // Keywords that can be used as identifiers in certain contexts
+// ISO/IEC 1539:1991 allows most keywords as user names except in ambiguous contexts
 identifier_or_keyword
     : IDENTIFIER
     | DATA         // DATA can be used as a variable name

--- a/grammars/src/Fortran90Lexer.g4
+++ b/grammars/src/Fortran90Lexer.g4
@@ -1,5 +1,6 @@
 // Fortran 90 (1990) Lexer - Unified Fixed/Free Form Support
-// Revolutionary Modern Foundation with Complete Format Compatibility
+// Reference: ISO/IEC 1539:1991 (Fortran 90)
+//            WG5 N692 draft (validation/pdfs/Fortran90_WG5_N692.txt)
 lexer grammar Fortran90Lexer;
 
 import FORTRAN77Lexer;  // Inherit F77 (1977) constructs
@@ -8,294 +9,597 @@ import FORTRAN77Lexer;  // Inherit F77 (1977) constructs
 // FORTRAN 90 UNIFIED LEXER OVERVIEW
 // ====================================================================
 //
-// Fortran 90 (ISO 1539:1991) represents the most significant revolution 
-// in Fortran history - introducing free-form source format while maintaining
-// complete backward compatibility with fixed-form.
+// This lexer implements token rules for Fortran 90 as defined in:
+//   ISO/IEC 1539:1991 (Fortran 90 International Standard)
+//   WG5 N692 (Fortran 90 draft, equivalent to final standard)
 //
-// This lexer supports BOTH formats in a single grammar:
-// - Fixed-form: .f, .for files (column-based, F77 compatibility)
-// - Free-form: .f90+ files (flexible layout, modern syntax)
+// ISO/IEC 1539:1991 Standard Structure Overview:
+//   Section 1: Overview
+//   Section 2: Fortran Terms and Concepts
+//   Section 3: Characters and Low Level Syntax (3.1-3.4)
+//   Section 4: Data Types (4.1-4.5)
+//   Section 5: Data Object Declarations (5.1-5.5)
+//   Section 6: Use of Data Objects (6.1-6.5)
+//   Section 7: Expressions and Assignment (7.1-7.5)
+//   Section 8: Execution Control (8.1-8.3)
+//   Section 9: Input/Output Statements (9.1-9.9)
+//   Section 10: Input/Output Editing (10.1-10.9)
+//   Section 11: Program Units (11.1-11.3)
+//   Section 12: Procedures (12.1-12.5)
+//   Section 13: Intrinsic Procedures (13.1-13.14)
+//   Section 14: Scope, Association, and Definition (14.1-14.7)
+//   Annex A: Glossary
+//   Annex B: Syntax Rules (BNF summary)
+//
+// This lexer supports BOTH fixed-form and free-form source formats:
+// - Fixed-form: .f, .for files (ISO/IEC 1539:1991 Section 3.3)
+// - Free-form: .f90+ files (ISO/IEC 1539:1991 Section 3.4)
 //
 // Format detection is handled by the parser/driver based on file extension.
 //
-// REVOLUTIONARY F90 FEATURES:
-// - Module system with explicit interfaces
-// - Dynamic arrays (ALLOCATABLE, POINTER)
-// - Derived types (user-defined structures)  
-// - Array operations and constructors
-// - Enhanced control flow (SELECT CASE, WHERE)
-// - Modern I/O (NAMELIST, non-advancing)
+// MAJOR F90 FEATURES (with ISO section references):
+// - Free-form source (Section 3.4)
+// - Module system with explicit interfaces (Section 11.3)
+// - Dynamic arrays - ALLOCATABLE, POINTER (Section 5.1.2.4, 6.3)
+// - Derived types - user-defined structures (Section 4.4)
+// - Array operations and constructors (Section 4.5, 7.5.4)
+// - Enhanced control flow - SELECT CASE, WHERE (Section 8.1.3, 7.5.3)
+// - Modern I/O - NAMELIST, non-advancing (Section 5.4, 9.4.1)
+// - KIND type parameters (Section 4.3.1)
+// - Recursive procedures (Section 12.5.2)
 //
 // INHERITANCE ARCHITECTURE (IN THIS REPO):
 // FORTRAN / FORTRANII / FORTRAN66 / FORTRAN77
-//   → Fortran90Lexer
-//   → Fortran95Lexer
-//   → F2003+ standards
+//   -> Fortran90Lexer
+//   -> Fortran95Lexer
+//   -> F2003+ standards
 //
 // ====================================================================
 
 // ====================================================================
-// FORMAT MODES
+// SOURCE FORM - ISO/IEC 1539:1991 Section 3
 // ====================================================================
-
+//
+// ISO/IEC 1539:1991 Section 3 defines the source form:
+// - Section 3.1: Processor character set (alphanumeric and special chars)
+// - Section 3.2: Low-level syntax (lexical tokens)
+// - Section 3.3: Fixed source form (columns 1-72, labels in 1-5, cont in 6)
+// - Section 3.4: Free source form (line-oriented, ! comments, & continuation)
+//
 // Default mode is free-form (F90+ primary format)
 // Fixed-form mode can be activated by parser based on file extension
 
-// Unified comment handling with improved format detection
-// Priority: Free-form ! comments (most common in F90+)
+// ====================================================================
+// COMMENTS - ISO/IEC 1539:1991 Section 3.3.2 and 3.4.4
+// ====================================================================
+
+// Free-form comment - ISO/IEC 1539:1991 Section 3.4.4
+// Syntax: ! followed by any characters to end of line
+// The ! initiates a comment that extends to the end of the line
 FREE_FORM_COMMENT
     : '!' ~[\r\n]* -> channel(HIDDEN)
     ;
 
-// Fixed-form comments: C, c, or * at start of line (column 1)
+// Fixed-form comment - ISO/IEC 1539:1991 Section 3.3.2
+// Syntax: C, c, or * in column 1 makes entire line a comment
 // Must follow a newline to ensure column 1 position
 FIXED_FORM_COMMENT
     : [\r\n]+ [Cc] [ \t] ~[\r\n]* -> channel(HIDDEN)
     ;
 
 // Star comment at column 1 (fixed-form only)
+// ISO/IEC 1539:1991 Section 3.3.2
 STAR_COMMENT
     : [\r\n]+ '*' ~[\r\n]* -> channel(HIDDEN)
     ;
 
-// Free-form continuation (& at end of line)  
+// ====================================================================
+// CONTINUATION - ISO/IEC 1539:1991 Section 3.3.1.3 and 3.4.3
+// ====================================================================
+
+// Free-form continuation - ISO/IEC 1539:1991 Section 3.4.3
+// Syntax: & at end of line continues statement on next line
+// An optional & at start of next line indicates where continuation resumes
 CONTINUATION
     : '&' [ \t]* FREE_FORM_COMMENT? -> channel(HIDDEN)
     ;
 
 // ====================================================================
-// FORTRAN 90 KEYWORDS (REVOLUTIONARY FEATURES)
+// MODULE SYSTEM KEYWORDS - ISO/IEC 1539:1991 Section 11.3
 // ====================================================================
+//
+// ISO/IEC 1539:1991 Section 11.3 defines the module system:
+// - R1104 (module) -> MODULE module-name [specification-part]
+//                     [module-subprogram-part] END [MODULE [module-name]]
+// - R1107 (use-stmt) -> USE module-name [, rename-list] |
+//                       USE module-name, ONLY: [only-list]
+// - Section 11.3.2 defines PUBLIC and PRIVATE accessibility
 
-// Module system (F90 major innovation)
+// MODULE keyword - ISO/IEC 1539:1991 Section 11.3, R1104
 MODULE          : ('m'|'M') ('o'|'O') ('d'|'D') ('u'|'U') ('l'|'L') ('e'|'E') ;
-END_MODULE      : ('e'|'E') ('n'|'N') ('d'|'D') WS+ 
+// END MODULE - ISO/IEC 1539:1991 Section 11.3, R1104
+END_MODULE      : ('e'|'E') ('n'|'N') ('d'|'D') WS+
                   ('m'|'M') ('o'|'O') ('d'|'D') ('u'|'U') ('l'|'L') ('e'|'E') ;
+// USE keyword - ISO/IEC 1539:1991 Section 11.3.2, R1107
 USE             : ('u'|'U') ('s'|'S') ('e'|'E') ;
+// ONLY keyword - ISO/IEC 1539:1991 Section 11.3.2, R1108
 ONLY            : ('o'|'O') ('n'|'N') ('l'|'L') ('y'|'Y') ;
+// PUBLIC attribute - ISO/IEC 1539:1991 Section 5.1.2.1, R522
 PUBLIC          : ('p'|'P') ('u'|'U') ('b'|'B') ('l'|'L') ('i'|'I') ('c'|'C') ;
-PRIVATE         : ('p'|'P') ('r'|'R') ('i'|'I') ('v'|'V') 
+// PRIVATE attribute - ISO/IEC 1539:1991 Section 5.1.2.1, R522
+PRIVATE         : ('p'|'P') ('r'|'R') ('i'|'I') ('v'|'V')
                   ('a'|'A') ('t'|'T') ('e'|'E') ;
 
-// Interface blocks (F90 generic procedures)
-INTERFACE       : ('i'|'I') ('n'|'N') ('t'|'T') ('e'|'E') ('r'|'R') 
+// ====================================================================
+// INTERFACE BLOCKS - ISO/IEC 1539:1991 Section 12.3
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 12.3 defines interface blocks:
+// - R1201 (interface-block) -> interface-stmt [interface-specification]...
+//                              end-interface-stmt
+// - R1202 (interface-stmt) -> INTERFACE [generic-spec]
+// - R1203 (generic-spec) -> generic-name | OPERATOR(defined-operator) |
+//                           ASSIGNMENT(=)
+
+// INTERFACE keyword - ISO/IEC 1539:1991 Section 12.3, R1202
+INTERFACE       : ('i'|'I') ('n'|'N') ('t'|'T') ('e'|'E') ('r'|'R')
                   ('f'|'F') ('a'|'A') ('c'|'C') ('e'|'E') ;
-END_INTERFACE   : ('e'|'E') ('n'|'N') ('d'|'D') WS+ ('i'|'I') ('n'|'N') ('t'|'T') 
+// END INTERFACE - ISO/IEC 1539:1991 Section 12.3, R1201
+END_INTERFACE   : ('e'|'E') ('n'|'N') ('d'|'D') WS+ ('i'|'I') ('n'|'N') ('t'|'T')
                   ('e'|'E') ('r'|'R') ('f'|'F') ('a'|'A') ('c'|'C') ('e'|'E') ;
-GENERIC         : ('g'|'G') ('e'|'E') ('n'|'N') ('e'|'E') 
+// GENERIC keyword - ISO/IEC 1539:1991 Section 12.3.2.1
+GENERIC         : ('g'|'G') ('e'|'E') ('n'|'N') ('e'|'E')
                   ('r'|'R') ('i'|'I') ('c'|'C') ;
-OPERATOR        : ('o'|'O') ('p'|'P') ('e'|'E') ('r'|'R') 
+// OPERATOR keyword - ISO/IEC 1539:1991 Section 12.3, R1203
+OPERATOR        : ('o'|'O') ('p'|'P') ('e'|'E') ('r'|'R')
                   ('a'|'A') ('t'|'T') ('o'|'O') ('r'|'R') ;
-ASSIGNMENT      : ('a'|'A') ('s'|'S') ('s'|'S') ('i'|'I') ('g'|'G') 
+// ASSIGNMENT keyword - ISO/IEC 1539:1991 Section 12.3, R1203
+ASSIGNMENT      : ('a'|'A') ('s'|'S') ('s'|'S') ('i'|'I') ('g'|'G')
                   ('n'|'N') ('m'|'M') ('e'|'E') ('n'|'N') ('t'|'T') ;
 
-// Procedure enhancements (ISO/IEC 1539:1991 Section 12.5.2)
-// RECURSIVE is a genuine F90 feature introduced in ISO/IEC 1539:1991.
+// ====================================================================
+// PROCEDURE ENHANCEMENTS - ISO/IEC 1539:1991 Section 12.5.2
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 12.5.2 defines procedure prefixes:
+// - R1214 (prefix) -> prefix-spec [prefix-spec]...
+// - R1215 (prefix-spec) -> type-spec | RECURSIVE
 // NOTE: PURE and ELEMENTAL are Fortran 95 features (ISO/IEC 1539-1:1997),
 // defined in Fortran95Lexer.g4, NOT here.
+
+// RECURSIVE prefix - ISO/IEC 1539:1991 Section 12.5.2, R1215
 RECURSIVE       : ('r'|'R') ('e'|'E') ('c'|'C') ('u'|'U') ('r'|'R')
                   ('s'|'S') ('i'|'I') ('v'|'V') ('e'|'E') ;
+// RESULT clause - ISO/IEC 1539:1991 Section 12.5.2.2, R1216
 RESULT          : ('r'|'R') ('e'|'E') ('s'|'S') ('u'|'U') ('l'|'L') ('t'|'T') ;
 
-// Derived types (F90 major innovation)  
+// ====================================================================
+// DERIVED TYPES - ISO/IEC 1539:1991 Section 4.4
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 4.4 defines derived types:
+// - R422 (derived-type-def) -> derived-type-stmt [private-sequence-stmt]...
+//                              component-def-stmt... end-type-stmt
+// - R423 (derived-type-stmt) -> TYPE [[, access-spec] ::] type-name
+// - R429 (end-type-stmt) -> END TYPE [type-name]
+// - R430 (sequence-stmt) -> SEQUENCE
+
+// TYPE keyword - ISO/IEC 1539:1991 Section 4.4, R423
 TYPE            : ('t'|'T') ('y'|'Y') ('p'|'P') ('e'|'E') ;
-END_TYPE        : ('e'|'E') ('n'|'N') ('d'|'D') WS+ 
+// END TYPE - ISO/IEC 1539:1991 Section 4.4, R429
+END_TYPE        : ('e'|'E') ('n'|'N') ('d'|'D') WS+
                   ('t'|'T') ('y'|'Y') ('p'|'P') ('e'|'E') ;
-SEQUENCE        : ('s'|'S') ('e'|'E') ('q'|'Q') ('u'|'U') 
+// SEQUENCE statement - ISO/IEC 1539:1991 Section 4.4.1, R430
+SEQUENCE        : ('s'|'S') ('e'|'E') ('q'|'Q') ('u'|'U')
                   ('e'|'E') ('n'|'N') ('c'|'C') ('e'|'E') ;
 
-// Dynamic arrays and pointers (F90 runtime memory management)
-ALLOCATABLE     : ('a'|'A') ('l'|'L') ('l'|'L') ('o'|'O') ('c'|'C') ('a'|'A') 
+// ====================================================================
+// DYNAMIC MEMORY MANAGEMENT - ISO/IEC 1539:1991 Section 5.1.2.4 and 6.3
+// ====================================================================
+//
+// ISO/IEC 1539:1991 defines dynamic memory constructs:
+// - Section 5.1.2.4.3: ALLOCATABLE attribute (R515)
+// - Section 5.1.2.4.4: POINTER attribute (R516)
+// - Section 5.1.2.4.5: TARGET attribute (R517)
+// - Section 6.3.1: ALLOCATE statement (R620)
+// - Section 6.3.3: DEALLOCATE statement (R626)
+// - Section 6.3.2: NULLIFY statement (R624)
+
+// ALLOCATABLE attribute - ISO/IEC 1539:1991 Section 5.1.2.4.3, R515
+ALLOCATABLE     : ('a'|'A') ('l'|'L') ('l'|'L') ('o'|'O') ('c'|'C') ('a'|'A')
                   ('t'|'T') ('a'|'A') ('b'|'B') ('l'|'L') ('e'|'E') ;
-POINTER         : ('p'|'P') ('o'|'O') ('i'|'I') ('n'|'N') 
+// POINTER attribute - ISO/IEC 1539:1991 Section 5.1.2.4.4, R516
+POINTER         : ('p'|'P') ('o'|'O') ('i'|'I') ('n'|'N')
                   ('t'|'T') ('e'|'E') ('r'|'R') ;
+// TARGET attribute - ISO/IEC 1539:1991 Section 5.1.2.4.5, R517
 TARGET          : ('t'|'T') ('a'|'A') ('r'|'R') ('g'|'G') ('e'|'E') ('t'|'T') ;
-ALLOCATE        : ('a'|'A') ('l'|'L') ('l'|'L') ('o'|'O') 
+// ALLOCATE statement - ISO/IEC 1539:1991 Section 6.3.1, R620
+ALLOCATE        : ('a'|'A') ('l'|'L') ('l'|'L') ('o'|'O')
                   ('c'|'C') ('a'|'A') ('t'|'T') ('e'|'E') ;
-DEALLOCATE      : ('d'|'D') ('e'|'E') ('a'|'A') ('l'|'L') ('l'|'L') 
+// DEALLOCATE statement - ISO/IEC 1539:1991 Section 6.3.3, R626
+DEALLOCATE      : ('d'|'D') ('e'|'E') ('a'|'A') ('l'|'L') ('l'|'L')
                   ('o'|'O') ('c'|'C') ('a'|'A') ('t'|'T') ('e'|'E') ;
-NULLIFY         : ('n'|'N') ('u'|'U') ('l'|'L') ('l'|'L') 
+// NULLIFY statement - ISO/IEC 1539:1991 Section 6.3.2, R624
+NULLIFY         : ('n'|'N') ('u'|'U') ('l'|'L') ('l'|'L')
                   ('i'|'I') ('f'|'F') ('y'|'Y') ;
-ASSOCIATED      : ('a'|'A') ('s'|'S') ('s'|'S') ('o'|'O') ('c'|'C') 
+// ASSOCIATED intrinsic - ISO/IEC 1539:1991 Section 13.8.6
+ASSOCIATED      : ('a'|'A') ('s'|'S') ('s'|'S') ('o'|'O') ('c'|'C')
                   ('i'|'I') ('a'|'A') ('t'|'T') ('e'|'E') ('d'|'D') ;
 
-// Enhanced control flow
+// ====================================================================
+// CONTROL FLOW - ISO/IEC 1539:1991 Section 8.1
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 8.1 defines execution control constructs:
+// - Section 8.1.3: CASE construct (R808-R813)
+// - Section 7.5.3: WHERE construct (R738-R743)
+// - Section 8.1.4.4: CYCLE and EXIT statements (R834, R835)
+
+// SELECT CASE keywords - ISO/IEC 1539:1991 Section 8.1.3, R808
 SELECT          : ('s'|'S') ('e'|'E') ('l'|'L') ('e'|'E') ('c'|'C') ('t'|'T') ;
+// CASE keyword - ISO/IEC 1539:1991 Section 8.1.3.2, R811
 CASE            : ('c'|'C') ('a'|'A') ('s'|'S') ('e'|'E') ;
-DEFAULT         : ('d'|'D') ('e'|'E') ('f'|'F') ('a'|'A') 
+// DEFAULT case selector - ISO/IEC 1539:1991 Section 8.1.3.2, R812
+DEFAULT         : ('d'|'D') ('e'|'E') ('f'|'F') ('a'|'A')
                   ('u'|'U') ('l'|'L') ('t'|'T') ;
-END_SELECT      : ('e'|'E') ('n'|'N') ('d'|'D') WS+ ('s'|'S') ('e'|'E') 
+// END SELECT - ISO/IEC 1539:1991 Section 8.1.3, R813
+END_SELECT      : ('e'|'E') ('n'|'N') ('d'|'D') WS+ ('s'|'S') ('e'|'E')
                   ('l'|'L') ('e'|'E') ('c'|'C') ('t'|'T') ;
+// WHERE keyword - ISO/IEC 1539:1991 Section 7.5.3, R738
 WHERE           : ('w'|'W') ('h'|'H') ('e'|'E') ('r'|'R') ('e'|'E') ;
-END_WHERE       : ('e'|'E') ('n'|'N') ('d'|'D') WS+ ('w'|'W') ('h'|'H') 
+// END WHERE - ISO/IEC 1539:1991 Section 7.5.3, R743
+END_WHERE       : ('e'|'E') ('n'|'N') ('d'|'D') WS+ ('w'|'W') ('h'|'H')
                   ('e'|'E') ('r'|'R') ('e'|'E') ;
-ELSEWHERE       : ('e'|'E') ('l'|'L') ('s'|'S') ('e'|'E') ('w'|'W') 
+// ELSEWHERE - ISO/IEC 1539:1991 Section 7.5.3, R741
+ELSEWHERE       : ('e'|'E') ('l'|'L') ('s'|'S') ('e'|'E') ('w'|'W')
                   ('h'|'H') ('e'|'E') ('r'|'R') ('e'|'E') ;
 
-// Enhanced loop control
+// ====================================================================
+// LOOP CONTROL - ISO/IEC 1539:1991 Section 8.1.4
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 8.1.4 defines DO construct control:
+// - Section 8.1.4.4.1: CYCLE statement (R834)
+// - Section 8.1.4.4.2: EXIT statement (R835)
+
+// CYCLE statement - ISO/IEC 1539:1991 Section 8.1.4.4.1, R834
 CYCLE           : ('c'|'C') ('y'|'Y') ('c'|'C') ('l'|'L') ('e'|'E') ;
+// EXIT statement - ISO/IEC 1539:1991 Section 8.1.4.4.2, R835
 EXIT            : ('e'|'E') ('x'|'X') ('i'|'I') ('t'|'T') ;
 
-// Enhanced I/O
-NAMELIST        : ('n'|'N') ('a'|'A') ('m'|'M') ('e'|'E') 
+// ====================================================================
+// INPUT/OUTPUT - ISO/IEC 1539:1991 Section 9
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 9 defines I/O statements and specifiers:
+// - Section 5.4: NAMELIST statement (R527)
+// - Section 9.4.1: I/O control specifiers (R911-R921)
+// - Section 9.4.1.5: ADVANCE= specifier (non-advancing I/O)
+// - Section 9.4.1.6: SIZE= specifier (characters transferred)
+// - Section 9.4.1.2: IOSTAT= specifier
+// - Section 9.4.1.4: EOR= specifier (end-of-record)
+
+// NAMELIST statement - ISO/IEC 1539:1991 Section 5.4, R527
+NAMELIST        : ('n'|'N') ('a'|'A') ('m'|'M') ('e'|'E')
                   ('l'|'L') ('i'|'I') ('s'|'S') ('t'|'T') ;
-ADVANCE         : ('a'|'A') ('d'|'D') ('v'|'V') ('a'|'A') 
+// ADVANCE= specifier - ISO/IEC 1539:1991 Section 9.4.1.5
+ADVANCE         : ('a'|'A') ('d'|'D') ('v'|'V') ('a'|'A')
                   ('n'|'N') ('c'|'C') ('e'|'E') ;
+// SIZE= specifier - ISO/IEC 1539:1991 Section 9.4.1.6
 SIZE            : ('s'|'S') ('i'|'I') ('z'|'Z') ('e'|'E') ;
+// STAT= specifier (allocation status) - ISO/IEC 1539:1991 Section 6.3.1, R623
 STAT            : ('s'|'S') ('t'|'T') ('a'|'A') ('t'|'T') ;
+// EOR= specifier - ISO/IEC 1539:1991 Section 9.4.1.4
 EOR             : ('e'|'E') ('o'|'O') ('r'|'R') ;
+// IOSTAT= specifier - ISO/IEC 1539:1991 Section 9.4.1.2, R921
 IOSTAT          : ('i'|'I') ('o'|'O') ('s'|'S') ('t'|'T') ('a'|'A') ('t'|'T') ;
 
-// Intent specifications (F90 procedure interface)
+// ====================================================================
+// PROCEDURE ARGUMENTS - ISO/IEC 1539:1991 Section 5.1.2.3 and 12.4.1.2
+// ====================================================================
+//
+// ISO/IEC 1539:1991 defines procedure argument attributes:
+// - Section 5.1.2.3: INTENT attribute (R518)
+// - Section 5.1.2.6: OPTIONAL attribute (R521)
+// - Section 13.8.64: PRESENT intrinsic
+
+// INTENT attribute - ISO/IEC 1539:1991 Section 5.1.2.3, R518
 INTENT          : ('i'|'I') ('n'|'N') ('t'|'T') ('e'|'E') ('n'|'N') ('t'|'T') ;
+// INTENT(IN) - ISO/IEC 1539:1991 Section 5.1.2.3, R519
 IN              : ('i'|'I') ('n'|'N') ;
+// INTENT(OUT) - ISO/IEC 1539:1991 Section 5.1.2.3, R519
 OUT             : ('o'|'O') ('u'|'U') ('t'|'T') ;
+// INTENT(INOUT) - ISO/IEC 1539:1991 Section 5.1.2.3, R519
 INOUT           : ('i'|'I') ('n'|'N') ('o'|'O') ('u'|'U') ('t'|'T') ;
 
-// Optional arguments
-OPTIONAL        : ('o'|'O') ('p'|'P') ('t'|'T') ('i'|'I') 
+// OPTIONAL attribute - ISO/IEC 1539:1991 Section 5.1.2.6, R521
+OPTIONAL        : ('o'|'O') ('p'|'P') ('t'|'T') ('i'|'I')
                   ('o'|'O') ('n'|'N') ('a'|'A') ('l'|'L') ;
-PRESENT         : ('p'|'P') ('r'|'R') ('e'|'E') ('s'|'S') 
+// PRESENT intrinsic - ISO/IEC 1539:1991 Section 13.8.64
+PRESENT         : ('p'|'P') ('r'|'R') ('e'|'E') ('s'|'S')
                   ('e'|'E') ('n'|'N') ('t'|'T') ;
 
-// Enhanced data types
+// ====================================================================
+// KIND TYPE PARAMETERS - ISO/IEC 1539:1991 Section 4.3.1
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 4.3.1 defines kind type parameters:
+// - R401 (type-param-value) -> scalar-int-expr | * | :
+// - R404 (kind-selector) -> (KIND = scalar-int-initialization-expr) |
+//                           (scalar-int-initialization-expr)
+// - Section 13.8.73: SELECTED_INT_KIND intrinsic
+// - Section 13.8.74: SELECTED_REAL_KIND intrinsic
+
+// KIND keyword - ISO/IEC 1539:1991 Section 4.3.1, R404
 KIND            : ('k'|'K') ('i'|'I') ('n'|'N') ('d'|'D') ;
+// LEN keyword (character length) - ISO/IEC 1539:1991 Section 4.3.2.1, R406
 LEN             : ('l'|'L') ('e'|'E') ('n'|'N') ;
-SELECTED_INT_KIND     : ('s'|'S') ('e'|'E') ('l'|'L') ('e'|'E') ('c'|'C') 
-                        ('t'|'T') ('e'|'E') ('d'|'D') '_' ('i'|'I') ('n'|'N') 
+// SELECTED_INT_KIND intrinsic - ISO/IEC 1539:1991 Section 13.8.73
+SELECTED_INT_KIND     : ('s'|'S') ('e'|'E') ('l'|'L') ('e'|'E') ('c'|'C')
+                        ('t'|'T') ('e'|'E') ('d'|'D') '_' ('i'|'I') ('n'|'N')
                         ('t'|'T') '_' ('k'|'K') ('i'|'I') ('n'|'N') ('d'|'D') ;
-SELECTED_REAL_KIND    : ('s'|'S') ('e'|'E') ('l'|'L') ('e'|'E') ('c'|'C') 
-                        ('t'|'T') ('e'|'E') ('d'|'D') '_' ('r'|'R') ('e'|'E') 
-                        ('a'|'A') ('l'|'L') '_' ('k'|'K') ('i'|'I') 
+// SELECTED_REAL_KIND intrinsic - ISO/IEC 1539:1991 Section 13.8.74
+SELECTED_REAL_KIND    : ('s'|'S') ('e'|'E') ('l'|'L') ('e'|'E') ('c'|'C')
+                        ('t'|'T') ('e'|'E') ('d'|'D') '_' ('r'|'R') ('e'|'E')
+                        ('a'|'A') ('l'|'L') '_' ('k'|'K') ('i'|'I')
                         ('n'|'N') ('d'|'D') ;
 
-// Additional F90 keywords
-CONTAINS        : ('c'|'C') ('o'|'O') ('n'|'N') ('t'|'T') 
+// ====================================================================
+// PROGRAM STRUCTURE KEYWORDS - ISO/IEC 1539:1991 Section 11-12
+// ====================================================================
+//
+// ISO/IEC 1539:1991 defines program structure keywords:
+// - Section 12.5.1: CONTAINS statement (R1217)
+// - Section 12.3.2.2: IMPORT statement (host association)
+// - Section 12.3: PROCEDURE keyword
+// - Section 9.4.1.1: UNIT=, FMT=, REC=, ERR= specifiers
+// - Section 8.1.4: DO WHILE construct
+
+// CONTAINS statement - ISO/IEC 1539:1991 Section 12.5.1, R1217
+CONTAINS        : ('c'|'C') ('o'|'O') ('n'|'N') ('t'|'T')
                   ('a'|'A') ('i'|'I') ('n'|'N') ('s'|'S') ;
+// IMPORT statement - ISO/IEC 1539:1991 Section 12.3.2.2 (host association)
+// NOTE: Full IMPORT is Fortran 2003; F90 has implicit host association
 IMPORT          : ('i'|'I') ('m'|'M') ('p'|'P') ('o'|'O') ('r'|'R') ('t'|'T') ;
-PROCEDURE       : ('p'|'P') ('r'|'R') ('o'|'O') ('c'|'C') ('e'|'E') 
+// PROCEDURE keyword - ISO/IEC 1539:1991 Section 12.3
+PROCEDURE       : ('p'|'P') ('r'|'R') ('o'|'O') ('c'|'C') ('e'|'E')
                   ('d'|'D') ('u'|'U') ('r'|'R') ('e'|'E') ;
+// UNIT= specifier - ISO/IEC 1539:1991 Section 9.4.1.1, R911
 UNIT            : ('u'|'U') ('n'|'N') ('i'|'I') ('t'|'T') ;
+// FMT= specifier - ISO/IEC 1539:1991 Section 9.4.1.1, R912
 FMT             : ('f'|'F') ('m'|'M') ('t'|'T') ;
+// REC= specifier - ISO/IEC 1539:1991 Section 9.4.1.3
 REC             : ('r'|'R') ('e'|'E') ('c'|'C') ;
+// ERR= specifier - ISO/IEC 1539:1991 Section 9.4.1.2
 ERR             : ('e'|'E') ('r'|'R') ('r'|'R') ;
+// WHILE keyword (DO WHILE) - ISO/IEC 1539:1991 Section 8.1.4.1.1, R820
 WHILE           : ('w'|'W') ('h'|'H') ('i'|'I') ('l'|'L') ('e'|'E') ;
 
-// ====================================================================  
-// FORTRAN 90 OPERATORS (NEW AND ENHANCED)
 // ====================================================================
+// FORTRAN 90 OPERATORS - ISO/IEC 1539:1991 Section 3.2 and 7.2
+// ====================================================================
+//
+// ISO/IEC 1539:1991 defines new operators and special characters:
+// - Section 3.2.3: Special characters
+// - Section 7.2.2: Relational operators (new symbolic forms)
+// - Section 6.1.2: Component selector (%)
+// - Section 7.5.2: Pointer assignment (=>)
+// - Section 4.5: Array constructor delimiter (/ /)
 
-// F90 specific operators (free-form innovations)
+// Double colon separator - ISO/IEC 1539:1991 Section 5.1, R501
 DOUBLE_COLON    : '::' ;
+// Pointer assignment operator - ISO/IEC 1539:1991 Section 7.5.2, R735
 POINTER_ASSIGN  : '=>' ;
+// Component selector - ISO/IEC 1539:1991 Section 6.1.2, R614
 PERCENT         : '%' ;
-SLASH           : '/' ;    // For array constructors (/ ... /)
+// Slash (array constructor delimiter) - ISO/IEC 1539:1991 Section 4.5, R432
+SLASH           : '/' ;
 // NOTE: Square brackets for array constructors [ ... ] are a Fortran 2003
 // feature (ISO/IEC 1539-1:2004), defined in Fortran2003Lexer.g4, NOT here.
 
-// F90 array intrinsic keywords
+// ====================================================================
+// ARRAY INQUIRY KEYWORDS - ISO/IEC 1539:1991 Section 13.8
+// ====================================================================
+
+// LBOUND intrinsic - ISO/IEC 1539:1991 Section 13.8.43
 LBOUND          : L B O U N D ;
+// UBOUND intrinsic - ISO/IEC 1539:1991 Section 13.8.93
 UBOUND          : U B O U N D ;
+// ALLOCATED intrinsic - ISO/IEC 1539:1991 Section 13.8.4
 ALLOCATED       : A L L O C A T E D ;
 
-// Enhanced relational operators (both styles supported)
+// ====================================================================
+// RELATIONAL OPERATORS - ISO/IEC 1539:1991 Section 7.2.2
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 7.2.2.4 defines new symbolic relational operators:
+// - .EQ. and == (equal)
+// - .NE. and /= (not equal)
+// - .LT. and < (less than)
+// - .LE. and <= (less than or equal)
+// - .GT. and > (greater than)
+// - .GE. and >= (greater than or equal)
+// The dotted forms are inherited from FORTRAN 77.
+
+// == operator - ISO/IEC 1539:1991 Section 7.2.2.4, R713
 EQ_OP           : '==' ;
+// /= operator - ISO/IEC 1539:1991 Section 7.2.2.4, R713
 NE_OP           : '/=' ;
+// < operator - ISO/IEC 1539:1991 Section 7.2.2.4, R713
 LT_OP           : '<' ;
+// <= operator - ISO/IEC 1539:1991 Section 7.2.2.4, R713
 LE_OP           : '<=' ;
+// > operator - ISO/IEC 1539:1991 Section 7.2.2.4, R713
 GT_OP           : '>' ;
+// >= operator - ISO/IEC 1539:1991 Section 7.2.2.4, R713
 GE_OP           : '>=' ;
 
 // ====================================================================
-// FORTRAN 90 LITERALS (ENHANCED)
+// FORTRAN 90 LITERALS - ISO/IEC 1539:1991 Section 4
 // ====================================================================
+//
+// ISO/IEC 1539:1991 Section 4 defines literal constants:
+// - Section 4.3.1.1: Integer literal constants (R405)
+// - Section 4.3.1.2: Real literal constants (R412)
+// - Section 4.3.2: Character literal constants (R420)
+// - Section 4.3.3: BOZ literal constants (R407-R409)
+// - Section 4.3.1: Kind type parameters (_kind suffix)
 
-// Kind-parameterized literals (F90 innovation)
+// Kind-parameterized integer literal - ISO/IEC 1539:1991 Section 4.3.1.1, R405
 INTEGER_LITERAL_KIND : DIGIT+ '_' IDENTIFIER ;
 
-// Override INTEGER_LITERAL to take precedence over LABEL from earlier standards
+// Integer literal constant - ISO/IEC 1539:1991 Section 4.3.1.1, R405
+// Override to take precedence over LABEL from earlier standards
 INTEGER_LITERAL : DIGIT+ ;
 
-// Override REAL_LITERAL to ensure consistency
+// Real literal constant - ISO/IEC 1539:1991 Section 4.3.1.2, R412
+// Override to ensure consistency
 REAL_LITERAL    : DIGIT+ '.' DIGIT* EXPONENT?
                 | '.' DIGIT+ EXPONENT?
                 | DIGIT+ EXPONENT ;
 
+// Kind-parameterized real literal - ISO/IEC 1539:1991 Section 4.3.1.2, R413
 REAL_LITERAL_KIND    : (DIGIT+ '.' DIGIT* | '.' DIGIT+) EXPONENT? '_' IDENTIFIER
                     | DIGIT+ EXPONENT '_' IDENTIFIER ;
 
-// String literals (F90 adds double quotes)
+// Character literal constants - ISO/IEC 1539:1991 Section 4.3.2.1, R420
+// F90 adds double quotes as alternative to single quotes
 DOUBLE_QUOTE_STRING  : '"' (~["\r\n] | '""')* '"' ;
 SINGLE_QUOTE_STRING  : '\'' (~['\r\n] | '\'\'')* '\'' ;
 
-// BOZ literal constants (F90 binary/octal/hex)
+// ====================================================================
+// BOZ LITERAL CONSTANTS - ISO/IEC 1539:1991 Section 4.3.3
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 4.3.3 defines BOZ literal constants:
+// - R407 (boz-literal-constant) -> binary-constant | octal-constant | hex-constant
+// - R408 (binary-constant) -> B quote digit [digit]... quote
+// - R409 (octal-constant) -> O quote digit [digit]... quote
+// - R410 (hex-constant) -> Z quote hex-digit [hex-digit]... quote
+
+// Binary constant - ISO/IEC 1539:1991 Section 4.3.3, R408
 BINARY_CONSTANT : ('b'|'B') '\'' [01]+ '\'' ;
+// Octal constant - ISO/IEC 1539:1991 Section 4.3.3, R409
 OCTAL_CONSTANT  : ('o'|'O') '\'' [0-7]+ '\'' ;
+// Hex constant - ISO/IEC 1539:1991 Section 4.3.3, R410
 HEX_CONSTANT    : ('z'|'Z'|'x'|'X') '\'' [0-9a-fA-F]+ '\'' ;
 
+// Exponent fragment - ISO/IEC 1539:1991 Section 4.3.1.2
 fragment EXPONENT : [eEdD] [+-]? DIGIT+ ;
 
 // ====================================================================
-// FORTRAN 90 INTRINSIC FUNCTIONS (MAJOR ADDITIONS)
+// FORTRAN 90 INTRINSIC PROCEDURES - ISO/IEC 1539:1991 Section 13
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 13 defines intrinsic procedures.
+// F90 introduces many new array and transformational intrinsics.
+// Section numbers reference the individual intrinsic descriptions.
+
+// ====================================================================
+// ARRAY REDUCTION INTRINSICS - ISO/IEC 1539:1991 Section 13.8
 // ====================================================================
 
-// Array inquiry functions
+// ALL intrinsic - ISO/IEC 1539:1991 Section 13.8.3
 ALL_INTRINSIC         : ('a'|'A') ('l'|'L') ('l'|'L') ;
+// ANY intrinsic - ISO/IEC 1539:1991 Section 13.8.5
 ANY_INTRINSIC         : ('a'|'A') ('n'|'N') ('y'|'Y') ;
+// COUNT intrinsic - ISO/IEC 1539:1991 Section 13.8.17
 COUNT_INTRINSIC       : ('c'|'C') ('o'|'O') ('u'|'U') ('n'|'N') ('t'|'T') ;
-DOT_PRODUCT_INTRINSIC : ('d'|'D') ('o'|'O') ('t'|'T') '_' ('p'|'P') ('r'|'R') 
+// DOT_PRODUCT intrinsic - ISO/IEC 1539:1991 Section 13.8.24
+DOT_PRODUCT_INTRINSIC : ('d'|'D') ('o'|'O') ('t'|'T') '_' ('p'|'P') ('r'|'R')
                         ('o'|'O') ('d'|'D') ('u'|'U') ('c'|'C') ('t'|'T') ;
+// MATMUL intrinsic - ISO/IEC 1539:1991 Section 13.8.50
 MATMUL_INTRINSIC      : ('m'|'M') ('a'|'A') ('t'|'T') ('m'|'M') ('u'|'U') ('l'|'L') ;
+// MAXVAL intrinsic - ISO/IEC 1539:1991 Section 13.8.52
 MAXVAL_INTRINSIC      : ('m'|'M') ('a'|'A') ('x'|'X') ('v'|'V') ('a'|'A') ('l'|'L') ;
+// MINVAL intrinsic - ISO/IEC 1539:1991 Section 13.8.55
 MINVAL_INTRINSIC      : ('m'|'M') ('i'|'I') ('n'|'N') ('v'|'V') ('a'|'A') ('l'|'L') ;
-PRODUCT_INTRINSIC     : ('p'|'P') ('r'|'R') ('o'|'O') ('d'|'D') 
+// PRODUCT intrinsic - ISO/IEC 1539:1991 Section 13.8.65
+PRODUCT_INTRINSIC     : ('p'|'P') ('r'|'R') ('o'|'O') ('d'|'D')
                         ('u'|'U') ('c'|'C') ('t'|'T') ;
+// SUM intrinsic - ISO/IEC 1539:1991 Section 13.8.88
 SUM_INTRINSIC         : ('s'|'S') ('u'|'U') ('m'|'M') ;
-TRANSPOSE_INTRINSIC   : ('t'|'T') ('r'|'R') ('a'|'A') ('n'|'N') ('s'|'S') 
+// TRANSPOSE intrinsic - ISO/IEC 1539:1991 Section 13.8.89
+TRANSPOSE_INTRINSIC   : ('t'|'T') ('r'|'R') ('a'|'A') ('n'|'N') ('s'|'S')
                         ('p'|'P') ('o'|'O') ('s'|'S') ('e'|'E') ;
 
-// Array shape functions
+// ====================================================================
+// ARRAY INQUIRY INTRINSICS - ISO/IEC 1539:1991 Section 13.8
+// ====================================================================
+
+// SIZE intrinsic - ISO/IEC 1539:1991 Section 13.8.83
 SIZE_INTRINSIC        : ('s'|'S') ('i'|'I') ('z'|'Z') ('e'|'E') ;
+// SHAPE intrinsic - ISO/IEC 1539:1991 Section 13.8.81
 SHAPE_INTRINSIC       : ('s'|'S') ('h'|'H') ('a'|'A') ('p'|'P') ('e'|'E') ;
+// UBOUND intrinsic - ISO/IEC 1539:1991 Section 13.8.93
 UBOUND_INTRINSIC      : ('u'|'U') ('b'|'B') ('o'|'O') ('u'|'U') ('n'|'N') ('d'|'D') ;
+// LBOUND intrinsic - ISO/IEC 1539:1991 Section 13.8.43
 LBOUND_INTRINSIC      : ('l'|'L') ('b'|'B') ('o'|'O') ('u'|'U') ('n'|'N') ('d'|'D') ;
-ALLOCATED_INTRINSIC   : ('a'|'A') ('l'|'L') ('l'|'L') ('o'|'O') ('c'|'C') 
+// ALLOCATED intrinsic - ISO/IEC 1539:1991 Section 13.8.4
+ALLOCATED_INTRINSIC   : ('a'|'A') ('l'|'L') ('l'|'L') ('o'|'O') ('c'|'C')
                         ('a'|'A') ('t'|'T') ('e'|'E') ('d'|'D') ;
 
-// Array manipulation functions
+// ====================================================================
+// ARRAY MANIPULATION INTRINSICS - ISO/IEC 1539:1991 Section 13.8
+// ====================================================================
+
+// PACK intrinsic - ISO/IEC 1539:1991 Section 13.8.60
 PACK_INTRINSIC        : ('p'|'P') ('a'|'A') ('c'|'C') ('k'|'K') ;
+// UNPACK intrinsic - ISO/IEC 1539:1991 Section 13.8.94
 UNPACK_INTRINSIC      : ('u'|'U') ('n'|'N') ('p'|'P') ('a'|'A') ('c'|'C') ('k'|'K') ;
-RESHAPE_INTRINSIC     : ('r'|'R') ('e'|'E') ('s'|'S') ('h'|'H') 
+// RESHAPE intrinsic - ISO/IEC 1539:1991 Section 13.8.69
+RESHAPE_INTRINSIC     : ('r'|'R') ('e'|'E') ('s'|'S') ('h'|'H')
                         ('a'|'A') ('p'|'P') ('e'|'E') ;
+// SPREAD intrinsic - ISO/IEC 1539:1991 Section 13.8.85
 SPREAD_INTRINSIC      : ('s'|'S') ('p'|'P') ('r'|'R') ('e'|'E') ('a'|'A') ('d'|'D') ;
+// MERGE intrinsic - ISO/IEC 1539:1991 Section 13.8.53
 MERGE_INTRINSIC       : ('m'|'M') ('e'|'E') ('r'|'R') ('g'|'G') ('e'|'E') ;
 
-// String functions
+// ====================================================================
+// CHARACTER INTRINSICS - ISO/IEC 1539:1991 Section 13.8
+// ====================================================================
+
+// TRIM intrinsic - ISO/IEC 1539:1991 Section 13.8.91
 TRIM_INTRINSIC        : ('t'|'T') ('r'|'R') ('i'|'I') ('m'|'M') ;
-ADJUSTL_INTRINSIC     : ('a'|'A') ('d'|'D') ('j'|'J') ('u'|'U') 
+// ADJUSTL intrinsic - ISO/IEC 1539:1991 Section 13.8.1
+ADJUSTL_INTRINSIC     : ('a'|'A') ('d'|'D') ('j'|'J') ('u'|'U')
                         ('s'|'S') ('t'|'T') ('l'|'L') ;
-ADJUSTR_INTRINSIC     : ('a'|'A') ('d'|'D') ('j'|'J') ('u'|'U') 
+// ADJUSTR intrinsic - ISO/IEC 1539:1991 Section 13.8.2
+ADJUSTR_INTRINSIC     : ('a'|'A') ('d'|'D') ('j'|'J') ('u'|'U')
                         ('s'|'S') ('t'|'T') ('r'|'R') ;
+// REPEAT intrinsic - ISO/IEC 1539:1991 Section 13.8.68
 REPEAT_INTRINSIC      : ('r'|'R') ('e'|'E') ('p'|'P') ('e'|'E') ('a'|'A') ('t'|'T') ;
 
 // ====================================================================
-// WHITESPACE AND SEPARATORS
+// STATEMENT SEPARATORS - ISO/IEC 1539:1991 Section 3.4.2
 // ====================================================================
 
 // Semicolon for multiple statements per line (free-form)
+// ISO/IEC 1539:1991 Section 3.4.2: A semicolon separates statements
 SEMICOLON : ';' ;
 
 // ====================================================================
-// F90-SPECIFIC TOKENS (not in SharedCoreLexer)
+// IMPLICIT STATEMENT - ISO/IEC 1539:1991 Section 5.3
 // ====================================================================
+//
+// ISO/IEC 1539:1991 Section 5.3 defines the IMPLICIT statement:
+// - R540 (implicit-stmt) -> IMPLICIT implicit-spec-list |
+//                           IMPLICIT NONE
+// - R541 (implicit-spec) -> type-spec (letter-spec-list)
 
-// F90-specific tokens (not in earlier standards)
-// Note: DOUBLE, PRECISION, COMPLEX inherited from FORTRAN IV (1962)
-// Note: SAVE, CONCAT inherited from FORTRAN 77 (1977)
-// Note: EQUIVALENCE, DIMENSION inherited from SharedCoreLexer (FORTRAN I, 1957)
-IMPLICIT        : ('i'|'I') ('m'|'M') ('p'|'P') ('l'|'L') 
+// IMPLICIT keyword - ISO/IEC 1539:1991 Section 5.3, R540
+IMPLICIT        : ('i'|'I') ('m'|'M') ('p'|'P') ('l'|'L')
                   ('i'|'I') ('c'|'C') ('i'|'I') ('t'|'T') ;
+// NONE keyword (IMPLICIT NONE) - ISO/IEC 1539:1991 Section 5.3, R540
 NONE            : ('n'|'N') ('o'|'O') ('n'|'N') ('e'|'E') ;
+
+// ====================================================================
+// WHITESPACE HANDLING - ISO/IEC 1539:1991 Section 3.2.4
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 3.2.4 defines blank interpretation:
+// - In free form, blanks are significant (separate lexical tokens)
+// - In fixed form, blanks in columns 7-72 are generally insignificant
 
 // Whitespace handling - MUST skip spaces and tabs
 WHITESPACE : [ \t]+ -> skip ;
@@ -306,21 +610,36 @@ NEWLINE    : [\r\n]+ ;
 // Whitespace fragment for compound tokens
 fragment WS : [ \t]+ ;
 
-// Digit fragment for numeric literals
+// Digit fragment for numeric literals - ISO/IEC 1539:1991 Section 3.1.1
 fragment DIGIT : [0-9] ;
 
 // ====================================================================
-// FORTRAN 90 LEXER NOTES
+// FORTRAN 90 LEXER - ISO/IEC 1539:1991 SPEC-GRAMMAR MAPPING
 // ====================================================================
 //
-// This lexer is intended to support both fixed-form (.f, .for) and
-// free-form (.f90+) Fortran 90 source in a single grammar, and to
-// provide tokens for the major F90 language features exercised by the
-// tests in this repository.
+// This lexer implements token rules for Fortran 90 as defined in
+// ISO/IEC 1539:1991 (WG5 N692). It is not a formally validated,
+// complete implementation of every detail of the standard, but
+// provides a practical basis for parsing F90+ source files.
 //
-// It is not a formally validated, complete implementation of every
-// detail of ISO/IEC 1539-1:1991, but it provides a practical basis for
-// experimenting with and testing F90+, and for serving as a base lexer
-// for later standards.
+// ISO/IEC 1539:1991 SPEC-GRAMMAR MAPPING (LEXER):
+// Section 3 (Source form)     -> FREE_FORM_COMMENT, FIXED_FORM_COMMENT,
+//                                CONTINUATION, NEWLINE, SEMICOLON
+// Section 4 (Data types)      -> INTEGER_LITERAL*, REAL_LITERAL*, *_CONSTANT,
+//                                *_QUOTE_STRING, KIND, LEN
+// Section 5 (Declarations)    -> PUBLIC, PRIVATE, ALLOCATABLE, POINTER,
+//                                TARGET, INTENT, OPTIONAL, IMPLICIT, NONE
+// Section 6 (Use of data)     -> ALLOCATE, DEALLOCATE, NULLIFY, PERCENT
+// Section 7 (Expressions)     -> EQ_OP, NE_OP, LT_OP, LE_OP, GT_OP, GE_OP,
+//                                POINTER_ASSIGN, DOUBLE_COLON
+// Section 8 (Control)         -> SELECT, CASE, DEFAULT, WHERE, ELSEWHERE,
+//                                CYCLE, EXIT, WHILE, END_*
+// Section 9 (I/O)             -> NAMELIST, ADVANCE, SIZE, STAT, EOR, IOSTAT,
+//                                UNIT, FMT, REC, ERR
+// Section 11 (Program units)  -> MODULE, END_MODULE, USE, ONLY, CONTAINS
+// Section 12 (Procedures)     -> INTERFACE, END_INTERFACE, GENERIC, OPERATOR,
+//                                ASSIGNMENT, RECURSIVE, RESULT, PROCEDURE
+// Section 13 (Intrinsics)     -> *_INTRINSIC tokens, SELECTED_*_KIND,
+//                                ASSOCIATED, ALLOCATED, PRESENT
 //
 // ====================================================================

--- a/grammars/src/Fortran90Parser.g4
+++ b/grammars/src/Fortran90Parser.g4
@@ -1,16 +1,17 @@
 // Fortran 90 (1990) Parser - Unified Fixed/Free Form Support
-// Revolutionary Modern Foundation with Complete Format Compatibility
+// Reference: ISO/IEC 1539:1991 (Fortran 90)
+//            WG5 N692 draft (validation/pdfs/Fortran90_WG5_N692.txt)
 // Refactored per issue #252 into smaller delegate modules
 parser grammar Fortran90Parser;
 
 import FORTRAN77Parser,  // FORTRAN 77 (1977) - structured programming foundation
-       F90ModulesParser, // Module system and interfaces
-       F90TypesParser,   // Type declarations and derived types
-       F90ControlParser, // Control structures (SELECT CASE, WHERE, DO, IF)
-       F90IOParser,      // I/O statements and NAMELIST
-       F90ExprsParser,   // Expressions and array operations
-       F90MemoryParser,  // Dynamic memory management
-       F90ProcsParser,   // Procedures and subprograms
+       F90ModulesParser, // Module system and interfaces (Section 11.3, 12.3)
+       F90TypesParser,   // Type declarations and derived types (Section 4, 5)
+       F90ControlParser, // Control structures (Section 7.5.3, 8.1)
+       F90IOParser,      // I/O statements and NAMELIST (Section 5.4, 9)
+       F90ExprsParser,   // Expressions and array operations (Section 4.5, 7)
+       F90MemoryParser,  // Dynamic memory management (Section 6.3)
+       F90ProcsParser,   // Procedures and subprograms (Section 12)
        F90InheritedParser;  // Inherited F77 compatibility rules
 
 options {
@@ -21,22 +22,39 @@ options {
 // FORTRAN 90 UNIFIED PARSER OVERVIEW
 // ====================================================================
 //
-// Fortran 90 (ISO 1539:1991) represents the most significant revolution
-// in Fortran history, introducing free-form source format while maintaining
-// complete backward compatibility with fixed-form.
+// This parser implements syntax rules for Fortran 90 as defined in:
+//   ISO/IEC 1539:1991 (Fortran 90 International Standard)
+//   WG5 N692 (Fortran 90 draft, equivalent to final standard)
 //
-// This parser handles BOTH formats in a single grammar:
-// - Fixed-form: .f, .for files (F77 compatibility)
-// - Free-form: .f90+ files (modern syntax)
+// ISO/IEC 1539:1991 Standard Structure Overview:
+//   Section 1: Overview
+//   Section 2: Fortran Terms and Concepts (2.1-2.5)
+//   Section 3: Characters and Low Level Syntax (3.1-3.4)
+//   Section 4: Data Types (4.1-4.5)
+//   Section 5: Data Object Declarations (5.1-5.5)
+//   Section 6: Use of Data Objects (6.1-6.5)
+//   Section 7: Expressions and Assignment (7.1-7.5)
+//   Section 8: Execution Control (8.1-8.3)
+//   Section 9: Input/Output Statements (9.1-9.9)
+//   Section 10: Input/Output Editing (10.1-10.9)
+//   Section 11: Program Units (11.1-11.3)
+//   Section 12: Procedures (12.1-12.5)
+//   Section 13: Intrinsic Procedures (13.1-13.14)
+//   Section 14: Scope, Association, and Definition (14.1-14.7)
+//   Annex B: Syntax Rules (BNF summary)
 //
-// REVOLUTIONARY F90 FEATURES (in delegate grammars):
-// - Module system with explicit interfaces (F90ModulesParser)
-// - Dynamic memory management (F90MemoryParser)
-// - Derived types and enhanced type system (F90TypesParser)
-// - Array operations and constructors (F90ExprsParser)
-// - Enhanced control flow (F90ControlParser)
-// - Enhanced I/O with NAMELIST (F90IOParser)
-// - RECURSIVE procedures (F90ProcsParser)
+// This parser handles BOTH fixed-form and free-form formats:
+// - Fixed-form: .f, .for files (ISO/IEC 1539:1991 Section 3.3)
+// - Free-form: .f90+ files (ISO/IEC 1539:1991 Section 3.4)
+//
+// MAJOR F90 FEATURES (with ISO section references and delegate files):
+// - Module system (Section 11.3) -> F90ModulesParser
+// - Dynamic memory (Section 6.3) -> F90MemoryParser
+// - Derived types (Section 4.4) -> F90TypesParser
+// - Array operations (Section 4.5, 7.5.4) -> F90ExprsParser
+// - Control flow (Section 8.1) -> F90ControlParser
+// - Enhanced I/O (Section 9) -> F90IOParser
+// - Procedures (Section 12) -> F90ProcsParser
 //
 // NOTE: PURE and ELEMENTAL are Fortran 95 features (ISO/IEC 1539-1:1997),
 // NOT Fortran 90 features. They are properly defined in Fortran95Parser.g4.
@@ -51,147 +69,194 @@ options {
 // ====================================================================
 
 // ====================================================================
-// FORTRAN 90 PROGRAM STRUCTURE (ENHANCED)
+// PROGRAM STRUCTURE - ISO/IEC 1539:1991 Section 2 and 11
 // ====================================================================
-// ISO/IEC 1539:1991 Section 2.1
-// Program units: main program, external subprogram, module, block data.
+//
+// ISO/IEC 1539:1991 Section 2.1 defines the concept of program units:
+// - R201 (program) -> program-unit [program-unit]...
+// - R202 (program-unit) -> main-program | external-subprogram |
+//                          module | block-data
+//
+// ISO/IEC 1539:1991 Section 11 defines program unit structure in detail.
 
 // F90 program unit (major enhancement - adds modules)
+// ISO/IEC 1539:1991 Section 2.1, R202
 program_unit_f90
     : NEWLINE* (main_program | module | external_subprogram) NEWLINE*
     ;
 
-// Main program structure (enhanced with F90 features)
-// ISO/IEC 1539:1991 Section 11.1
+// ====================================================================
+// MAIN PROGRAM - ISO/IEC 1539:1991 Section 11.1
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 11.1 defines the main program:
+// - R1101 (main-program) -> [program-stmt] [specification-part]
+//                           [execution-part] [internal-subprogram-part]
+//                           end-program-stmt
+// - R1102 (program-stmt) -> PROGRAM program-name
+// - R1103 (end-program-stmt) -> END [PROGRAM [program-name]]
+
+// Main program structure - ISO/IEC 1539:1991 Section 11.1, R1101
 main_program
     : program_stmt specification_part? execution_part?
       internal_subprogram_part? end_program_stmt
     ;
 
+// PROGRAM statement - ISO/IEC 1539:1991 Section 11.1, R1102
 program_stmt
     : PROGRAM IDENTIFIER NEWLINE*
     ;
 
+// END PROGRAM statement - ISO/IEC 1539:1991 Section 11.1, R1103
 end_program_stmt
     : END (PROGRAM (IDENTIFIER)?)? NEWLINE*
     ;
 
 // ====================================================================
-// SPECIFICATION PART (F90 ENHANCED)
+// SPECIFICATION PART - ISO/IEC 1539:1991 Section 2.3 and 5
 // ====================================================================
-// ISO/IEC 1539:1991 Section 5
-// Declares variables, types, interfaces, and attributes.
+//
+// ISO/IEC 1539:1991 Section 2.3.1 defines the specification part:
+// - R204 (specification-part) -> [use-stmt]... [implicit-part]
+//                                [declaration-construct]...
+// - R207 (declaration-construct) -> derived-type-def | interface-block |
+//                                   type-declaration-stmt | ...
+//
+// Section 5 provides detailed specification statement rules.
 
-// Specification part (F90 enhancements)
+// Specification part - ISO/IEC 1539:1991 Section 2.3.1, R204
 specification_part
     : (NEWLINE* (use_stmt | import_stmt))*
         (NEWLINE* implicit_stmt_f90)?
         (NEWLINE* declaration_construct)* NEWLINE*
     ;
 
-// Declaration construct (F90 extensions)
+// Declaration construct - ISO/IEC 1539:1991 Section 2.3.1, R207
 declaration_construct
-    : type_declaration_stmt_f90
-    | derived_type_def              // F90 derived types
-    | interface_block               // F90 interface blocks
-    | parameter_stmt
-    | data_stmt
-    | namelist_stmt                 // F90 namelist
-    | common_stmt
-    | equivalence_stmt
-    | dimension_stmt
-    | allocatable_stmt              // F90 allocatable declaration
-    | pointer_stmt                  // F90 pointer declaration
-    | target_stmt                   // F90 target declaration
-    | optional_stmt                 // F90 optional declaration
-    | intent_stmt                   // F90 intent declaration
-    | public_stmt                   // F90 visibility control
-    | private_stmt                  // F90 visibility control
-    | save_stmt
-    | external_stmt
-    | intrinsic_stmt
+    : type_declaration_stmt_f90      // Section 5.1
+    | derived_type_def               // Section 4.4 - F90 derived types
+    | interface_block                // Section 12.3 - F90 interface blocks
+    | parameter_stmt                 // Section 5.1.2.11
+    | data_stmt                      // Section 5.2.9
+    | namelist_stmt                  // Section 5.4 - F90 namelist
+    | common_stmt                    // Section 5.5.1
+    | equivalence_stmt               // Section 5.5.2
+    | dimension_stmt                 // Section 5.1.2.4.1
+    | allocatable_stmt               // Section 5.1.2.4.3 - F90 allocatable
+    | pointer_stmt                   // Section 5.1.2.4.4 - F90 pointer
+    | target_stmt                    // Section 5.1.2.4.5 - F90 target
+    | optional_stmt                  // Section 5.1.2.6 - F90 optional
+    | intent_stmt                    // Section 5.1.2.3 - F90 intent
+    | public_stmt                    // Section 5.1.2.1 - F90 visibility
+    | private_stmt                   // Section 5.1.2.1 - F90 visibility
+    | save_stmt                      // Section 5.1.2.5
+    | external_stmt                  // Section 5.1.2.7
+    | intrinsic_stmt                 // Section 5.1.2.8
     ;
 
 // ====================================================================
-// EXECUTION PART (F90 ENHANCED)
+// EXECUTION PART - ISO/IEC 1539:1991 Section 2.3 and 8
 // ====================================================================
-// ISO/IEC 1539:1991 Section 8
-// Contains executable statements and constructs.
+//
+// ISO/IEC 1539:1991 Section 2.3.3 defines the execution part:
+// - R208 (execution-part) -> executable-construct [execution-part-construct]...
+// - R214 (executable-construct) -> action-stmt | construct
+// - R215 (action-stmt) -> assignment-stmt | call-stmt | ...
+// - R216 (construct) -> if-construct | case-construct | do-construct |
+//                       where-construct
+//
+// Section 8 provides detailed execution control rules.
 
-// Execution part (enhanced for F90)
+// Execution part - ISO/IEC 1539:1991 Section 2.3.3, R208
 execution_part
     : (NEWLINE* executable_construct)* NEWLINE*
     ;
 
+// Executable construct - ISO/IEC 1539:1991 Section 2.3.3, R214
 executable_construct
     : executable_stmt
     | construct
     ;
 
+// Action statement - ISO/IEC 1539:1991 Section 2.3.3, R215
 executable_stmt
-    : call_stmt_f90                 // Enhanced procedure calls
-    | return_stmt
-    | stop_stmt
-    | cycle_stmt                    // F90 enhanced loop control
-    | exit_stmt                     // F90 enhanced loop control
-    | goto_stmt
-    | arithmetic_if_stmt
-    | continue_stmt
-    | read_stmt_f90                 // Enhanced I/O
-    | write_stmt_f90                // Enhanced I/O
-    | print_stmt_f90                // F77-inherited print statement
-    | allocate_stmt                 // F90 memory management
-    | deallocate_stmt               // F90 memory management
-    | nullify_stmt                  // F90 pointer nullification
-    | where_stmt                    // F90 array conditional
-    | pointer_assignment_stmt       // F90 pointer assignment
-    | assignment_stmt_f90           // Last resort to avoid ENDIF conflict
+    : call_stmt_f90                  // Section 12.4 - Enhanced procedure calls
+    | return_stmt                    // Section 12.4.3
+    | stop_stmt                      // Section 8.3
+    | cycle_stmt                     // Section 8.1.4.4.1 - F90 loop control
+    | exit_stmt                      // Section 8.1.4.4.2 - F90 loop control
+    | goto_stmt                      // Section 8.2
+    | arithmetic_if_stmt             // Section 8.1.1.2 (obsolescent)
+    | continue_stmt                  // Section 8.2
+    | read_stmt_f90                  // Section 9.4 - Enhanced I/O
+    | write_stmt_f90                 // Section 9.4 - Enhanced I/O
+    | print_stmt_f90                 // Section 9.4 - F77-inherited print
+    | allocate_stmt                  // Section 6.3.1 - F90 memory management
+    | deallocate_stmt                // Section 6.3.3 - F90 memory management
+    | nullify_stmt                   // Section 6.3.2 - F90 pointer nullification
+    | where_stmt                     // Section 7.5.3 - F90 array conditional
+    | pointer_assignment_stmt        // Section 7.5.2 - F90 pointer assignment
+    | assignment_stmt_f90            // Section 7.5.1 - Last resort for ENDIF
     ;
 
-// Construct (F90 enhanced control structures)
+// Construct - ISO/IEC 1539:1991 Section 2.3.3, R216
 construct
-    : if_construct
-    | select_case_construct         // F90 innovation
-    | do_construct_f90              // F90 enhanced DO
-    | where_construct               // F90 array construct
+    : if_construct                   // Section 8.1.1
+    | select_case_construct          // Section 8.1.3 - F90 innovation
+    | do_construct_f90               // Section 8.1.4 - F90 enhanced DO
+    | where_construct                // Section 7.5.3 - F90 array construct
     ;
 
 // ====================================================================
-// FORTRAN 90 UNIFIED PARSER STATUS
+// FORTRAN 90 PARSER - ISO/IEC 1539:1991 SPEC-GRAMMAR MAPPING
 // ====================================================================
 //
-// Refactored per issue #252 into smaller delegate grammars:
-// - F90ModulesParser.g4: Module system and interface blocks (~100 lines)
-// - F90TypesParser.g4: Type declarations and derived types (~180 lines)
-// - F90ControlParser.g4: Control structures (~150 lines)
-// - F90IOParser.g4: I/O statements and NAMELIST (~100 lines)
-// - F90ExprsParser.g4: Expressions and array operations (~170 lines)
-// - F90MemoryParser.g4: Dynamic memory management (~60 lines)
-// - F90ProcsParser.g4: Procedures and subprograms (~100 lines)
-// - F90InheritedParser.g4: Inherited F77 compatibility (~180 lines)
-// - Fortran90Parser.g4 (this file): Program structure (~150 lines)
+// Refactored per issue #252 into smaller delegate grammars.
+// Each delegate file maps to specific ISO/IEC 1539:1991 sections:
 //
-// MAJOR F90 FEATURES COVERED BY THIS GRAMMAR INCLUDE:
-// - Module system (MODULE, USE, PUBLIC/PRIVATE visibility)
-// - Interface blocks (explicit interfaces, generic procedures, operator overloading)
-// - Derived types (TYPE definitions, structure constructors, component access)
-// - Dynamic arrays (ALLOCATABLE, POINTER, TARGET, memory management)
-// - Enhanced control structures (SELECT CASE, WHERE, named constructs)
-// - Array operations (constructors, sections, intrinsic functions)
-// - Enhanced I/O (NAMELIST, non-advancing I/O, enhanced error handling)
-// - Modern expressions (new operators, logical expressions, array expressions)
-// - Enhanced procedures (RECURSIVE, OPTIONAL, INTENT, keyword arguments)
-// - Unified format support (both fixed and free form in one grammar)
+// - F90ModulesParser.g4: Section 11.3 (Modules), Section 12.3 (Interfaces)
+// - F90TypesParser.g4: Section 4.4 (Derived types), Section 5.1 (Declarations)
+// - F90ControlParser.g4: Section 8.1 (Constructs), Section 7.5.3 (WHERE)
+// - F90IOParser.g4: Section 5.4 (NAMELIST), Section 9 (I/O)
+// - F90ExprsParser.g4: Section 4.5 (Arrays), Section 7 (Expressions)
+// - F90MemoryParser.g4: Section 6.3 (Dynamic allocation)
+// - F90ProcsParser.g4: Section 12 (Procedures)
+// - F90InheritedParser.g4: F77 compatibility (inherited rules)
+// - Fortran90Parser.g4: Section 2, 11 (Program structure)
 //
-// COMPATIBILITY FEATURES:
-// - F77 backward compatibility through FORTRAN77Parser inheritance
-// - Legacy constructs (arithmetic IF, computed GOTO, etc.)
-// - Traditional I/O (FORMAT statements, unit-based I/O)
-// - Backward compatibility with all inherited FORTRAN features
+// ISO/IEC 1539:1991 SPEC-GRAMMAR MAPPING (PARSER):
+// Section 2 (Concepts)       -> program_unit_f90
+// Section 4 (Types)          -> type_spec_f90, derived_type_def, literal_f90
+// Section 5 (Declarations)   -> specification_part, declaration_construct,
+//                               type_declaration_stmt_f90, *_stmt
+// Section 6 (Data objects)   -> variable_f90, allocate_stmt, deallocate_stmt,
+//                               nullify_stmt
+// Section 7 (Expressions)    -> expr_f90, primary_f90, where_*, assignment_*
+// Section 8 (Control)        -> if_construct, select_case_construct,
+//                               do_construct_f90, cycle_stmt, exit_stmt
+// Section 9 (I/O)            -> read_stmt_f90, write_stmt_f90, io_control_spec
+// Section 11 (Programs)      -> main_program, module, end_*_stmt
+// Section 12 (Procedures)    -> function_stmt, subroutine_stmt, interface_block,
+//                               call_stmt_f90
+// Section 13 (Intrinsics)    -> intrinsic_function_f90
 //
-// EXTENSION FOUNDATION:
-// - Architecture ready for F95 inheritance and extension
-// - Modular design supports seamless F95+ feature addition
+// MAJOR F90 FEATURES IMPLEMENTED (with ISO section refs):
+// - Module system (Section 11.3): MODULE, USE, PUBLIC/PRIVATE
+// - Interface blocks (Section 12.3): explicit interfaces, generic procedures
+// - Derived types (Section 4.4): TYPE definitions, structure constructors
+// - Dynamic arrays (Section 6.3): ALLOCATABLE, POINTER, TARGET
+// - Control structures (Section 8.1): SELECT CASE, WHERE, named constructs
+// - Array operations (Section 4.5, 7.5.4): constructors, sections, intrinsics
+// - Enhanced I/O (Section 9): NAMELIST, non-advancing I/O
+// - Procedures (Section 12): RECURSIVE, OPTIONAL, INTENT, keyword arguments
+// - Unified format support (Section 3.3, 3.4): fixed and free form
+//
+// BACKWARD COMPATIBILITY:
+// - F77 compatibility through FORTRAN77Parser inheritance
+// - Legacy constructs maintained for compatibility
+//
+// FORWARD COMPATIBILITY:
+// - Architecture ready for F95 inheritance
 // - Clear extension points for subsequent standards
 //
 // ====================================================================


### PR DESCRIPTION
## Summary

- Add comprehensive ISO/IEC 1539:1991 (WG5 N692) section references to all Fortran 90 grammar files
- Add spec-grammar cross-walk table to docs/fortran_90_audit.md
- All grammar changes are documentation-only (comments); no functional grammar changes

## Changes

**Fortran90Lexer.g4:**
- Added ISO standard structure overview in header
- Inline ISO section references for all token rules (comments, keywords, operators, literals, intrinsics)
- Added spec-grammar mapping summary at end

**Fortran90Parser.g4:**
- Added ISO overview and delegate file mappings in header
- Inline section refs for program structure rules
- Added spec-grammar mapping in closing comments

**Delegate Parser Files:**
- F90ModulesParser.g4: MODULE (11.3), USE (11.3.2), INTERFACE (12.3)
- F90TypesParser.g4: Derived types (4.4), type declarations (5.1), attributes (5.1.2), array specs (5.1.2.4)
- F90ControlParser.g4: SELECT CASE (8.1.3), WHERE (7.5.3), DO (8.1.4), IF (8.1.1)
- F90IOParser.g4: NAMELIST (5.4), I/O (9)
- F90ExprsParser.g4: Expressions (7), arrays (4.5)
- F90MemoryParser.g4: Dynamic allocation (6.3)
- F90ProcsParser.g4: Procedures (12)

**Documentation:**
- Added ISO section-grammar cross-walk table to fortran_90_audit.md

## Verification

```
make test
================= 695 passed, 1 skipped, 63 xfailed in 35.55s ==================
```

## Test plan

- [x] All existing tests pass (695 passed)
- [x] No functional grammar changes (documentation-only)
- [x] Follows established annotation pattern from #276 (F77 annotations)