### PR TITLE
feat: add semantic validation for F2018 teams, events, and collectives (fixes #192)

### DIFF
--- a/tests/Fortran2018/test_issue192_teams_events_semantics.py
+++ b/tests/Fortran2018/test_issue192_teams_events_semantics.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Semantic Validation Tests for F2018 Teams, Events, Collectives - Issue #192
+
+Comprehensive test suite for Fortran 2018 teams, events, and collective
+subroutine semantic validation per ISO/IEC 1539-1:2018:
+- Team constructs and TEAM_TYPE declarations (Section 11.6)
+- Event constructs and EVENT_TYPE declarations (Section 11.6.8)
+- Collective subroutine calls (Sections 16.9.46-50)
+
+These tests validate the semantic analysis layer on top of the ANTLR grammar,
+ensuring that teams/events/collectives code conforms to the standard beyond
+syntactic correctness.
+"""
+
+import sys
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, "grammars/generated/modern")
+sys.path.insert(0, "tools")
+sys.path.append(str(Path(__file__).parent.parent))
+
+from f2018_teams_events_validator import (
+    F2018TeamsEventsValidator,
+    F2018TeamsEventsValidationResult,
+    DiagnosticSeverity,
+    COLLECTIVE_TYPES,
+    validate_teams_semantics,
+    validate_events_semantics,
+    validate_collective_semantics,
+)
+from fixture_utils import load_fixture
+
+
+class TestF2018TeamsEventsValidatorBasic:
+    """Basic tests for the teams/events/collectives validator infrastructure."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_empty_module_no_errors(self):
+        """Empty module should have no semantic errors."""
+        code = """
+module empty_mod
+    implicit none
+end module empty_mod
+"""
+        result = self.validator.validate_code(code)
+        assert not result.has_errors, f"Unexpected errors: {result.diagnostics}"
+
+    def test_syntax_error_detected(self):
+        """Syntax errors should be reported before semantic analysis."""
+        code = """
+module broken
+    this is not valid fortran syntax!!!
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        assert result.has_errors
+        assert any(d.code == "SYNTAX_E001" for d in result.diagnostics)
+
+    def test_validation_result_properties(self):
+        """F2018TeamsEventsValidationResult should correctly report counts."""
+        code = """
+module test_mod
+    implicit none
+end module test_mod
+"""
+        result = self.validator.validate_code(code)
+        assert result.error_count == 0
+        assert result.warning_count == 0
+        assert not result.has_errors
+
+
+class TestTeamDeclarationSemantics:
+    """Semantic validation tests for TEAM_TYPE declarations (Section 11.6)."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_team_type_declaration_detected(self):
+        """TEAM_TYPE declaration should be detected and tracked."""
+        code = """
+program team_decl_test
+    use, intrinsic :: iso_fortran_env
+    implicit none
+    type(team_type) :: my_team
+end program team_decl_test
+"""
+        result = self.validator.validate_code(code)
+        assert len(result.team_declarations) > 0
+
+    def test_multiple_team_declarations(self):
+        """Multiple TEAM_TYPE declarations should all be tracked."""
+        code = """
+program multi_team_test
+    use, intrinsic :: iso_fortran_env
+    implicit none
+    type(team_type) :: team1
+    type(team_type) :: team2
+end program multi_team_test
+"""
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+
+
+class TestEventDeclarationSemantics:
+    """Semantic validation tests for EVENT_TYPE declarations (Section 11.6.8)."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_event_type_declaration_detected(self):
+        """EVENT_TYPE declaration should be detected and tracked."""
+        code = """
+program event_decl_test
+    use, intrinsic :: iso_fortran_env
+    implicit none
+    type(event_type) :: my_event
+end program event_decl_test
+"""
+        result = self.validator.validate_code(code)
+        assert len(result.event_declarations) > 0
+
+    def test_multiple_event_declarations(self):
+        """Multiple EVENT_TYPE declarations should all be tracked."""
+        code = """
+program multi_event_test
+    use, intrinsic :: iso_fortran_env
+    implicit none
+    type(event_type) :: event1
+    type(event_type) :: event2
+end program multi_event_test
+"""
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+
+
+class TestFormTeamSemantics:
+    """Semantic validation tests for FORM TEAM statement (Section 11.6.9)."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_form_team_statement_detected(self):
+        """FORM TEAM statement should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert len(result.form_team_statements) > 0
+
+    def test_form_team_with_new_index(self):
+        """FORM TEAM with NEW_INDEX should be validated."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        form_teams_with_new_index = [
+            s for s in result.form_team_statements if s.has_new_index
+        ]
+        assert len(form_teams_with_new_index) > 0
+
+    def test_form_team_with_stat_errmsg(self):
+        """FORM TEAM with STAT and ERRMSG should be validated."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+
+
+class TestChangeTeamSemantics:
+    """Semantic validation tests for CHANGE TEAM construct (Section 11.6.7)."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_change_team_construct_detected(self):
+        """CHANGE TEAM construct should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert len(result.change_team_constructs) > 0
+
+    def test_change_team_with_stat(self):
+        """CHANGE TEAM with STAT should be validated."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        change_teams_with_stat = [
+            c for c in result.change_team_constructs if c.has_stat
+        ]
+        assert len(change_teams_with_stat) > 0
+
+
+class TestEventStatementSemantics:
+    """Semantic validation tests for event statements (Section 11.6.8)."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_event_post_detected(self):
+        """EVENT POST statement should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        event_posts = [
+            e for e in result.event_statements if e.stmt_type == "event_post"
+        ]
+        assert len(event_posts) > 0
+
+    def test_event_wait_detected(self):
+        """EVENT WAIT statement should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        event_waits = [
+            e for e in result.event_statements if e.stmt_type == "event_wait"
+        ]
+        assert len(event_waits) > 0
+
+    def test_event_query_detected(self):
+        """EVENT_QUERY statement should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        event_queries = [
+            e for e in result.event_statements if e.stmt_type == "event_query"
+        ]
+        assert len(event_queries) > 0
+
+    def test_event_wait_with_until_count(self):
+        """EVENT WAIT with UNTIL_COUNT should be validated."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        event_waits_with_until = [
+            e for e in result.event_statements
+            if e.stmt_type == "event_wait" and e.has_until_count
+        ]
+        assert len(event_waits_with_until) > 0
+
+
+class TestCollectiveSubroutineSemantics:
+    """Semantic validation tests for collective subroutines (Sections 16.9.46-50)."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_co_sum_detected(self):
+        """CO_SUM call should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        co_sums = [c for c in result.collective_calls if c.collective_type == "co_sum"]
+        assert len(co_sums) > 0
+
+    def test_co_min_detected(self):
+        """CO_MIN call should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        co_mins = [c for c in result.collective_calls if c.collective_type == "co_min"]
+        assert len(co_mins) > 0
+
+    def test_co_max_detected(self):
+        """CO_MAX call should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        co_maxs = [c for c in result.collective_calls if c.collective_type == "co_max"]
+        assert len(co_maxs) > 0
+
+    def test_co_reduce_detected(self):
+        """CO_REDUCE call should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        co_reduces = [
+            c for c in result.collective_calls if c.collective_type == "co_reduce"
+        ]
+        assert len(co_reduces) > 0
+
+    def test_co_broadcast_detected(self):
+        """CO_BROADCAST call should be detected and tracked."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        co_broadcasts = [
+            c for c in result.collective_calls if c.collective_type == "co_broadcast"
+        ]
+        assert len(co_broadcasts) > 0
+
+    def test_collective_with_stat(self):
+        """Collective subroutine with STAT should be validated."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        collectives_with_stat = [c for c in result.collective_calls if c.has_stat]
+        assert len(collectives_with_stat) > 0
+
+    def test_collective_with_errmsg(self):
+        """Collective subroutine with ERRMSG should be validated."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        collectives_with_errmsg = [c for c in result.collective_calls if c.has_errmsg]
+        assert len(collectives_with_errmsg) > 0
+
+    def test_collective_types_complete(self):
+        """COLLECTIVE_TYPES should include all F2018 collective subroutines."""
+        expected = {"co_sum", "co_min", "co_max", "co_reduce", "co_broadcast"}
+        assert expected == COLLECTIVE_TYPES
+
+
+class TestTeamEventCollectiveInteractions:
+    """Tests for interactions between teams, events, and collectives."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_full_teams_events_collectives_program(self):
+        """Full program with teams, events, and collectives should validate."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+
+        assert len(result.form_team_statements) > 0
+        assert len(result.change_team_constructs) > 0
+        assert len(result.event_statements) > 0
+        assert len(result.collective_calls) > 0
+
+    def test_collectives_outside_change_team_info(self):
+        """Collectives outside CHANGE TEAM should produce INFO diagnostic."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        has_coll_info = any(
+            d.code == "COLL_I001" for d in result.diagnostics
+        )
+        assert has_coll_info, "Expected COLL_I001 info for collectives outside team"
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience validation functions."""
+
+    def test_validate_teams_semantics_function(self):
+        """validate_teams_semantics() should work as standalone function."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = validate_teams_semantics(code)
+        assert not result.has_errors
+        assert len(result.form_team_statements) > 0
+
+    def test_validate_events_semantics_function(self):
+        """validate_events_semantics() should work as standalone function."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_event_semantics.f90",
+        )
+        result = validate_events_semantics(code)
+        assert not result.has_errors
+        assert len(result.event_statements) > 0
+
+    def test_validate_collective_semantics_function(self):
+        """validate_collective_semantics() should work as standalone function."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = validate_collective_semantics(code)
+        assert not result.has_errors
+        assert len(result.collective_calls) > 0
+
+
+class TestDiagnosticQuality:
+    """Tests for diagnostic message quality and ISO references."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_diagnostic_has_severity(self):
+        """All diagnostics should have a severity level."""
+        code = """
+module broken
+    invalid syntax here
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        for diag in result.diagnostics:
+            assert diag.severity in DiagnosticSeverity
+
+    def test_diagnostic_has_code(self):
+        """All diagnostics should have a unique code."""
+        code = """
+module broken
+    invalid syntax here
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        for diag in result.diagnostics:
+            assert diag.code is not None
+            assert len(diag.code) > 0
+
+    def test_diagnostic_has_message(self):
+        """All diagnostics should have a descriptive message."""
+        code = """
+module broken
+    invalid syntax here
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        for diag in result.diagnostics:
+            assert diag.message is not None
+            assert len(diag.message) > 0
+
+
+class TestISOComplianceValidation:
+    """Tests verifying ISO/IEC 1539-1:2018 compliance checks."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_iso_section_references_in_diagnostics(self):
+        """Diagnostics should reference ISO sections per standard."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        iso_refs = [d.iso_section for d in result.diagnostics if d.iso_section]
+        assert len(iso_refs) > 0, "Expected ISO section references in diagnostics"
+
+    def test_collective_diagnostics_reference_sections(self):
+        """Collective-related diagnostics should cite ISO standard sections."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "teams_collectives_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        info_diags = [
+            d for d in result.diagnostics
+            if d.severity == DiagnosticSeverity.INFO
+        ]
+        assert len(info_diags) > 0, "Expected INFO diagnostics for collective code"
+        assert any(
+            d.iso_section for d in info_diags
+        ), "Expected ISO section references in diagnostics"
+
+
+class TestTeamSkeleton:
+    """Tests using the team_skeleton_module.f90 fixture."""
+
+    def setup_method(self):
+        self.validator = F2018TeamsEventsValidator()
+
+    def test_team_skeleton_parses_and_validates(self):
+        """team_skeleton_module.f90 should parse and validate."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_skeleton_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+
+    def test_team_skeleton_detects_form_team(self):
+        """team_skeleton_module.f90 should have FORM TEAM detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_skeleton_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert len(result.form_team_statements) > 0
+
+    def test_team_skeleton_detects_change_team(self):
+        """team_skeleton_module.f90 should have CHANGE TEAM detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_skeleton_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert len(result.change_team_constructs) > 0
+
+    def test_team_skeleton_detects_events(self):
+        """team_skeleton_module.f90 should have event statements detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "team_skeleton_module.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert len(result.event_statements) > 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/f2018_teams_events_validator.py
+++ b/tools/f2018_teams_events_validator.py
@@ -1,0 +1,717 @@
+#!/usr/bin/env python3
+"""Fortran 2018 Teams, Events, and Collectives Semantic Validator
+
+Implements semantic validation for Fortran 2018 teams, events, and collective
+coarray features per ISO/IEC 1539-1:2018 (Fortran 2018 standard).
+
+This validator checks:
+- Team constructs and TEAM_TYPE declarations (Section 11.6)
+- Event constructs and EVENT_TYPE declarations (Section 11.6.8)
+- Collective subroutine calls (Sections 16.9.46-50)
+- Interactions between teams, events, and collectives
+
+Reference: ISO/IEC 1539-1:2018 (Fortran 2018 International Standard)
+"""
+
+import re
+import sys
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+sys.path.insert(
+    0, str(Path(__file__).parent.parent / "grammars" / "generated" / "modern")
+)
+
+from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
+from Fortran2018Lexer import Fortran2018Lexer
+from Fortran2018Parser import Fortran2018Parser
+from Fortran2018ParserListener import Fortran2018ParserListener
+
+
+class DiagnosticSeverity(Enum):
+    ERROR = auto()
+    WARNING = auto()
+    INFO = auto()
+
+
+@dataclass
+class SemanticDiagnostic:
+    severity: DiagnosticSeverity
+    code: str
+    message: str
+    line: Optional[int] = None
+    column: Optional[int] = None
+    iso_section: Optional[str] = None
+
+
+@dataclass
+class TeamDeclaration:
+    """Represents a TEAM_TYPE variable declaration."""
+    name: str
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class EventDeclaration:
+    """Represents an EVENT_TYPE variable declaration."""
+    name: str
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class FormTeamStatement:
+    """Represents a FORM TEAM statement for analysis."""
+    team_number_expr: str
+    team_variable: str
+    has_new_index: bool = False
+    has_stat: bool = False
+    has_errmsg: bool = False
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class ChangeTeamConstruct:
+    """Represents a CHANGE TEAM construct for analysis."""
+    team_value: str
+    has_coarray_associations: bool = False
+    has_stat: bool = False
+    has_errmsg: bool = False
+    in_pure_procedure: bool = False
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class EventStatement:
+    """Represents an event statement (POST/WAIT/QUERY) for analysis."""
+    stmt_type: str
+    event_variable: str
+    has_stat: bool = False
+    has_errmsg: bool = False
+    has_until_count: bool = False
+    has_count: bool = False
+    in_pure_procedure: bool = False
+    in_change_team: bool = False
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class CollectiveCall:
+    """Represents a collective subroutine call for analysis."""
+    collective_type: str
+    variable: str
+    has_stat: bool = False
+    has_errmsg: bool = False
+    has_result_image: bool = False
+    has_source_image: bool = False
+    has_operation: bool = False
+    in_pure_procedure: bool = False
+    in_change_team: bool = False
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class F2018TeamsEventsValidationResult:
+    """Results from F2018 teams/events/collectives semantic validation."""
+    diagnostics: List[SemanticDiagnostic] = field(default_factory=list)
+    team_declarations: Dict[str, TeamDeclaration] = field(default_factory=dict)
+    event_declarations: Dict[str, EventDeclaration] = field(default_factory=dict)
+    form_team_statements: List[FormTeamStatement] = field(default_factory=list)
+    change_team_constructs: List[ChangeTeamConstruct] = field(default_factory=list)
+    event_statements: List[EventStatement] = field(default_factory=list)
+    collective_calls: List[CollectiveCall] = field(default_factory=list)
+
+    @property
+    def has_errors(self) -> bool:
+        return any(d.severity == DiagnosticSeverity.ERROR for d in self.diagnostics)
+
+    @property
+    def error_count(self) -> int:
+        return sum(
+            1 for d in self.diagnostics if d.severity == DiagnosticSeverity.ERROR
+        )
+
+    @property
+    def warning_count(self) -> int:
+        return sum(
+            1 for d in self.diagnostics if d.severity == DiagnosticSeverity.WARNING
+        )
+
+
+COLLECTIVE_TYPES: Set[str] = {
+    "co_sum", "co_min", "co_max", "co_reduce", "co_broadcast",
+}
+
+
+class F2018TeamsEventsListener(Fortran2018ParserListener):
+    """ANTLR listener for F2018 teams/events/collectives semantic analysis."""
+
+    def __init__(self):
+        super().__init__()
+        self.result = F2018TeamsEventsValidationResult()
+        self._in_pure_procedure = False
+        self._in_change_team = False
+        self._change_team_depth = 0
+        self._current_team_var: Optional[str] = None
+        self._current_event_var: Optional[str] = None
+
+    def _get_token_text(self, ctx) -> str:
+        if ctx is None:
+            return ""
+        return ctx.getText().lower()
+
+    def _get_location(self, ctx) -> Tuple[Optional[int], Optional[int]]:
+        if ctx is None:
+            return None, None
+        if hasattr(ctx, "start") and ctx.start:
+            return ctx.start.line, ctx.start.column
+        return None, None
+
+    def _add_diagnostic(
+        self,
+        severity: DiagnosticSeverity,
+        code: str,
+        message: str,
+        ctx=None,
+        iso_section: Optional[str] = None,
+    ):
+        line, column = self._get_location(ctx)
+        self.result.diagnostics.append(
+            SemanticDiagnostic(
+                severity=severity,
+                code=code,
+                message=message,
+                line=line,
+                column=column,
+                iso_section=iso_section,
+            )
+        )
+
+    def enterFunction_stmt_f2018(self, ctx):
+        """Track PURE function context."""
+        text = self._get_token_text(ctx)
+        if "pure" in text or "elemental" in text:
+            self._in_pure_procedure = True
+
+    def exitEnd_function_stmt(self, ctx):
+        """Exit function context."""
+        self._in_pure_procedure = False
+
+    def enterSubroutine_stmt_f2018(self, ctx):
+        """Track PURE subroutine context."""
+        text = self._get_token_text(ctx)
+        if "pure" in text or "elemental" in text:
+            self._in_pure_procedure = True
+
+    def exitEnd_subroutine_stmt(self, ctx):
+        """Exit subroutine context."""
+        self._in_pure_procedure = False
+
+    def enterTeam_declaration_stmt(self, ctx):
+        """Process TEAM_TYPE declaration."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+        names = re.findall(r"::\s*(\w+)", text)
+        for name in names:
+            decl = TeamDeclaration(name=name, line=line, column=col)
+            self.result.team_declarations[name] = decl
+
+    def enterEvent_declaration_stmt(self, ctx):
+        """Process EVENT_TYPE declaration."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+        names = re.findall(r"::\s*(\w+)", text)
+        for name in names:
+            decl = EventDeclaration(name=name, line=line, column=col)
+            self.result.event_declarations[name] = decl
+
+    def enterForm_team_stmt(self, ctx):
+        """Process FORM TEAM statement per ISO/IEC 1539-1:2018 Section 11.6.9."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        team_match = re.search(
+            r"form\s*team\s*\(\s*([^,]+)\s*,\s*(\w+)", text
+        )
+        team_num = team_match.group(1).strip() if team_match else ""
+        team_var = team_match.group(2) if team_match else ""
+
+        stmt = FormTeamStatement(
+            team_number_expr=team_num,
+            team_variable=team_var,
+            has_new_index="new_index" in text,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            line=line,
+            column=col,
+        )
+        self.result.form_team_statements.append(stmt)
+
+        if self._in_pure_procedure:
+            self._add_diagnostic(
+                DiagnosticSeverity.ERROR,
+                "TEAM_E001",
+                "FORM TEAM statement is not permitted in a PURE procedure. "
+                "Per ISO/IEC 1539-1:2018 Section 11.6.9, FORM TEAM is an image "
+                "control statement and shall not appear in a pure subprogram.",
+                ctx,
+                "11.6.9",
+            )
+
+        self._validate_form_team_statement(stmt, ctx)
+
+    def _validate_form_team_statement(self, stmt: FormTeamStatement, ctx):
+        """Validate FORM TEAM statement per ISO/IEC 1539-1:2018."""
+        if stmt.team_variable:
+            if stmt.team_variable not in self.result.team_declarations:
+                self._add_diagnostic(
+                    DiagnosticSeverity.INFO,
+                    "TEAM_I001",
+                    f"Team variable '{stmt.team_variable}' in FORM TEAM may "
+                    "reference a TEAM_TYPE variable declared in another scope. "
+                    "Per ISO/IEC 1539-1:2018 Section 11.6.9, the team-variable "
+                    "shall be a scalar variable of type TEAM_TYPE.",
+                    ctx,
+                    "11.6.9",
+                )
+
+    def enterChange_team_construct(self, ctx):
+        """Enter CHANGE TEAM construct per ISO/IEC 1539-1:2018 Section 11.6.7."""
+        self._in_change_team = True
+        self._change_team_depth += 1
+
+    def exitChange_team_construct(self, ctx):
+        """Exit CHANGE TEAM construct."""
+        if self._change_team_depth > 0:
+            self._change_team_depth -= 1
+        if self._change_team_depth == 0:
+            self._in_change_team = False
+
+    def enterChange_team_stmt(self, ctx):
+        """Process CHANGE TEAM statement per ISO/IEC 1539-1:2018 Section 11.6.7."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        team_match = re.search(r"change\s*team\s*\(\s*([^,)]+)", text)
+        team_val = team_match.group(1).strip() if team_match else ""
+
+        construct = ChangeTeamConstruct(
+            team_value=team_val,
+            has_coarray_associations="=>" in text,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            in_pure_procedure=self._in_pure_procedure,
+            line=line,
+            column=col,
+        )
+        self.result.change_team_constructs.append(construct)
+
+        if self._in_pure_procedure:
+            self._add_diagnostic(
+                DiagnosticSeverity.ERROR,
+                "TEAM_E002",
+                "CHANGE TEAM statement is not permitted in a PURE procedure. "
+                "Per ISO/IEC 1539-1:2018 Section 11.6.7, CHANGE TEAM is an "
+                "image control statement and shall not appear in a pure "
+                "subprogram.",
+                ctx,
+                "11.6.7",
+            )
+
+        if self._change_team_depth > 1:
+            self._add_diagnostic(
+                DiagnosticSeverity.INFO,
+                "TEAM_I002",
+                "Nested CHANGE TEAM construct detected. Per ISO/IEC 1539-1:2018 "
+                "Section 11.6.7, nested CHANGE TEAM constructs create a team "
+                "hierarchy that must be carefully managed.",
+                ctx,
+                "11.6.7",
+            )
+
+    def enterEnd_team_stmt(self, ctx):
+        """Process END TEAM statement per ISO/IEC 1539-1:2018 Section 11.6.7."""
+        text = self._get_token_text(ctx)
+
+        if self._in_pure_procedure:
+            self._add_diagnostic(
+                DiagnosticSeverity.ERROR,
+                "TEAM_E003",
+                "END TEAM statement is not permitted in a PURE procedure. "
+                "Per ISO/IEC 1539-1:2018 Section 11.6.7, END TEAM is part of "
+                "an image control construct and shall not appear in a pure "
+                "subprogram.",
+                ctx,
+                "11.6.7",
+            )
+
+    def enterEvent_post_stmt(self, ctx):
+        """Process EVENT POST statement per ISO/IEC 1539-1:2018 Section 11.6.8."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        event_match = re.search(r"event\s*post\s*\(\s*(\w+)", text)
+        event_var = event_match.group(1) if event_match else ""
+
+        stmt = EventStatement(
+            stmt_type="event_post",
+            event_variable=event_var,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            in_pure_procedure=self._in_pure_procedure,
+            in_change_team=self._in_change_team,
+            line=line,
+            column=col,
+        )
+        self.result.event_statements.append(stmt)
+
+        if self._in_pure_procedure:
+            self._add_diagnostic(
+                DiagnosticSeverity.ERROR,
+                "EVENT_E001",
+                "EVENT POST statement is not permitted in a PURE procedure. "
+                "Per ISO/IEC 1539-1:2018 Section 11.6.8, EVENT POST is an "
+                "image control statement and shall not appear in a pure "
+                "subprogram.",
+                ctx,
+                "11.6.8",
+            )
+
+        self._validate_event_statement(stmt, ctx)
+
+    def enterEvent_wait_stmt(self, ctx):
+        """Process EVENT WAIT statement per ISO/IEC 1539-1:2018 Section 11.6.8."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        event_match = re.search(r"event\s*wait\s*\(\s*(\w+)", text)
+        event_var = event_match.group(1) if event_match else ""
+
+        stmt = EventStatement(
+            stmt_type="event_wait",
+            event_variable=event_var,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            has_until_count="until_count" in text,
+            in_pure_procedure=self._in_pure_procedure,
+            in_change_team=self._in_change_team,
+            line=line,
+            column=col,
+        )
+        self.result.event_statements.append(stmt)
+
+        if self._in_pure_procedure:
+            self._add_diagnostic(
+                DiagnosticSeverity.ERROR,
+                "EVENT_E002",
+                "EVENT WAIT statement is not permitted in a PURE procedure. "
+                "Per ISO/IEC 1539-1:2018 Section 11.6.8, EVENT WAIT is an "
+                "image control statement and shall not appear in a pure "
+                "subprogram.",
+                ctx,
+                "11.6.8",
+            )
+
+        self._validate_event_statement(stmt, ctx)
+
+    def enterEvent_query_stmt(self, ctx):
+        """Process EVENT_QUERY per ISO/IEC 1539-1:2018 Section 16.9.72."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        event_match = re.search(r"event\s*query\s*\(\s*(\w+)", text)
+        event_var = event_match.group(1) if event_match else ""
+
+        stmt = EventStatement(
+            stmt_type="event_query",
+            event_variable=event_var,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            has_count="count=" in text or "count =" in text,
+            in_pure_procedure=self._in_pure_procedure,
+            in_change_team=self._in_change_team,
+            line=line,
+            column=col,
+        )
+        self.result.event_statements.append(stmt)
+
+        self._validate_event_statement(stmt, ctx)
+
+    def _validate_event_statement(self, stmt: EventStatement, ctx):
+        """Validate event statement per ISO/IEC 1539-1:2018."""
+        if stmt.event_variable:
+            if stmt.event_variable not in self.result.event_declarations:
+                self._add_diagnostic(
+                    DiagnosticSeverity.INFO,
+                    "EVENT_I001",
+                    f"Event variable '{stmt.event_variable}' may reference an "
+                    "EVENT_TYPE variable declared in another scope. Per "
+                    "ISO/IEC 1539-1:2018 Section 11.6.8, the event-variable "
+                    "shall be a scalar variable of type EVENT_TYPE.",
+                    ctx,
+                    "11.6.8",
+                )
+
+    def enterCo_sum_stmt(self, ctx):
+        """Process CO_SUM call per ISO/IEC 1539-1:2018 Section 16.9.50."""
+        self._process_collective_call(ctx, "co_sum")
+
+    def enterCo_min_stmt(self, ctx):
+        """Process CO_MIN call per ISO/IEC 1539-1:2018 Section 16.9.48."""
+        self._process_collective_call(ctx, "co_min")
+
+    def enterCo_max_stmt(self, ctx):
+        """Process CO_MAX call per ISO/IEC 1539-1:2018 Section 16.9.47."""
+        self._process_collective_call(ctx, "co_max")
+
+    def enterCo_reduce_stmt(self, ctx):
+        """Process CO_REDUCE call per ISO/IEC 1539-1:2018 Section 16.9.49."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        var_match = re.search(r"co_reduce\s*\(\s*(\w+)", text)
+        variable = var_match.group(1) if var_match else ""
+
+        call = CollectiveCall(
+            collective_type="co_reduce",
+            variable=variable,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            has_result_image="result_image=" in text or "result_image =" in text,
+            has_operation=True,
+            in_pure_procedure=self._in_pure_procedure,
+            in_change_team=self._in_change_team,
+            line=line,
+            column=col,
+        )
+        self.result.collective_calls.append(call)
+
+        self._validate_collective_call(call, ctx, "16.9.49")
+
+    def enterCo_broadcast_stmt(self, ctx):
+        """Process CO_BROADCAST call per ISO/IEC 1539-1:2018 Section 16.9.46."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        var_match = re.search(r"co_broadcast\s*\(\s*(\w+)", text)
+        variable = var_match.group(1) if var_match else ""
+
+        call = CollectiveCall(
+            collective_type="co_broadcast",
+            variable=variable,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            has_source_image="source_image=" in text or "source_image =" in text,
+            in_pure_procedure=self._in_pure_procedure,
+            in_change_team=self._in_change_team,
+            line=line,
+            column=col,
+        )
+        self.result.collective_calls.append(call)
+
+        if not call.has_source_image:
+            self._add_diagnostic(
+                DiagnosticSeverity.WARNING,
+                "COLL_W001",
+                "CO_BROADCAST call without SOURCE_IMAGE argument. Per "
+                "ISO/IEC 1539-1:2018 Section 16.9.46, SOURCE_IMAGE is a "
+                "required argument that specifies the source image.",
+                ctx,
+                "16.9.46",
+            )
+
+        self._validate_collective_call(call, ctx, "16.9.46")
+
+    def _process_collective_call(self, ctx, collective_type: str):
+        """Process a collective subroutine call."""
+        text = self._get_token_text(ctx)
+        line, col = self._get_location(ctx)
+
+        var_match = re.search(rf"{collective_type}\s*\(\s*(\w+)", text)
+        variable = var_match.group(1) if var_match else ""
+
+        section_map = {
+            "co_sum": "16.9.50",
+            "co_min": "16.9.48",
+            "co_max": "16.9.47",
+        }
+
+        call = CollectiveCall(
+            collective_type=collective_type,
+            variable=variable,
+            has_stat="stat=" in text or "stat =" in text,
+            has_errmsg="errmsg=" in text or "errmsg =" in text,
+            has_result_image="result_image=" in text or "result_image =" in text,
+            in_pure_procedure=self._in_pure_procedure,
+            in_change_team=self._in_change_team,
+            line=line,
+            column=col,
+        )
+        self.result.collective_calls.append(call)
+
+        self._validate_collective_call(call, ctx, section_map.get(collective_type, ""))
+
+    def _validate_collective_call(
+        self, call: CollectiveCall, ctx, iso_section: str
+    ):
+        """Validate collective subroutine call per ISO/IEC 1539-1:2018."""
+        if call.in_pure_procedure:
+            self._add_diagnostic(
+                DiagnosticSeverity.ERROR,
+                "COLL_E001",
+                f"{call.collective_type.upper()} call is not permitted in a "
+                "PURE procedure. Per ISO/IEC 1539-1:2018, collective "
+                "subroutines perform inter-image communication and shall "
+                "not appear in a pure subprogram.",
+                ctx,
+                iso_section,
+            )
+
+
+class F2018TeamsEventsValidator:
+    """Semantic validator for Fortran 2018 teams, events, and collectives."""
+
+    def __init__(self):
+        self._lexer = None
+        self._parser = None
+
+    def validate_code(self, code: str) -> F2018TeamsEventsValidationResult:
+        """Validate Fortran 2018 code for teams/events/collectives semantics."""
+        input_stream = InputStream(code)
+        self._lexer = Fortran2018Lexer(input_stream)
+        token_stream = CommonTokenStream(self._lexer)
+        self._parser = Fortran2018Parser(token_stream)
+
+        tree = self._parser.program_unit_f2018()
+
+        syntax_errors = self._parser.getNumberOfSyntaxErrors()
+        result = F2018TeamsEventsValidationResult()
+
+        if syntax_errors > 0:
+            result.diagnostics.append(
+                SemanticDiagnostic(
+                    severity=DiagnosticSeverity.ERROR,
+                    code="SYNTAX_E001",
+                    message=f"Code contains {syntax_errors} syntax error(s). "
+                    "Fix syntax errors before semantic validation.",
+                )
+            )
+            return result
+
+        listener = F2018TeamsEventsListener()
+        walker = ParseTreeWalker()
+        walker.walk(listener, tree)
+
+        self._perform_cross_entity_validation(listener.result)
+
+        return listener.result
+
+    def _perform_cross_entity_validation(
+        self, result: F2018TeamsEventsValidationResult
+    ):
+        """Perform validation that requires cross-referencing entities."""
+        self._validate_team_event_interactions(result)
+        self._validate_collective_team_interactions(result)
+
+    def _validate_team_event_interactions(
+        self, result: F2018TeamsEventsValidationResult
+    ):
+        """Validate interactions between teams and events."""
+        team_count = len(result.team_declarations)
+        event_count = len(result.event_declarations)
+        change_team_count = len(result.change_team_constructs)
+
+        if event_count > 0 and change_team_count > 0:
+            events_in_team = [
+                e for e in result.event_statements if e.in_change_team
+            ]
+            if events_in_team:
+                result.diagnostics.append(
+                    SemanticDiagnostic(
+                        severity=DiagnosticSeverity.INFO,
+                        code="TEAM_EVENT_I001",
+                        message="Event statements within CHANGE TEAM constructs "
+                        "detected. Per ISO/IEC 1539-1:2018 Section 11.6, events "
+                        "used within teams operate on the current team context.",
+                        iso_section="11.6",
+                    )
+                )
+
+    def _validate_collective_team_interactions(
+        self, result: F2018TeamsEventsValidationResult
+    ):
+        """Validate interactions between collectives and teams."""
+        change_team_count = len(result.change_team_constructs)
+        collective_count = len(result.collective_calls)
+
+        if collective_count > 0 and change_team_count > 0:
+            collectives_in_team = [
+                c for c in result.collective_calls if c.in_change_team
+            ]
+            if collectives_in_team:
+                result.diagnostics.append(
+                    SemanticDiagnostic(
+                        severity=DiagnosticSeverity.INFO,
+                        code="TEAM_COLL_I001",
+                        message="Collective subroutine calls within CHANGE TEAM "
+                        "constructs detected. Per ISO/IEC 1539-1:2018 Sections "
+                        "11.6 and 16.9.46-50, collectives operate on the "
+                        "current team by default.",
+                        iso_section="11.6",
+                    )
+                )
+
+        if collective_count > 0 and change_team_count == 0:
+            result.diagnostics.append(
+                SemanticDiagnostic(
+                    severity=DiagnosticSeverity.INFO,
+                    code="COLL_I001",
+                    message=f"Code contains {collective_count} collective "
+                    "subroutine call(s) outside any CHANGE TEAM construct. "
+                    "Per ISO/IEC 1539-1:2018 Section 16.9.46-50, these "
+                    "collectives operate on the initial team (all images).",
+                    iso_section="16.9.46",
+                )
+            )
+
+    def validate_file(self, filepath: str) -> F2018TeamsEventsValidationResult:
+        """Validate a Fortran 2018 file for teams/events/collectives."""
+        path = Path(filepath)
+        if not path.exists():
+            result = F2018TeamsEventsValidationResult()
+            result.diagnostics.append(
+                SemanticDiagnostic(
+                    severity=DiagnosticSeverity.ERROR,
+                    code="FILE_E001",
+                    message=f"File not found: {filepath}",
+                )
+            )
+            return result
+
+        code = path.read_text()
+        return self.validate_code(code)
+
+
+def validate_teams_semantics(code: str) -> F2018TeamsEventsValidationResult:
+    """Convenience function to validate team semantics."""
+    validator = F2018TeamsEventsValidator()
+    return validator.validate_code(code)
+
+
+def validate_events_semantics(code: str) -> F2018TeamsEventsValidationResult:
+    """Convenience function to validate event semantics."""
+    validator = F2018TeamsEventsValidator()
+    return validator.validate_code(code)
+
+
+def validate_collective_semantics(code: str) -> F2018TeamsEventsValidationResult:
+    """Convenience function to validate collective subroutine semantics."""
+    validator = F2018TeamsEventsValidator()
+    return validator.validate_code(code)


### PR DESCRIPTION
## Summary

- Implement semantic validation for Fortran 2018 teams, events, and collective coarray features per ISO/IEC 1539-1:2018
- Add validator for team constructs (FORM TEAM, CHANGE TEAM) per Section 11.6
- Add validator for event statements (EVENT POST/WAIT/QUERY) per Section 11.6.8
- Add validator for collective subroutine calls (CO_SUM/MIN/MAX/REDUCE/BROADCAST) per Sections 16.9.46-50
- Include 38 comprehensive tests for the new semantic validation

## Verification

```
$ python -m pytest tests/Fortran2018/test_issue192_teams_events_semantics.py -v
============================= test session starts ==============================
collected 38 items

tests/Fortran2018/test_issue192_teams_events_semantics.py::TestF2018TeamsEventsValidatorBasic::test_empty_module_no_errors PASSED
tests/Fortran2018/test_issue192_teams_events_semantics.py::TestF2018TeamsEventsValidatorBasic::test_syntax_error_detected PASSED
tests/Fortran2018/test_issue192_teams_events_semantics.py::TestF2018TeamsEventsValidatorBasic::test_validation_result_properties PASSED
...
tests/Fortran2018/test_issue192_teams_events_semantics.py::TestTeamSkeleton::test_team_skeleton_detects_events PASSED

============================== 38 passed in 1.86s ==============================

$ python -m pytest tests/ -v --tb=short
================= 960 passed, 1 skipped, 72 xfailed in 40.92s ==================
```
