### PR TITLE
fix: F90 ENTRY statement R1219 (fixes #316)

### DIFF
--- a/grammars/src/F90ProcsParser.g4
+++ b/grammars/src/F90ProcsParser.g4
@@ -115,3 +115,38 @@ internal_subprogram_f90
     : function_subprogram_f90
     | subroutine_subprogram_f90
     ;
+
+// ====================================================================
+// ENTRY STATEMENT - ISO/IEC 1539:1991 Section 12.5.2.4
+// ====================================================================
+//
+// R1219 entry-stmt is ENTRY entry-name [ ( [ dummy-arg-list ] ) [ suffix ] ]
+//
+// The ENTRY statement specifies an alternate entry point into a function
+// or subroutine subprogram. In F90, the RESULT clause (suffix) is permitted
+// for function ENTRY statements.
+//
+// Constraints:
+// - ENTRY may only appear in a function or subroutine subprogram
+// - ENTRY must not appear in an internal subprogram
+// - ENTRY must not appear between a nonblock DO and its terminal statement
+// - The entry-name becomes accessible to the host scoping unit
+
+// F90 ENTRY statement with optional RESULT clause
+// ISO/IEC 1539:1991 Section 12.5.2.4, R1219
+entry_stmt_f90
+    : ENTRY IDENTIFIER entry_dummy_arg_list_f90? suffix?
+    ;
+
+// Dummy argument list for ENTRY - ISO/IEC 1539:1991 Section 12.5.2.4
+// R1220 dummy-arg is dummy-arg-name | *
+entry_dummy_arg_list_f90
+    : LPAREN entry_dummy_arg_f90? (COMMA entry_dummy_arg_f90)* RPAREN
+    ;
+
+// Dummy argument for ENTRY - ISO/IEC 1539:1991 Section 12.5.2.4
+// Includes alternate return specifier (*) per Section 12.4.3
+entry_dummy_arg_f90
+    : identifier_or_keyword
+    | MULTIPLY                  // Alternate return specifier (*)
+    ;

--- a/grammars/src/Fortran90Parser.g4
+++ b/grammars/src/Fortran90Parser.g4
@@ -196,6 +196,7 @@ executable_stmt
     | nullify_stmt                   // Section 6.3.2 - F90 pointer nullification
     | where_stmt                     // Section 7.5.3 - F90 array conditional
     | pointer_assignment_stmt        // Section 7.5.2 - F90 pointer assignment
+    | entry_stmt_f90                 // Section 12.5.2.4 - F90 ENTRY statement
     | assignment_stmt_f90            // Section 7.5.1 - Last resort for ENDIF
     ;
 

--- a/tests/fixtures/Fortran90/test_entry_statement/entry_stmt_f90.f90
+++ b/tests/fixtures/Fortran90/test_entry_statement/entry_stmt_f90.f90
@@ -1,0 +1,76 @@
+! ENTRY statement test fixture - ISO/IEC 1539:1991 Section 12.5.2.4
+! Tests R1219: entry-stmt is ENTRY entry-name [ ( [ dummy-arg-list ] ) [ suffix ] ]
+program test_entry_program
+    implicit none
+    real :: result_val
+
+    call compute_ops(2.0, 3.0, result_val)
+    call compute_product(2.0, 3.0, result_val)
+    call reset_value(result_val)
+
+end program test_entry_program
+
+! Subroutine with multiple ENTRY points
+subroutine compute_ops(a, b, result)
+    implicit none
+    real, intent(in) :: a, b
+    real, intent(out) :: result
+
+    result = a + b
+    return
+
+    ! ENTRY with different parameter names
+entry compute_product(x, y, result)
+    result = x * y
+    return
+
+    ! ENTRY with no argument list
+entry reset_value(result)
+    result = 0.0
+    return
+
+end subroutine compute_ops
+
+! Function with ENTRY and RESULT clause (F90 enhancement)
+function power_base(x, n) result(res)
+    implicit none
+    real, intent(in) :: x
+    integer, intent(in) :: n
+    real :: res
+    integer :: i
+
+    res = 1.0
+    do i = 1, n
+        res = res * x
+    end do
+    return
+
+    ! ENTRY with RESULT clause - F90 specific
+entry square_value(x) result(res)
+    res = x * x
+    return
+
+    ! ENTRY with empty argument list and RESULT
+entry get_unity() result(res)
+    res = 1.0
+    return
+
+end function power_base
+
+! Subroutine with alternate return specifier in ENTRY
+subroutine safe_divide(a, b, quotient, *)
+    implicit none
+    real, intent(in) :: a, b
+    real, intent(out) :: quotient
+
+    if (b == 0.0) return 1
+    quotient = a / b
+    return
+
+    ! ENTRY with alternate return specifier (*)
+entry checked_reciprocal(val, reciprocal, *)
+    if (val == 0.0) return 1
+    reciprocal = 1.0 / val
+    return
+
+end subroutine safe_divide


### PR DESCRIPTION
## Summary

- Implement F90 ENTRY statement per ISO/IEC 1539:1991 Section 12.5.2.4
- Add `entry_stmt_f90` parser rule with optional RESULT clause support
- Add `entry_dummy_arg_list_f90` supporting alternate return specifier (`*`)
- Wire into `executable_stmt` in Fortran90Parser

## ISO Reference

ISO/IEC 1539:1991 Section 12.5.2.4 - ENTRY statement

```
R1219 entry-stmt is ENTRY entry-name [ ( [ dummy-arg-list ] ) [ suffix ] ]
R1220 dummy-arg is dummy-arg-name | *
```

## Verification

```
$ make test
================= 1057 passed, 1 skipped, 3 xfailed in 55.96s ==================

$ make lint
✅ Lint completed successfully
```

Entry fixture test result:
```
tests/test_fixture_parsing.py::test_fixture_parses_without_errors[Fortran90-relpath215] PASSED
```

## Test Fixture

Added `tests/fixtures/Fortran90/test_entry_statement/entry_stmt_f90.f90` exercising:
- ENTRY in subroutines with different argument lists
- ENTRY with RESULT clause (F90 enhancement)
- ENTRY with alternate return specifier (`*`)
- ENTRY with empty argument list