### PR TITLE
fix: enable F90 character*n length syntax (fixes #317)

### DIFF
--- a/grammars/src/F90TypesParser.g4
+++ b/grammars/src/F90TypesParser.g4
@@ -118,6 +118,15 @@ intrinsic_type_spec_f90
     | COMPLEX (kind_selector)?      // Section 4.3.1.4
     | LOGICAL (kind_selector)?      // Section 4.3.4
     | CHARACTER (char_selector)?    // Section 4.3.2
+    | CHARACTER char_length_star    // Section 5.1.1.5 (obsolescent)
+    ;
+
+// Character length with asterisk - ISO/IEC 1539:1991 Section 5.1.1.5
+// Obsolescent form: CHARACTER*n, CHARACTER*(*), CHARACTER*(expr)
+char_length_star
+    : MULTIPLY expr_f90                    // CHARACTER*80
+    | MULTIPLY LPAREN MULTIPLY RPAREN      // CHARACTER*(*) assumed length
+    | MULTIPLY LPAREN expr_f90 RPAREN      // CHARACTER*(80)
     ;
 
 // Derived type specification - ISO/IEC 1539:1991 Section 5.1, R502

--- a/tests/fixtures/Fortran90/test_character_star_n_syntax/character_star_forms.f90
+++ b/tests/fixtures/Fortran90/test_character_star_n_syntax/character_star_forms.f90
@@ -1,0 +1,14 @@
+program character_star_forms
+    implicit none
+    character*80 :: line
+    character*20 :: name
+    character*(*) :: assumed_str
+    character*(100) :: expr_form
+    character*1 :: single_char
+    character*(80+20) :: computed_len
+
+    line = "This is a test line"
+    name = "Test"
+    single_char = "X"
+
+end program character_star_forms

--- a/tests/xpass_fixtures.py
+++ b/tests/xpass_fixtures.py
@@ -36,7 +36,7 @@ XPASS_FIXTURES: Dict[Tuple[str, Path], str] = {
         Path("Fortran90/test_comprehensive_parsing/free_form_features_program.f90"),
     ): (
         "Fortran 90 fixture {relpath} reports {errors} syntax errors due to "
-        "character*n length syntax gaps. Tracked by Issue #311."
+        "bracket array constructor syntax (F2003 feature). Tracked by Issue #311."
     ),
     (
         "Fortran90",


### PR DESCRIPTION
## Summary

- Adds support for the obsolescent `CHARACTER*n` length syntax in Fortran 90 grammar per ISO/IEC 1539:1991 Section 5.1.1.5
- Fixes xpass_fixtures.py reason for `free_form_features_program.f90` to accurately describe actual issue

## Changes

### Grammar (F90TypesParser.g4)
Added `char_length_star` rule supporting:
- `CHARACTER*80 :: line` - numeric length
- `CHARACTER*(*) :: str` - assumed length  
- `CHARACTER*(expr) :: computed` - parenthesized expression

### Test Fixtures
New fixture `test_character_star_n_syntax/character_star_forms.f90` exercises all three forms.

### Documentation Fix
Corrected xpass reason for `free_form_features_program.f90` - actual issue is bracket array constructor `[1,2,3]` (F2003 feature), not character*n.

## Verification

```
$ make test
================= 1052 passed, 1 skipped, 3 xfailed in 55.37s ==================
```

```python
# Direct parse test
import sys
sys.path.insert(0, 'grammars/generated/modern')
from antlr4 import InputStream, CommonTokenStream
from Fortran90Lexer import Fortran90Lexer
from Fortran90Parser import Fortran90Parser

code = '''program char_test
    implicit none
    character*80 :: line
    character*(*) :: str
    character*(100) :: expr_form
end program char_test
'''
# Parse errors: 0
# Success: True
```

## ISO Reference

ISO/IEC 1539:1991 Section 5.1.1.5 - Character type (obsolescent forms)