### PR TITLE
docs: track J3/98-114 semantic rules for F95 (fixes #183)

### DIFF
--- a/validation/pdfs/Fortran95_J3_98-114_RFI.txt
+++ b/validation/pdfs/Fortran95_J3_98-114_RFI.txt
@@ -1,0 +1,111 @@
+
+                                                     J3/98-114
+
+To:         J3
+From:       Robert Paul Corbett
+Subject:    Fortran 95 Request for Interpretation
+Date:       31 January 1998
+
+
+Sections 12.2.1.1 and 12.2.2 of the Fortran 95 standard
+define rules for dummy arguments and function returns in the
+presence of explicit interfaces that allow array bounds
+expressions to be evaluated on either the calling side or
+the called side of a call.  The interpretation provided for
+RFI 000049 on the X3J3 website clarifies and reinforces the
+conditions that permit evaluation on either side of the
+call.  The erratum published in the same file for RFI 000070
+changes the semantics of dummy arguments.  The erratum does
+not explicitly mention function results, but it might be
+considered to imply a similar change to the semantics of
+function results.
+
+The erratum provided for RFI 000070 refers to altered text
+for the interpretation provided for RFI 000049.  The version
+of the interpretation that appears in the file on the X3J3
+website does not contain the altered text.
+
+The definition of characteristics of function results as
+stated in Section 12.2.2 of the Fortran 95 standard permits
+more efficient implementation of array-valued functions, at
+least for some architectures, than the definition implied by
+the erratum provided for RFI 000070.  For Sun, it is more
+efficient for the calling routines to allocate space for
+array results than to have the called routines allocate the
+space.  In order for the calling routine to allocate space
+for an array result, it must know the size of the array.
+To determine the size of the array, it must evaluate the
+array bounds expressions given in the explicit interface
+for the function.
+
+Section 12.2.2 of the Fortran 95 standard requires the
+values of the nonconstant bounds expressions given in an
+explicit interface to be the same as the values of the
+bounds expressions given in the corresponding function
+definition.  Thus, the values of the nonconstant bounds
+expressions used to determine the size of the array result
+can be passed to the called routine, avoiding any need for
+the called routine to re-evaluate those expressions.
+Because Fortran 95 allows user-defined routines to appear
+in bounds expressions, evaluating the bounds expressions
+more than once per call could prove inefficient and
+confusing.
+
+The change implied by the erratum provided for RFI 000070
+would remove the nonconstant bounds expressions from the
+characteristics of function results.  The shape would still
+be a characteristic, but the same shape can be produced by
+many different values of the bounds expressions.  Thus,
+the values of the nonconstant bounds expressions used in
+the called routine may differ from the values of the
+corresponding expressions in the explicit interface.
+
+For example, consider the explicit interface
+
+      INTERFACE
+        FUNCTION FOO(F, G, H)
+          INTERFACE
+            PURE INTEGER FUNCTION F()
+            END FUNCTION
+            PURE INTEGER FUNCTION G()
+            END FUNCTION
+            PURE INTEGER FUNCTION H()
+            END FUNCTION
+          END INTERFACE
+          CHARACTER*(F()) FOO(G():H())
+        END FUNCTION
+      END INTERFACE
+
+The definition given in Section 12.2.2 of the Fortran 95
+standard requires the values of the length and bounds
+expressions in the interface to be the same as the values
+of the corresponding length and bounds expressions in the
+function definition.
+
+Under the definition implied by the erratum provided for
+RFI 000070, the shapes must match, but the values of the
+nonconstant bounds expressions need not.  Thus, the
+function definition might be
+
+      FUNCTION FOO(F, G, H)
+        INTERFACE
+          PURE INTEGER FUNCTION F()
+          END FUNCTION
+          PURE INTEGER FUNCTION G()
+          END FUNCTION
+          PURE INTEGER FUNCTION H()
+          END FUNCTION
+        END INTERFACE
+        CHARACTER*(F()) FOO(G()-1:H()-1)
+        . . .
+      END FUNCTION
+
+In this case, the values of the bounds expressions used in
+the called routine must be the values of the expressions
+specified in the function definition, not the values of the
+expressions specified in the interface block.
+
+Question:  If a bound of a function result array is not
+           a constant expression, is the exact dependence
+           on the entities in the expression a
+           characteristic of the function result?


### PR DESCRIPTION
## Summary
- Add J3/98-114 RFI document to `validation/pdfs/Fortran95_J3_98-114_RFI.txt`
- Expand Section 9 of F95 audit with explicit ISO/IEC 1539-1:1997 Section 12.2 references
- Document enumerated semantic checks required for future tooling to comply with F95 characteristics rules

## Verification
```
make test
================= 726 passed, 1 skipped, 72 xfailed in 35.55s ==================
```

RFI document sourced from [j3-fortran/j3-papers](https://github.com/j3-fortran/j3-papers).