### PR TITLE
feat: add semantic validation for F2018 DO CONCURRENT with locality (fixes #193)

### DIFF
--- a/tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py
+++ b/tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Semantic Validation Tests for F2018 DO CONCURRENT with Locality - Issue #193
+
+Comprehensive test suite for Fortran 2018 DO CONCURRENT with locality specifiers
+per ISO/IEC 1539-1:2018:
+- DO CONCURRENT with locality specifiers (Section 11.1.7.2)
+- LOCAL, LOCAL_INIT, SHARED, DEFAULT(NONE) semantics (R1130)
+- Iteration independence with locality constraints (Section 11.1.7.5)
+- Variable declaration and usage requirements
+- Interactions with coarrays and teams
+
+These tests validate the semantic analysis layer on top of the ANTLR grammar,
+ensuring that DO CONCURRENT with locality code conforms to the standard beyond
+syntactic correctness.
+"""
+
+import sys
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, "grammars/generated/modern")
+sys.path.insert(0, "tools")
+sys.path.append(str(Path(__file__).parent.parent))
+
+from f2018_do_concurrent_locality_validator import (
+    F2018DoConcurrentLocalityValidator,
+    DoConcurrentLocalityValidationResult,
+    DiagnosticSeverity,
+    validate_do_concurrent_locality,
+)
+from fixture_utils import load_fixture
+
+
+class TestDoConcurrentLocalityValidatorBasic:
+    """Basic tests for the DO CONCURRENT locality semantic validator."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_empty_module_no_errors(self):
+        """Empty module should have no semantic errors."""
+        code = """
+module empty_mod
+    implicit none
+end module empty_mod
+"""
+        result = self.validator.validate_code(code)
+        assert not result.has_errors, f"Unexpected errors: {result.diagnostics}"
+
+    def test_syntax_error_detected(self):
+        """Syntax errors should be reported before semantic analysis."""
+        code = """
+module broken
+    this is not valid fortran syntax!!!
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        assert result.has_errors
+        assert any(d.code == "SYNTAX_E001" for d in result.diagnostics)
+
+    def test_validation_result_properties(self):
+        """DoConcurrentLocalityValidationResult should correctly report counts."""
+        code = """
+module test_mod
+    implicit none
+end module test_mod
+"""
+        result = self.validator.validate_code(code)
+        assert result.error_count == 0
+        assert result.warning_count == 0
+        assert not result.has_errors
+
+
+class TestDoConcurrentLocalBasicSemantics:
+    """Tests for LOCAL locality specifier semantics."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_local_basic_detected(self):
+        """DO CONCURRENT with LOCAL specifier should be detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_local_basic.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) > 0
+        construct = result.do_concurrent_constructs[0]
+        assert "temp" in construct.local_variables
+
+    def test_local_variable_usage_warning(self):
+        """LOCAL variable referenced without assignment should warn.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.4, LOCAL variables are
+        undefined at the beginning of each iteration.
+        """
+        code = """
+module test
+    implicit none
+contains
+    subroutine proc()
+        integer :: i, temp
+        integer :: a(10)
+        do concurrent (i = 1:10) local(temp)
+            a(i) = temp
+        end do
+    end subroutine proc
+end module test
+"""
+        result = self.validator.validate_code(code)
+        warnings = [d for d in result.diagnostics if d.code == "LOC_W002"]
+        assert len(warnings) > 0
+        assert warnings[0].severity == DiagnosticSeverity.WARNING
+
+
+class TestDoConcurrentLocalInitSemantics:
+    """Tests for LOCAL_INIT locality specifier semantics."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_local_init_detected(self):
+        """DO CONCURRENT with LOCAL_INIT specifier should be detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_local_init.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) > 0
+        construct = result.do_concurrent_constructs[0]
+        assert "accum" in construct.local_init_variables
+
+
+class TestDoConcurrentSharedSemantics:
+    """Tests for SHARED locality specifier semantics."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_shared_detected(self):
+        """DO CONCURRENT with SHARED specifier should be detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_shared.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) > 0
+        construct = result.do_concurrent_constructs[0]
+        assert "factor" in construct.shared_variables
+        assert "global_size" in construct.shared_variables
+
+    def test_shared_assignment_warning(self):
+        """Assigning to SHARED variable should produce warning.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.5, assigning to SHARED
+        variables may violate iteration independence.
+        """
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_violation_shared_assign.f90",
+        )
+        result = self.validator.validate_code(code)
+        warnings = [d for d in result.diagnostics if d.code == "LOC_W003"]
+        assert len(warnings) > 0
+        assert warnings[0].severity == DiagnosticSeverity.WARNING
+        assert "counter" in warnings[0].message
+
+
+class TestDoConcurrentDefaultNoneSemantics:
+    """Tests for DEFAULT(NONE) locality specifier semantics."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_default_none_valid(self):
+        """DO CONCURRENT with complete DEFAULT(NONE) should pass."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_default_none.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) > 0
+        construct = result.do_concurrent_constructs[0]
+        assert construct.has_default_none
+
+    def test_default_none_missing_locality_error(self):
+        """DEFAULT(NONE) with missing locality should produce error.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.5, when DEFAULT(NONE) is
+        specified, all variables must have explicit locality.
+        """
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_violation_default_none_missing.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert result.has_errors
+        errors = [d for d in result.diagnostics if d.code == "LOC_E009"]
+        assert len(errors) > 0
+        assert errors[0].iso_section == "11.1.7.5"
+
+
+class TestDoConcurrentCombinedLocalitySemantics:
+    """Tests for combined locality specifiers."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_combined_locality_detected(self):
+        """DO CONCURRENT with multiple locality specs should be detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_combined_locality.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) > 0
+        construct = result.do_concurrent_constructs[0]
+        assert "work_val" in construct.local_variables
+        assert "scale_factor" in construct.shared_variables
+
+
+class TestDoConcurrentLocalityViolations:
+    """Tests for locality specifier violations."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_index_in_locality_error(self):
+        """Index variable in locality spec should produce error.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.4, the index-name of a
+        concurrent-control shall not appear in a locality-spec.
+        """
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_violation_index_in_local.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert result.has_errors
+        errors = [d for d in result.diagnostics if d.code == "LOC_E007"]
+        assert len(errors) > 0
+        assert errors[0].iso_section == "11.1.7.4"
+        assert "i" in errors[0].message
+
+    def test_duplicate_locality_error(self):
+        """Variable in multiple locality specs should produce error.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.4, a variable-name shall
+        not appear in more than one locality-spec.
+        """
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_violation_duplicate.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert result.has_errors
+        errors = [d for d in result.diagnostics if d.code == "LOC_E008"]
+        assert len(errors) > 0
+        assert errors[0].iso_section == "11.1.7.4"
+        assert "temp" in errors[0].message
+
+
+class TestDoConcurrentMaskWithLocality:
+    """Tests for DO CONCURRENT with mask expression and locality."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_mask_with_locality(self):
+        """DO CONCURRENT with mask and locality should be detected."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_with_mask_and_locality.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) > 0
+
+
+class TestDoConcurrentNestedLocalitySemantics:
+    """Tests for nested DO CONCURRENT with locality."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_nested_locality_detected(self):
+        """Nested DO CONCURRENT with locality should produce INFO."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_nested_locality.f90",
+        )
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        nested_info = [d for d in result.diagnostics if d.code == "LOC_I002"]
+        assert len(nested_info) > 0
+        assert nested_info[0].severity == DiagnosticSeverity.INFO
+
+
+class TestDoConcurrentStopViolationsWithLocality:
+    """Tests for STOP violations in DO CONCURRENT with locality."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_stop_violation_detected(self):
+        """STOP within DO CONCURRENT with locality should produce ERROR."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue193_do_concurrent_locality_semantics",
+            "do_concurrent_violation_stop.f90",
+        )
+        result = self.validator.validate_code(code)
+        stop_errors = [d for d in result.diagnostics if d.code == "LOC_E001"]
+        assert len(stop_errors) > 0
+        assert stop_errors[0].iso_section == "11.1.7.5"
+
+
+class TestDoConcurrentLocalityInlineCode:
+    """Tests for inline DO CONCURRENT code with locality."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_inline_local_specifier(self):
+        """Inline DO CONCURRENT with LOCAL should be validated."""
+        code = """
+module test
+    implicit none
+contains
+    subroutine proc()
+        integer :: i, temp
+        real :: a(10)
+        do concurrent (i = 1:10) local(temp)
+            temp = i * 2
+            a(i) = real(temp)
+        end do
+    end subroutine proc
+end module test
+"""
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) >= 1
+        construct = result.do_concurrent_constructs[0]
+        assert "temp" in construct.local_variables
+
+    def test_inline_shared_specifier(self):
+        """Inline DO CONCURRENT with SHARED should be validated."""
+        code = """
+module test
+    implicit none
+contains
+    subroutine proc()
+        integer :: i
+        real :: factor
+        real :: a(10)
+        factor = 2.5
+        do concurrent (i = 1:10) shared(factor)
+            a(i) = real(i) * factor
+        end do
+    end subroutine proc
+end module test
+"""
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) >= 1
+        construct = result.do_concurrent_constructs[0]
+        assert "factor" in construct.shared_variables
+
+    def test_inline_default_none_complete(self):
+        """Inline DO CONCURRENT with complete DEFAULT(NONE) should pass."""
+        code = """
+module test
+    implicit none
+contains
+    subroutine proc()
+        integer :: i, temp
+        real :: a(10)
+        do concurrent (i = 1:10) local(temp) shared(a) default(none)
+            temp = i
+            a(i) = real(temp)
+        end do
+    end subroutine proc
+end module test
+"""
+        result = self.validator.validate_code(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) >= 1
+        construct = result.do_concurrent_constructs[0]
+        assert construct.has_default_none
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience validation functions."""
+
+    def test_validate_do_concurrent_locality_function(self):
+        """validate_do_concurrent_locality() should work as standalone."""
+        code = """
+module test
+    implicit none
+contains
+    subroutine work()
+        integer :: i, temp
+        real :: a(10)
+        do concurrent (i = 1:10) local(temp)
+            temp = i
+            a(i) = real(temp)
+        end do
+    end subroutine work
+end module test
+"""
+        result = validate_do_concurrent_locality(code)
+        assert not result.has_errors
+        assert len(result.do_concurrent_constructs) > 0
+
+
+class TestDiagnosticQuality:
+    """Tests for diagnostic message quality and ISO references."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_diagnostic_has_severity(self):
+        """All diagnostics should have a severity level."""
+        code = """
+module broken
+    invalid syntax here
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        for diag in result.diagnostics:
+            assert diag.severity in DiagnosticSeverity
+
+    def test_diagnostic_has_code(self):
+        """All diagnostics should have a unique code."""
+        code = """
+module broken
+    invalid syntax here
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        for diag in result.diagnostics:
+            assert diag.code is not None
+            assert len(diag.code) > 0
+
+    def test_diagnostic_has_message(self):
+        """All diagnostics should have a descriptive message."""
+        code = """
+module broken
+    invalid syntax here
+end module broken
+"""
+        result = self.validator.validate_code(code)
+        for diag in result.diagnostics:
+            assert diag.message is not None
+            assert len(diag.message) > 0
+
+
+class TestISOComplianceValidation:
+    """Tests verifying ISO/IEC 1539-1:2018 compliance checks."""
+
+    def setup_method(self):
+        self.validator = F2018DoConcurrentLocalityValidator()
+
+    def test_locality_error_references_iso_section(self):
+        """Locality errors should reference ISO section 11.1.7."""
+        code = """
+module test
+    implicit none
+contains
+    subroutine proc()
+        integer :: i
+        integer :: a(10)
+        do concurrent (i = 1:10) local(i)
+            a(i) = i
+        end do
+    end subroutine proc
+end module test
+"""
+        result = self.validator.validate_code(code)
+        locality_errors = [
+            d for d in result.diagnostics if d.code.startswith("LOC_E")
+        ]
+        assert len(locality_errors) > 0
+        assert any(
+            d.iso_section is not None and "11.1.7" in d.iso_section
+            for d in locality_errors
+        )
+
+    def test_stop_error_references_iso_section(self):
+        """STOP error in locality context should reference ISO 11.1.7.5."""
+        code = """
+module test
+    implicit none
+contains
+    subroutine proc()
+        integer :: i, temp
+        integer :: a(10)
+        do concurrent (i = 1:10) local(temp)
+            temp = i
+            stop
+            a(i) = temp
+        end do
+    end subroutine proc
+end module test
+"""
+        result = self.validator.validate_code(code)
+        stop_errors = [d for d in result.diagnostics if "STOP" in d.message]
+        assert len(stop_errors) > 0
+        assert any(d.iso_section == "11.1.7.5" for d in stop_errors)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_combined_locality.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_combined_locality.f90
@@ -1,0 +1,19 @@
+module do_concurrent_combined_locality
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.2 - Combined locality specifiers
+    implicit none
+contains
+    subroutine process_data(input, output, n)
+        real, intent(in) :: input(:)
+        real, intent(out) :: output(:)
+        integer, intent(in) :: n
+        integer :: i
+        real :: work_val
+        real :: scale_factor
+
+        scale_factor = 2.5
+        do concurrent(i=1:n) local(work_val) shared(scale_factor, n)
+            work_val = input(i)*scale_factor
+            output(i) = work_val + 1.0
+        end do
+    end subroutine process_data
+end module do_concurrent_combined_locality

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_default_none.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_default_none.f90
@@ -1,0 +1,17 @@
+module do_concurrent_default_none
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.5 - DO CONCURRENT with DEFAULT(NONE)
+    implicit none
+contains
+    subroutine strict_compute(a, b, n)
+        real, intent(in) :: a(:)
+        real, intent(out) :: b(:)
+        integer, intent(in) :: n
+        integer :: i
+        real :: temp
+
+        do concurrent(i=1:n) local(temp) shared(a, b, n) default(none)
+            temp = a(i)
+            b(i) = temp*2.0
+        end do
+    end subroutine strict_compute
+end module do_concurrent_default_none

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_local_basic.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_local_basic.f90
@@ -1,0 +1,16 @@
+module do_concurrent_local_basic
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.2 - DO CONCURRENT with LOCAL
+    implicit none
+contains
+    subroutine compute_squares(a, b)
+        integer, intent(in) :: a(:)
+        integer, intent(out) :: b(:)
+        integer :: i
+        integer :: temp
+
+        do concurrent(i=1:size(a)) local(temp)
+            temp = a(i)
+            b(i) = temp*temp
+        end do
+    end subroutine compute_squares
+end module do_concurrent_local_basic

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_local_init.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_local_init.f90
@@ -1,0 +1,16 @@
+module do_concurrent_local_init
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.2 - DO CONCURRENT with LOCAL_INIT
+    implicit none
+contains
+    subroutine accumulate(a, b)
+        integer, intent(in) :: a(:)
+        integer, intent(out) :: b(:)
+        integer :: i
+        integer :: accum
+
+        do concurrent(i=1:size(a)) local_init(accum)
+            accum = accum + a(i)
+            b(i) = accum
+        end do
+    end subroutine accumulate
+end module do_concurrent_local_init

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_nested_locality.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_nested_locality.f90
@@ -1,0 +1,19 @@
+module do_concurrent_nested_locality
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.5 - Nested DO CONCURRENT with locality
+    implicit none
+contains
+    subroutine matrix_init(mat, n, m)
+        real, intent(out) :: mat(:, :)
+        integer, intent(in) :: n, m
+        integer :: i, j
+        real :: row_val, col_val
+
+        do concurrent(i=1:n) local(row_val) shared(n)
+            row_val = real(i)
+            do concurrent(j=1:m) local(col_val) shared(m)
+                col_val = real(j)
+                mat(i, j) = row_val + col_val
+            end do
+        end do
+    end subroutine matrix_init
+end module do_concurrent_nested_locality

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_shared.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_shared.f90
@@ -1,0 +1,15 @@
+module do_concurrent_shared
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.2 - DO CONCURRENT with SHARED
+    implicit none
+    integer :: global_size = 100
+contains
+    subroutine scale_array(a, factor)
+        real, intent(inout) :: a(:)
+        real, intent(in) :: factor
+        integer :: i
+
+        do concurrent(i=1:global_size) shared(factor, global_size)
+            a(i) = a(i)*factor
+        end do
+    end subroutine scale_array
+end module do_concurrent_shared

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_default_none_missing.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_default_none_missing.f90
@@ -1,0 +1,15 @@
+module do_concurrent_violation_default_none
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.5 violation test
+    ! With DEFAULT(NONE), all variables must have locality specified
+    implicit none
+contains
+    subroutine missing_locality(a, b)
+        integer, intent(in) :: a(:)
+        integer, intent(out) :: b(:)
+        integer :: i
+
+        do concurrent(i=1:10) default(none)
+            b(i) = a(i) + 1
+        end do
+    end subroutine missing_locality
+end module do_concurrent_violation_default_none

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_duplicate.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_duplicate.f90
@@ -1,0 +1,16 @@
+module do_concurrent_violation_duplicate
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.4 violation test
+    ! Variable shall not appear in more than one locality specifier
+    implicit none
+contains
+    subroutine bad_duplicate(a)
+        integer, intent(inout) :: a(:)
+        integer :: i
+        integer :: temp
+
+        do concurrent(i=1:10) local(temp) shared(temp)
+            temp = a(i)
+            a(i) = temp + 1
+        end do
+    end subroutine bad_duplicate
+end module do_concurrent_violation_duplicate

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_index_in_local.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_index_in_local.f90
@@ -1,0 +1,14 @@
+module do_concurrent_violation_index_local
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.4 violation test
+    ! Index variable shall not appear in locality specifier
+    implicit none
+contains
+    subroutine bad_index_local(a)
+        integer, intent(inout) :: a(:)
+        integer :: i
+
+        do concurrent(i=1:10) local(i)
+            a(i) = i*2
+        end do
+    end subroutine bad_index_local
+end module do_concurrent_violation_index_local

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_shared_assign.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_shared_assign.f90
@@ -1,0 +1,17 @@
+module do_concurrent_violation_shared_assign
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.5 warning test
+    ! Assigning to SHARED variable may violate iteration independence
+    implicit none
+contains
+    subroutine shared_assign_warning(a)
+        integer, intent(inout) :: a(:)
+        integer :: i
+        integer :: counter
+
+        counter = 0
+        do concurrent(i=1:10) shared(counter)
+            counter = counter + 1
+            a(i) = counter
+        end do
+    end subroutine shared_assign_warning
+end module do_concurrent_violation_shared_assign

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_stop.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_violation_stop.f90
@@ -1,0 +1,17 @@
+module do_concurrent_violation_stop
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.5 violation test
+    ! STOP statement prohibited in DO CONCURRENT
+    implicit none
+contains
+    subroutine bad_stop(a)
+        integer, intent(inout) :: a(:)
+        integer :: i
+        integer :: temp
+
+        do concurrent(i=1:10) local(temp)
+            temp = a(i)
+            stop
+            a(i) = temp + 1
+        end do
+    end subroutine bad_stop
+end module do_concurrent_violation_stop

--- a/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_with_mask_and_locality.f90
+++ b/tests/fixtures/Fortran2018/test_issue193_do_concurrent_locality_semantics/do_concurrent_with_mask_and_locality.f90
@@ -1,0 +1,16 @@
+module do_concurrent_mask_locality
+    ! ISO/IEC 1539-1:2018 Section 11.1.7.2 - Mask with locality
+    implicit none
+contains
+    subroutine filter_positives(a, b)
+        integer, intent(in) :: a(:)
+        integer, intent(out) :: b(:)
+        integer :: i
+        integer :: temp
+
+        do concurrent(i=1:size(a), a(i) > 0) local(temp) shared(a, b)
+            temp = a(i)
+            b(i) = temp*2
+        end do
+    end subroutine filter_positives
+end module do_concurrent_mask_locality

--- a/tools/f2018_do_concurrent_locality_validator.py
+++ b/tools/f2018_do_concurrent_locality_validator.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python3
+"""Fortran 2018 DO CONCURRENT with Locality Semantic Validator
+
+Implements semantic validation for Fortran 2018 DO CONCURRENT construct with
+locality specifiers per ISO/IEC 1539-1:2018 (Fortran 2018 standard).
+
+This validator checks:
+- DO CONCURRENT with locality specifiers (Section 11.1.7.2)
+- LOCAL, LOCAL_INIT, SHARED, DEFAULT(NONE) semantics (R1130)
+- Iteration independence with locality constraints (Section 11.1.7.5)
+- Variable declaration and usage requirements
+- Interactions with coarrays and teams
+
+Reference: ISO/IEC 1539-1:2018 (Fortran 2018 International Standard)
+"""
+
+import re
+import sys
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+sys.path.insert(
+    0, str(Path(__file__).parent.parent / "grammars" / "generated" / "modern")
+)
+
+from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
+from Fortran2018Lexer import Fortran2018Lexer
+from Fortran2018Parser import Fortran2018Parser
+from Fortran2018ParserListener import Fortran2018ParserListener
+
+
+class DiagnosticSeverity(Enum):
+    ERROR = auto()
+    WARNING = auto()
+    INFO = auto()
+
+
+@dataclass
+class SemanticDiagnostic:
+    severity: DiagnosticSeverity
+    code: str
+    message: str
+    line: Optional[int] = None
+    column: Optional[int] = None
+    iso_section: Optional[str] = None
+
+
+@dataclass
+class LocalitySpec:
+    """Represents a locality specifier in DO CONCURRENT."""
+    spec_type: str
+    variables: List[str] = field(default_factory=list)
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class DoConcurrentLocalityConstruct:
+    """Represents a DO CONCURRENT construct with locality for semantic analysis.
+
+    Per ISO/IEC 1539-1:2018 Section 11.1.7.2, DO CONCURRENT may include
+    locality specifiers that define the scope and initialization of variables.
+    """
+    index_variables: List[str] = field(default_factory=list)
+    has_mask: bool = False
+    mask_expr: Optional[str] = None
+    local_variables: Set[str] = field(default_factory=set)
+    local_init_variables: Set[str] = field(default_factory=set)
+    shared_variables: Set[str] = field(default_factory=set)
+    has_default_none: bool = False
+    locality_specs: List[LocalitySpec] = field(default_factory=list)
+    assigned_variables: Set[str] = field(default_factory=set)
+    referenced_variables: Set[str] = field(default_factory=set)
+    contains_io: bool = False
+    contains_stop: bool = False
+    contains_sync: bool = False
+    contains_allocate: bool = False
+    contains_deallocate: bool = False
+    contains_coarray_ref: bool = False
+    contains_procedure_call: bool = False
+    called_procedures: Set[str] = field(default_factory=set)
+    depth: int = 0
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+
+@dataclass
+class DoConcurrentLocalityValidationResult:
+    """Results from DO CONCURRENT with locality semantic validation."""
+    diagnostics: List[SemanticDiagnostic] = field(default_factory=list)
+    do_concurrent_constructs: List[DoConcurrentLocalityConstruct] = field(
+        default_factory=list
+    )
+
+    @property
+    def has_errors(self) -> bool:
+        return any(d.severity == DiagnosticSeverity.ERROR for d in self.diagnostics)
+
+    @property
+    def error_count(self) -> int:
+        return sum(
+            1 for d in self.diagnostics if d.severity == DiagnosticSeverity.ERROR
+        )
+
+    @property
+    def warning_count(self) -> int:
+        return sum(
+            1 for d in self.diagnostics if d.severity == DiagnosticSeverity.WARNING
+        )
+
+
+class F2018DoConcurrentLocalityListener(Fortran2018ParserListener):
+    """ANTLR listener for F2018 DO CONCURRENT with locality semantic analysis."""
+
+    def __init__(self):
+        super().__init__()
+        self.result = DoConcurrentLocalityValidationResult()
+        self._do_concurrent_stack: List[DoConcurrentLocalityConstruct] = []
+        self._in_do_concurrent = False
+        self._current_do_concurrent: Optional[DoConcurrentLocalityConstruct] = None
+        self._pure_context = False
+        self._impure_allowed = True
+        self._declared_variables: Set[str] = set()
+        self._in_locality_spec = False
+
+    def _get_token_text(self, ctx) -> str:
+        if ctx is None:
+            return ""
+        return ctx.getText().lower()
+
+    def _get_location(self, ctx) -> Tuple[Optional[int], Optional[int]]:
+        if ctx is None:
+            return None, None
+        if hasattr(ctx, "start") and ctx.start:
+            return ctx.start.line, ctx.start.column
+        return None, None
+
+    def _add_diagnostic(
+        self,
+        severity: DiagnosticSeverity,
+        code: str,
+        message: str,
+        ctx=None,
+        iso_section: Optional[str] = None,
+    ):
+        line, column = self._get_location(ctx)
+        self.result.diagnostics.append(
+            SemanticDiagnostic(
+                severity=severity,
+                code=code,
+                message=message,
+                line=line,
+                column=column,
+                iso_section=iso_section,
+            )
+        )
+
+    def enterType_declaration_stmt(self, ctx):
+        """Track variable declarations for locality validation."""
+        text = self._get_token_text(ctx)
+        decl_match = re.search(r"::\s*(.+)$", text)
+        if decl_match:
+            decl_part = decl_match.group(1)
+            var_names = re.findall(r"(\w+)", decl_part)
+            for var in var_names:
+                if var not in ["dimension", "allocatable", "intent", "inout", "in",
+                               "out", "optional", "save", "target", "pointer"]:
+                    self._declared_variables.add(var)
+
+    def enterDo_concurrent_construct_f2018(self, ctx):
+        """Enter a DO CONCURRENT construct with F2018 locality support."""
+        line, col = self._get_location(ctx)
+        construct = DoConcurrentLocalityConstruct(
+            depth=len(self._do_concurrent_stack),
+            line=line,
+            column=col,
+        )
+        self._do_concurrent_stack.append(construct)
+        self._in_do_concurrent = True
+        self._current_do_concurrent = construct
+
+    def exitDo_concurrent_construct_f2018(self, ctx):
+        """Exit a DO CONCURRENT construct and perform validation."""
+        if self._do_concurrent_stack:
+            construct = self._do_concurrent_stack.pop()
+            self.result.do_concurrent_constructs.append(construct)
+            self._validate_do_concurrent_locality(construct, ctx)
+            if self._do_concurrent_stack:
+                self._current_do_concurrent = self._do_concurrent_stack[-1]
+            else:
+                self._current_do_concurrent = None
+                self._in_do_concurrent = False
+
+    def enterDo_concurrent_stmt_f2018(self, ctx):
+        """Process DO CONCURRENT statement header with locality specifiers."""
+        text = self._get_token_text(ctx)
+        if self._current_do_concurrent is None:
+            return
+
+        index_vars = self._extract_index_variables(text)
+        self._current_do_concurrent.index_variables = index_vars
+
+        paren_match = re.search(r"\(([^)]+)\)", text)
+        if paren_match:
+            header_content = paren_match.group(1)
+            if "," in header_content:
+                parts = header_content.split(",")
+                for part in parts[1:]:
+                    part = part.strip()
+                    if not re.match(r"\w+\s*=", part):
+                        self._current_do_concurrent.has_mask = True
+                        break
+
+    def enterConcurrent_locality(self, ctx):
+        """Process locality specifiers per ISO/IEC 1539-1:2018 R1130."""
+        text = self._get_token_text(ctx)
+        if self._current_do_concurrent is None:
+            return
+
+        line, col = self._get_location(ctx)
+
+        if text.startswith("local_init"):
+            var_match = re.search(r"local_init\s*\(([^)]+)\)", text)
+            if var_match:
+                vars_text = var_match.group(1)
+                variables = [v.strip() for v in vars_text.split(",")]
+                spec = LocalitySpec(
+                    spec_type="local_init",
+                    variables=variables,
+                    line=line,
+                    column=col,
+                )
+                self._current_do_concurrent.locality_specs.append(spec)
+                self._current_do_concurrent.local_init_variables.update(variables)
+        elif text.startswith("local"):
+            var_match = re.search(r"local\s*\(([^)]+)\)", text)
+            if var_match:
+                vars_text = var_match.group(1)
+                variables = [v.strip() for v in vars_text.split(",")]
+                spec = LocalitySpec(
+                    spec_type="local",
+                    variables=variables,
+                    line=line,
+                    column=col,
+                )
+                self._current_do_concurrent.locality_specs.append(spec)
+                self._current_do_concurrent.local_variables.update(variables)
+        elif text.startswith("shared"):
+            var_match = re.search(r"shared\s*\(([^)]+)\)", text)
+            if var_match:
+                vars_text = var_match.group(1)
+                variables = [v.strip() for v in vars_text.split(",")]
+                spec = LocalitySpec(
+                    spec_type="shared",
+                    variables=variables,
+                    line=line,
+                    column=col,
+                )
+                self._current_do_concurrent.locality_specs.append(spec)
+                self._current_do_concurrent.shared_variables.update(variables)
+        elif "default" in text and "none" in text:
+            spec = LocalitySpec(
+                spec_type="default_none",
+                variables=[],
+                line=line,
+                column=col,
+            )
+            self._current_do_concurrent.locality_specs.append(spec)
+            self._current_do_concurrent.has_default_none = True
+
+    def _extract_index_variables(self, text: str) -> List[str]:
+        """Extract index variable names from DO CONCURRENT header."""
+        vars_found = []
+        pattern = r"(\w+)\s*=\s*[^:,]+:[^:,]+"
+        for match in re.finditer(pattern, text):
+            var_name = match.group(1)
+            if var_name not in ["concurrent", "do"]:
+                vars_found.append(var_name)
+        return vars_found
+
+    def enterAssignment_stmt(self, ctx):
+        """Track variable assignments and references within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+
+        text = self._get_token_text(ctx)
+        lhs_match = re.match(r"(\w+)", text)
+        if lhs_match:
+            var_name = lhs_match.group(1)
+            self._current_do_concurrent.assigned_variables.add(var_name)
+
+        equals_pos = text.find("=")
+        if equals_pos != -1:
+            rhs_text = text[equals_pos + 1:]
+            rhs_vars = self._extract_referenced_variables(rhs_text)
+            self._current_do_concurrent.referenced_variables.update(rhs_vars)
+
+    def _extract_referenced_variables(self, text: str) -> Set[str]:
+        """Extract variable names referenced in an expression."""
+        keywords = {
+            "real", "integer", "logical", "character", "complex", "double",
+            "precision", "kind", "len", "size", "shape", "lbound", "ubound",
+            "allocated", "associated", "present", "abs", "sqrt", "sin", "cos",
+            "tan", "exp", "log", "max", "min", "mod", "nint", "floor", "ceiling",
+            "sum", "product", "maxval", "minval", "any", "all", "count", "pack",
+            "unpack", "merge", "spread", "reshape", "transpose", "matmul", "dot",
+        }
+        identifiers = set(re.findall(r"\b([a-z_]\w*)\b", text))
+        return identifiers - keywords
+
+    def enterCall_stmt(self, ctx):
+        """Track procedure calls within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+
+        text = self._get_token_text(ctx)
+        self._current_do_concurrent.contains_procedure_call = True
+
+        call_match = re.search(r"call\s+(\w+)", text)
+        if call_match:
+            proc_name = call_match.group(1)
+            self._current_do_concurrent.called_procedures.add(proc_name)
+
+    def enterPrint_stmt(self, ctx):
+        """Track PRINT statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_io = True
+        self._add_diagnostic(
+            DiagnosticSeverity.WARNING,
+            "LOC_W001",
+            "PRINT statement within DO CONCURRENT may cause nondeterministic "
+            "output ordering. Per ISO/IEC 1539-1:2018 Section 11.1.7.5, "
+            "I/O operations are not recommended in DO CONCURRENT.",
+            ctx,
+            "11.1.7.5",
+        )
+
+    def enterStop_stmt(self, ctx):
+        """Track STOP statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_stop = True
+        self._add_diagnostic(
+            DiagnosticSeverity.ERROR,
+            "LOC_E001",
+            "STOP statement is prohibited within DO CONCURRENT. "
+            "Per ISO/IEC 1539-1:2018 Section 11.1.7.5, a STOP or ERROR STOP "
+            "statement shall not appear within a DO CONCURRENT construct.",
+            ctx,
+            "11.1.7.5",
+        )
+
+    def enterStop_stmt_f2018(self, ctx):
+        """Track F2018 STOP statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_stop = True
+        self._add_diagnostic(
+            DiagnosticSeverity.ERROR,
+            "LOC_E001",
+            "STOP statement is prohibited within DO CONCURRENT. "
+            "Per ISO/IEC 1539-1:2018 Section 11.1.7.5, a STOP or ERROR STOP "
+            "statement shall not appear within a DO CONCURRENT construct.",
+            ctx,
+            "11.1.7.5",
+        )
+
+    def enterError_stop_stmt(self, ctx):
+        """Track ERROR STOP statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_stop = True
+        self._add_diagnostic(
+            DiagnosticSeverity.ERROR,
+            "LOC_E002",
+            "ERROR STOP statement is prohibited within DO CONCURRENT. "
+            "Per ISO/IEC 1539-1:2018 Section 11.1.7.5, a STOP or ERROR STOP "
+            "statement shall not appear within a DO CONCURRENT construct.",
+            ctx,
+            "11.1.7.5",
+        )
+
+    def enterSync_all_stmt(self, ctx):
+        """Track SYNC ALL statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_sync = True
+        self._add_diagnostic(
+            DiagnosticSeverity.ERROR,
+            "LOC_E003",
+            "Image control statement SYNC ALL is prohibited within "
+            "DO CONCURRENT. Per ISO/IEC 1539-1:2018 Section 11.1.7.5, "
+            "an image control statement shall not appear within a "
+            "DO CONCURRENT construct.",
+            ctx,
+            "11.1.7.5",
+        )
+
+    def enterSync_images_stmt(self, ctx):
+        """Track SYNC IMAGES statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_sync = True
+        self._add_diagnostic(
+            DiagnosticSeverity.ERROR,
+            "LOC_E004",
+            "Image control statement SYNC IMAGES is prohibited within "
+            "DO CONCURRENT. Per ISO/IEC 1539-1:2018 Section 11.1.7.5, "
+            "an image control statement shall not appear within a "
+            "DO CONCURRENT construct.",
+            ctx,
+            "11.1.7.5",
+        )
+
+    def enterSync_memory_stmt(self, ctx):
+        """Track SYNC MEMORY statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_sync = True
+        self._add_diagnostic(
+            DiagnosticSeverity.ERROR,
+            "LOC_E005",
+            "Image control statement SYNC MEMORY is prohibited within "
+            "DO CONCURRENT. Per ISO/IEC 1539-1:2018 Section 11.1.7.5, "
+            "an image control statement shall not appear within a "
+            "DO CONCURRENT construct.",
+            ctx,
+            "11.1.7.5",
+        )
+
+    def enterAllocate_stmt(self, ctx):
+        """Track ALLOCATE statements within DO CONCURRENT."""
+        if not self._in_do_concurrent or self._current_do_concurrent is None:
+            return
+        self._current_do_concurrent.contains_allocate = True
+        text = self._get_token_text(ctx)
+        if "[" in text:
+            self._current_do_concurrent.contains_coarray_ref = True
+            self._add_diagnostic(
+                DiagnosticSeverity.ERROR,
+                "LOC_E006",
+                "ALLOCATE with coarray is prohibited within DO CONCURRENT. "
+                "Per ISO/IEC 1539-1:2018 Section 11.1.7.5, allocation of "
+                "coarrays shall not appear within a DO CONCURRENT construct.",
+                ctx,
+                "11.1.7.5",
+            )
+
+    def _validate_do_concurrent_locality(
+        self, construct: DoConcurrentLocalityConstruct, ctx
+    ):
+        """Validate a completed DO CONCURRENT construct with locality.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.2-11.1.7.5, validates:
+        - Locality specifier syntax and semantics
+        - Variable declarations for locality specs
+        - Index variable restrictions
+        - DEFAULT(NONE) completeness
+        - Duplicate locality specifications
+        """
+        self._validate_index_variable_locality(construct, ctx)
+        self._validate_duplicate_locality(construct, ctx)
+        self._validate_default_none_completeness(construct, ctx)
+        self._validate_local_variable_usage(construct, ctx)
+        self._validate_shared_variable_usage(construct, ctx)
+        self._validate_iteration_independence(construct, ctx)
+
+    def _validate_index_variable_locality(
+        self, construct: DoConcurrentLocalityConstruct, ctx
+    ):
+        """Check that index variables are not in locality specs.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.4, the index-name of a
+        concurrent-control shall not appear in a locality-spec.
+        """
+        for idx_var in construct.index_variables:
+            all_locality_vars = (
+                construct.local_variables |
+                construct.local_init_variables |
+                construct.shared_variables
+            )
+            if idx_var in all_locality_vars:
+                self._add_diagnostic(
+                    DiagnosticSeverity.ERROR,
+                    "LOC_E007",
+                    f"Index variable '{idx_var}' shall not appear in a "
+                    "locality specifier. Per ISO/IEC 1539-1:2018 Section "
+                    "11.1.7.4, the index-name of a concurrent-control is "
+                    "implicitly LOCAL and cannot be explicitly specified.",
+                    ctx,
+                    "11.1.7.4",
+                )
+
+    def _validate_duplicate_locality(
+        self, construct: DoConcurrentLocalityConstruct, ctx
+    ):
+        """Check for duplicate variables in locality specs.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.4, a variable-name shall
+        not appear in more than one locality-spec.
+        """
+        all_vars: Dict[str, str] = {}
+        for spec in construct.locality_specs:
+            for var in spec.variables:
+                if var in all_vars:
+                    self._add_diagnostic(
+                        DiagnosticSeverity.ERROR,
+                        "LOC_E008",
+                        f"Variable '{var}' appears in multiple locality "
+                        f"specifiers ({all_vars[var]} and {spec.spec_type}). "
+                        "Per ISO/IEC 1539-1:2018 Section 11.1.7.4, a "
+                        "variable-name shall not appear in more than one "
+                        "locality-spec.",
+                        ctx,
+                        "11.1.7.4",
+                    )
+                else:
+                    all_vars[var] = spec.spec_type
+
+    def _validate_default_none_completeness(
+        self, construct: DoConcurrentLocalityConstruct, ctx
+    ):
+        """Check DEFAULT(NONE) completeness.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.5, if DEFAULT(NONE) appears,
+        each variable referenced in the DO CONCURRENT block must have its
+        locality explicitly specified.
+        """
+        if not construct.has_default_none:
+            return
+
+        all_locality_vars = (
+            construct.local_variables |
+            construct.local_init_variables |
+            construct.shared_variables |
+            set(construct.index_variables)
+        )
+
+        all_referenced = construct.referenced_variables | construct.assigned_variables
+
+        for var in all_referenced:
+            if var not in all_locality_vars:
+                self._add_diagnostic(
+                    DiagnosticSeverity.ERROR,
+                    "LOC_E009",
+                    f"Variable '{var}' used in DO CONCURRENT with "
+                    "DEFAULT(NONE) but has no locality specifier. Per "
+                    "ISO/IEC 1539-1:2018 Section 11.1.7.5, when DEFAULT(NONE) "
+                    "is specified, each variable used in the loop shall have "
+                    "an explicit locality specification.",
+                    ctx,
+                    "11.1.7.5",
+                )
+
+    def _validate_local_variable_usage(
+        self, construct: DoConcurrentLocalityConstruct, ctx
+    ):
+        """Validate LOCAL variable semantics.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.4, a LOCAL variable is a
+        construct entity with the same type, type parameters, and rank as
+        the variable with that name outside the construct, but it is
+        undefined at the beginning of each iteration.
+        """
+        for var in construct.local_variables:
+            if var in construct.referenced_variables:
+                if var not in construct.assigned_variables:
+                    self._add_diagnostic(
+                        DiagnosticSeverity.WARNING,
+                        "LOC_W002",
+                        f"LOCAL variable '{var}' is referenced but may be "
+                        "undefined. Per ISO/IEC 1539-1:2018 Section 11.1.7.4, "
+                        "LOCAL variables are undefined at the start of each "
+                        "iteration. Ensure the variable is assigned before use.",
+                        ctx,
+                        "11.1.7.4",
+                    )
+
+    def _validate_shared_variable_usage(
+        self, construct: DoConcurrentLocalityConstruct, ctx
+    ):
+        """Validate SHARED variable semantics.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.5, a SHARED variable is
+        shared across all iterations. For iteration independence, SHARED
+        variables should generally not be assigned within the loop unless
+        all iterations assign the same value or there is synchronization.
+        """
+        for var in construct.shared_variables:
+            if var in construct.assigned_variables:
+                self._add_diagnostic(
+                    DiagnosticSeverity.WARNING,
+                    "LOC_W003",
+                    f"SHARED variable '{var}' is assigned within DO "
+                    "CONCURRENT. Per ISO/IEC 1539-1:2018 Section 11.1.7.5, "
+                    "assigning to a SHARED variable may violate iteration "
+                    "independence unless all iterations assign the same value.",
+                    ctx,
+                    "11.1.7.5",
+                )
+
+    def _validate_iteration_independence(
+        self, construct: DoConcurrentLocalityConstruct, ctx
+    ):
+        """Check for potential iteration independence violations.
+
+        Per ISO/IEC 1539-1:2018 Section 11.1.7.5, iterations of DO CONCURRENT
+        must be able to execute in any order or concurrently.
+        """
+        unspecified_assigned = (
+            construct.assigned_variables -
+            construct.local_variables -
+            construct.local_init_variables -
+            construct.shared_variables -
+            set(construct.index_variables)
+        )
+
+        for var in unspecified_assigned:
+            if var in construct.referenced_variables:
+                if not construct.has_default_none:
+                    self._add_diagnostic(
+                        DiagnosticSeverity.INFO,
+                        "LOC_I001",
+                        f"Variable '{var}' is both assigned and referenced "
+                        "within DO CONCURRENT without explicit locality. "
+                        "Per ISO/IEC 1539-1:2018 Section 11.1.7.5, consider "
+                        "adding a locality specifier (LOCAL, LOCAL_INIT, or "
+                        "SHARED) to clarify iteration independence.",
+                        ctx,
+                        "11.1.7.5",
+                    )
+
+
+class F2018DoConcurrentLocalityValidator:
+    """Semantic validator for Fortran 2018 DO CONCURRENT with locality."""
+
+    def __init__(self):
+        self._lexer = None
+        self._parser = None
+
+    def validate_code(self, code: str) -> DoConcurrentLocalityValidationResult:
+        """Validate Fortran 2018 code for DO CONCURRENT with locality."""
+        input_stream = InputStream(code)
+        self._lexer = Fortran2018Lexer(input_stream)
+        token_stream = CommonTokenStream(self._lexer)
+        self._parser = Fortran2018Parser(token_stream)
+
+        tree = self._parser.program_unit_f2018()
+
+        syntax_errors = self._parser.getNumberOfSyntaxErrors()
+        result = DoConcurrentLocalityValidationResult()
+
+        if syntax_errors > 0:
+            result.diagnostics.append(
+                SemanticDiagnostic(
+                    severity=DiagnosticSeverity.ERROR,
+                    code="SYNTAX_E001",
+                    message=f"Code contains {syntax_errors} syntax error(s). "
+                    "Fix syntax errors before semantic validation.",
+                )
+            )
+            return result
+
+        listener = F2018DoConcurrentLocalityListener()
+        walker = ParseTreeWalker()
+        walker.walk(listener, tree)
+
+        self._perform_cross_validation(listener.result)
+
+        return listener.result
+
+    def _perform_cross_validation(
+        self, result: DoConcurrentLocalityValidationResult
+    ):
+        """Perform validation requiring cross-construct analysis."""
+        for construct in result.do_concurrent_constructs:
+            if construct.depth > 0:
+                result.diagnostics.append(
+                    SemanticDiagnostic(
+                        severity=DiagnosticSeverity.INFO,
+                        code="LOC_I002",
+                        message="Nested DO CONCURRENT detected. "
+                        "Per ISO/IEC 1539-1:2018 Section 11.1.7.5, nested "
+                        "DO CONCURRENT constructs must maintain independence "
+                        "across all levels of nesting. Locality specifiers "
+                        "at each level apply only to that level.",
+                        line=construct.line,
+                        column=construct.column,
+                        iso_section="11.1.7.5",
+                    )
+                )
+
+    def validate_file(self, filepath: str) -> DoConcurrentLocalityValidationResult:
+        """Validate a Fortran 2018 file for DO CONCURRENT with locality."""
+        path = Path(filepath)
+        if not path.exists():
+            result = DoConcurrentLocalityValidationResult()
+            result.diagnostics.append(
+                SemanticDiagnostic(
+                    severity=DiagnosticSeverity.ERROR,
+                    code="FILE_E001",
+                    message=f"File not found: {filepath}",
+                )
+            )
+            return result
+
+        code = path.read_text()
+        return self.validate_code(code)
+
+
+def validate_do_concurrent_locality(
+    code: str,
+) -> DoConcurrentLocalityValidationResult:
+    """Convenience function to validate DO CONCURRENT with locality."""
+    validator = F2018DoConcurrentLocalityValidator()
+    return validator.validate_code(code)


### PR DESCRIPTION
## Summary

- Add semantic validator for Fortran 2018 DO CONCURRENT with locality specifiers per ISO/IEC 1539-1:2018 Sections 11.1.7.2-11.1.7.5
- Implement LOCAL, LOCAL_INIT, SHARED, DEFAULT(NONE) locality semantics validation
- Detect violations: index vars in locality specs, duplicate vars across specs, incomplete DEFAULT(NONE)
- Add warnings for undefined LOCAL usage and SHARED variable assignment
- Include 25 comprehensive tests covering valid usage and error detection

## Verification

```
$ python -m pytest tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py -v
============================= test session starts ==============================
collected 25 items

tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityValidatorBasic::test_empty_module_no_errors PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityValidatorBasic::test_syntax_error_detected PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityValidatorBasic::test_validation_result_properties PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalBasicSemantics::test_local_basic_detected PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalBasicSemantics::test_local_variable_usage_warning PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalInitSemantics::test_local_init_detected PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentSharedSemantics::test_shared_detected PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentSharedSemantics::test_shared_assignment_warning PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentDefaultNoneSemantics::test_default_none_valid PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentDefaultNoneSemantics::test_default_none_missing_locality_error PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentCombinedLocalitySemantics::test_combined_locality_detected PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityViolations::test_index_in_locality_error PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityViolations::test_duplicate_locality_error PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentMaskWithLocality::test_mask_with_locality PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentNestedLocalitySemantics::test_nested_locality_detected PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentStopViolationsWithLocality::test_stop_violation_detected PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityInlineCode::test_inline_local_specifier PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityInlineCode::test_inline_shared_specifier PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDoConcurrentLocalityInlineCode::test_inline_default_none_complete PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestConvenienceFunctions::test_validate_do_concurrent_locality_function PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDiagnosticQuality::test_diagnostic_has_severity PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDiagnosticQuality::test_diagnostic_has_code PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestDiagnosticQuality::test_diagnostic_has_message PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestISOComplianceValidation::test_locality_error_references_iso_section PASSED
tests/Fortran2018/test_issue193_do_concurrent_locality_semantics.py::TestISOComplianceValidation::test_stop_error_references_iso_section PASSED

============================== 25 passed in 5.15s ==============================

$ python -m pytest tests/ -v --tb=short
================= 985 passed, 1 skipped, 72 xfailed in 44.65s ==================
```

## Test plan

- [x] All 25 new locality semantics tests pass
- [x] Full test suite (985 tests) passes with no regressions
- [x] LOCAL variable detection and undefined reference warning works
- [x] LOCAL_INIT variable detection works
- [x] SHARED variable detection and assignment warning works
- [x] DEFAULT(NONE) completeness validation works
- [x] Index variable in locality spec error detected
- [x] Duplicate variable across locality specs error detected
- [x] Nested DO CONCURRENT with locality detected
- [x] STOP statement violation in locality context detected