### PR TITLE
polish: centralize Fortran intrinsics for DO CONCURRENT (fixes #296)

### DIFF
--- a/tools/f2008_do_concurrent_validator.py
+++ b/tools/f2008_do_concurrent_validator.py
@@ -30,6 +30,8 @@ from Fortran2008Lexer import Fortran2008Lexer
 from Fortran2008Parser import Fortran2008Parser
 from Fortran2008ParserListener import Fortran2008ParserListener
 
+from fortran_intrinsics import FORTRAN_KEYWORDS_AND_INTRINSICS
+
 
 class DiagnosticSeverity(Enum):
     ERROR = auto()
@@ -211,17 +213,13 @@ class F2008DoConcurrentListener(Fortran2008ParserListener):
         must be independent - a variable defined in one iteration shall not be
         referenced in another. This method extracts identifiers that could be
         variable references to enable dependency checking.
+
+        Uses the centralized FORTRAN_KEYWORDS_AND_INTRINSICS set from
+        fortran_intrinsics module to filter out intrinsic procedure names,
+        reducing false positives in DO_CONC_I001 diagnostics.
         """
-        keywords = {
-            "real", "integer", "logical", "character", "complex", "double",
-            "precision", "kind", "len", "size", "shape", "lbound", "ubound",
-            "allocated", "associated", "present", "abs", "sqrt", "sin", "cos",
-            "tan", "exp", "log", "max", "min", "mod", "nint", "floor", "ceiling",
-            "sum", "product", "maxval", "minval", "any", "all", "count", "pack",
-            "unpack", "merge", "spread", "reshape", "transpose", "matmul", "dot",
-        }
         identifiers = set(re.findall(r"\b([a-z_]\w*)\b", text))
-        return identifiers - keywords
+        return identifiers - FORTRAN_KEYWORDS_AND_INTRINSICS
 
     def enterScalar_mask_expr(self, ctx):
         """Track variable references in DO CONCURRENT mask expressions.

--- a/tools/f2018_do_concurrent_locality_validator.py
+++ b/tools/f2018_do_concurrent_locality_validator.py
@@ -30,6 +30,8 @@ from Fortran2018Lexer import Fortran2018Lexer
 from Fortran2018Parser import Fortran2018Parser
 from Fortran2018ParserListener import Fortran2018ParserListener
 
+from fortran_intrinsics import FORTRAN_KEYWORDS_AND_INTRINSICS
+
 
 class DiagnosticSeverity(Enum):
     ERROR = auto()
@@ -298,17 +300,14 @@ class F2018DoConcurrentLocalityListener(Fortran2018ParserListener):
             self._current_do_concurrent.referenced_variables.update(rhs_vars)
 
     def _extract_referenced_variables(self, text: str) -> Set[str]:
-        """Extract variable names referenced in an expression."""
-        keywords = {
-            "real", "integer", "logical", "character", "complex", "double",
-            "precision", "kind", "len", "size", "shape", "lbound", "ubound",
-            "allocated", "associated", "present", "abs", "sqrt", "sin", "cos",
-            "tan", "exp", "log", "max", "min", "mod", "nint", "floor", "ceiling",
-            "sum", "product", "maxval", "minval", "any", "all", "count", "pack",
-            "unpack", "merge", "spread", "reshape", "transpose", "matmul", "dot",
-        }
+        """Extract variable names referenced in an expression.
+
+        Uses the centralized FORTRAN_KEYWORDS_AND_INTRINSICS set from
+        fortran_intrinsics module to filter out intrinsic procedure names,
+        reducing false positives in LOC_I001 diagnostics.
+        """
         identifiers = set(re.findall(r"\b([a-z_]\w*)\b", text))
-        return identifiers - keywords
+        return identifiers - FORTRAN_KEYWORDS_AND_INTRINSICS
 
     def enterCall_stmt(self, ctx):
         """Track procedure calls within DO CONCURRENT."""

--- a/tools/fortran_intrinsics.py
+++ b/tools/fortran_intrinsics.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Fortran Intrinsic Procedure Names
+
+Provides centralized sets of Fortran intrinsic procedure names per
+ISO/IEC 1539-1:2010 (Fortran 2008) Section 13 (Intrinsic Procedures).
+
+This module eliminates duplication of intrinsic name lists across validators
+and provides a single source of truth for intrinsic detection in DO CONCURRENT
+and other semantic analysis contexts.
+
+Reference: ISO/IEC 1539-1:2010 (Fortran 2008 International Standard), Chapter 13
+"""
+
+from typing import FrozenSet
+
+FORTRAN_TYPE_KEYWORDS: FrozenSet[str] = frozenset({
+    "real", "integer", "logical", "character", "complex", "double", "precision",
+})
+
+FORTRAN_2008_NUMERIC_INTRINSICS: FrozenSet[str] = frozenset({
+    "abs", "aimag", "aint", "anint", "ceiling", "cmplx", "conjg", "dble",
+    "dim", "dprod", "floor", "int", "max", "min", "mod", "modulo", "nint",
+    "real", "sign",
+})
+
+FORTRAN_2008_MATH_INTRINSICS: FrozenSet[str] = frozenset({
+    "acos", "asin", "atan", "atan2", "cos", "cosh", "exp", "log", "log10",
+    "sin", "sinh", "sqrt", "tan", "tanh",
+    "acosh", "asinh", "atanh", "bessel_j0", "bessel_j1", "bessel_jn",
+    "bessel_y0", "bessel_y1", "bessel_yn", "erf", "erfc", "erfc_scaled",
+    "gamma", "hypot", "log_gamma", "norm2",
+})
+
+FORTRAN_2008_CHARACTER_INTRINSICS: FrozenSet[str] = frozenset({
+    "achar", "adjustl", "adjustr", "char", "iachar", "ichar", "index",
+    "len", "len_trim", "lge", "lgt", "lle", "llt", "repeat", "scan",
+    "trim", "verify", "new_line",
+})
+
+FORTRAN_2008_KIND_INTRINSICS: FrozenSet[str] = frozenset({
+    "kind", "selected_char_kind", "selected_int_kind", "selected_real_kind",
+})
+
+FORTRAN_2008_MISC_TYPE_INQUIRY: FrozenSet[str] = frozenset({
+    "bit_size", "digits", "epsilon", "huge", "maxexponent", "minexponent",
+    "precision", "radix", "range", "tiny", "storage_size",
+})
+
+FORTRAN_2008_ARRAY_INTRINSICS: FrozenSet[str] = frozenset({
+    "all", "any", "count", "cshift", "dot_product", "eoshift", "lbound",
+    "matmul", "maxloc", "maxval", "merge", "minloc", "minval", "pack",
+    "product", "reshape", "shape", "size", "spread", "sum", "transpose",
+    "ubound", "unpack", "findloc", "is_contiguous",
+})
+
+FORTRAN_2008_POINTER_INTRINSICS: FrozenSet[str] = frozenset({
+    "allocated", "associated", "extends_type_of", "same_type_as",
+    "c_associated", "c_funloc", "c_loc", "c_sizeof", "c_f_pointer",
+    "c_f_procpointer", "move_alloc",
+})
+
+FORTRAN_2008_BIT_INTRINSICS: FrozenSet[str] = frozenset({
+    "bge", "bgt", "ble", "blt", "dshiftl", "dshiftr", "iall", "iand",
+    "iany", "ibclr", "ibits", "ibset", "ieor", "ior", "ishft", "ishftc",
+    "leadz", "maskl", "maskr", "merge_bits", "mvbits", "not", "popcnt",
+    "poppar", "shifta", "shiftl", "shiftr", "trailz",
+})
+
+FORTRAN_2008_INQUIRY_INTRINSICS: FrozenSet[str] = frozenset({
+    "command_argument_count", "present", "is_iostat_end", "is_iostat_eor",
+})
+
+FORTRAN_2008_COARRAY_INTRINSICS: FrozenSet[str] = frozenset({
+    "lcobound", "ucobound", "image_index", "num_images", "this_image",
+})
+
+FORTRAN_2008_TRANSFER_INTRINSICS: FrozenSet[str] = frozenset({
+    "transfer",
+})
+
+FORTRAN_2008_SYSTEM_INTRINSICS: FrozenSet[str] = frozenset({
+    "cpu_time", "date_and_time", "execute_command_line", "get_command",
+    "get_command_argument", "get_environment_variable", "random_number",
+    "random_seed", "system_clock",
+})
+
+FORTRAN_2008_NULL_INTRINSIC: FrozenSet[str] = frozenset({
+    "null",
+})
+
+FORTRAN_2008_ALL_INTRINSICS: FrozenSet[str] = (
+    FORTRAN_2008_NUMERIC_INTRINSICS |
+    FORTRAN_2008_MATH_INTRINSICS |
+    FORTRAN_2008_CHARACTER_INTRINSICS |
+    FORTRAN_2008_KIND_INTRINSICS |
+    FORTRAN_2008_MISC_TYPE_INQUIRY |
+    FORTRAN_2008_ARRAY_INTRINSICS |
+    FORTRAN_2008_POINTER_INTRINSICS |
+    FORTRAN_2008_BIT_INTRINSICS |
+    FORTRAN_2008_INQUIRY_INTRINSICS |
+    FORTRAN_2008_COARRAY_INTRINSICS |
+    FORTRAN_2008_TRANSFER_INTRINSICS |
+    FORTRAN_2008_SYSTEM_INTRINSICS |
+    FORTRAN_2008_NULL_INTRINSIC
+)
+
+FORTRAN_KEYWORDS_AND_INTRINSICS: FrozenSet[str] = (
+    FORTRAN_TYPE_KEYWORDS | FORTRAN_2008_ALL_INTRINSICS
+)


### PR DESCRIPTION
## Summary

- Add `tools/fortran_intrinsics.py` with categorized Fortran 2008 intrinsic sets per ISO/IEC 1539-1:2010 Section 13
- Refactor `_extract_referenced_variables` in both DO CONCURRENT validators to use the shared `FORTRAN_KEYWORDS_AND_INTRINSICS` set
- Eliminates code duplication and provides a single source of truth for intrinsic detection

## Test plan

- [x] All existing tests pass (1008 passed, 1 skipped, 72 xfailed)
- [x] `test_issue189_do_concurrent_semantics.py` - 29 tests pass
- [x] `test_issue193_do_concurrent_locality_semantics.py` - 25 tests pass

## Verification

```bash
python -m pytest tests/ -v --tb=short
# 1008 passed, 1 skipped, 72 xfailed in 45.58s
```

The centralized intrinsic list is significantly more complete than the original hard-coded sets, covering numeric, math, character, array, bit manipulation, coarray, and system intrinsics per the Fortran 2008 standard.