### PR TITLE
fix: implement F90 file I/O statements (fixes #315)

### DIFF
--- a/grammars/src/F90IOParser.g4
+++ b/grammars/src/F90IOParser.g4
@@ -60,9 +60,9 @@ io_control_spec
     : UNIT EQUALS io_unit_f90       // Unit specification (R910)
     | FMT EQUALS format_spec        // Format specification (R910)
     | IOSTAT EQUALS variable_f90    // I/O status
-    | ERR EQUALS label              // Error handling
-    | END EQUALS label              // End-of-file handling
-    | EOR EQUALS label              // End-of-record handling (F90)
+    | ERR EQUALS label_f90          // Error handling
+    | END EQUALS label_f90          // End-of-file handling
+    | EOR EQUALS label_f90          // End-of-record handling (F90)
     | ADVANCE EQUALS expr_f90       // Non-advancing I/O (F90)
     | SIZE EQUALS variable_f90      // Characters transferred (F90)
     | REC EQUALS expr_f90           // Record number (direct access)
@@ -132,6 +132,145 @@ do_variable
     : IDENTIFIER
     ;
 
-label
-    : INTEGER_LITERAL
+label_f90
+    : LABEL
+    | INTEGER_LITERAL
+    ;
+
+// ====================================================================
+// FILE CONNECTION/POSITIONING STATEMENTS - ISO/IEC 1539:1991 Section 9.7
+// ====================================================================
+//
+// These F90 statements override the F77 versions to use F90 lexer tokens.
+// ISO/IEC 1539:1991 Section 9.7.1: OPEN statement (R904)
+// ISO/IEC 1539:1991 Section 9.7.2: CLOSE statement (R908)
+// ISO/IEC 1539:1991 Section 9.7.3: INQUIRE statement (R929)
+// ISO/IEC 1539:1991 Section 9.6.1: BACKSPACE statement (R923)
+// ISO/IEC 1539:1991 Section 9.6.2: ENDFILE statement (R924)
+// ISO/IEC 1539:1991 Section 9.6.3: REWIND statement (R925)
+
+// OPEN statement - ISO/IEC 1539:1991 Section 9.7.1, R904
+open_stmt_f90
+    : OPEN LPAREN connect_spec_list_f90 RPAREN
+    ;
+
+// CLOSE statement - ISO/IEC 1539:1991 Section 9.7.2, R908
+close_stmt_f90
+    : CLOSE LPAREN close_spec_list_f90 RPAREN
+    ;
+
+// INQUIRE statement - ISO/IEC 1539:1991 Section 9.7.3, R929
+inquire_stmt_f90
+    : INQUIRE LPAREN inquire_spec_list_f90 RPAREN
+    ;
+
+// BACKSPACE statement - ISO/IEC 1539:1991 Section 9.6.1, R923
+backspace_stmt_f90
+    : BACKSPACE expr_f90
+    | BACKSPACE LPAREN position_spec_list_f90 RPAREN
+    ;
+
+// ENDFILE statement - ISO/IEC 1539:1991 Section 9.6.2, R924
+endfile_stmt_f90
+    : ENDFILE expr_f90
+    | ENDFILE LPAREN position_spec_list_f90 RPAREN
+    ;
+
+// REWIND statement - ISO/IEC 1539:1991 Section 9.6.3, R925
+rewind_stmt_f90
+    : REWIND expr_f90
+    | REWIND LPAREN position_spec_list_f90 RPAREN
+    ;
+
+// ====================================================================
+// F90 I/O SPECIFIER LISTS
+// ====================================================================
+
+// Connect specifier list - ISO/IEC 1539:1991 Section 9.7.1
+connect_spec_list_f90
+    : connect_spec_f90 (COMMA connect_spec_f90)*
+    ;
+
+// Connect specifier - ISO/IEC 1539:1991 Section 9.7.1, R905
+connect_spec_f90
+    : UNIT EQUALS expr_f90              // UNIT=u
+    | FILE EQUALS expr_f90              // FILE=fn
+    | STATUS EQUALS expr_f90            // STATUS=sta
+    | ACCESS EQUALS expr_f90            // ACCESS=acc
+    | FORM EQUALS expr_f90              // FORM=fm
+    | RECL EQUALS expr_f90              // RECL=rl
+    | BLANK EQUALS expr_f90             // BLANK=blnk
+    | IOSTAT EQUALS variable_f90        // IOSTAT=ios
+    | ERR EQUALS label_f90              // ERR=s
+    | POSITION EQUALS expr_f90          // POSITION=pos (F90)
+    | ACTION EQUALS expr_f90            // ACTION=act (F90)
+    | DELIM EQUALS expr_f90             // DELIM=del (F90)
+    | PAD EQUALS expr_f90               // PAD=pad (F90)
+    | expr_f90                          // Positional unit number
+    ;
+
+// Close specifier list - ISO/IEC 1539:1991 Section 9.7.2
+close_spec_list_f90
+    : close_spec_f90 (COMMA close_spec_f90)*
+    ;
+
+// Close specifier - ISO/IEC 1539:1991 Section 9.7.2, R909
+close_spec_f90
+    : UNIT EQUALS expr_f90              // UNIT=u
+    | STATUS EQUALS expr_f90            // STATUS=sta
+    | IOSTAT EQUALS variable_f90        // IOSTAT=ios
+    | ERR EQUALS label_f90              // ERR=s
+    | expr_f90                          // Positional unit number
+    ;
+
+// Inquire specifier list - ISO/IEC 1539:1991 Section 9.7.3
+inquire_spec_list_f90
+    : inquire_spec_f90 (COMMA inquire_spec_f90)*
+    ;
+
+// Inquire specifier - ISO/IEC 1539:1991 Section 9.7.3, R930
+// NOTE: Some specifiers (NAME, NAMED, NUMBER, FORMATTED, UNFORMATTED) use
+// io_specifier_name which matches IDENTIFIER to avoid conflicts with other uses.
+inquire_spec_f90
+    : UNIT EQUALS expr_f90              // UNIT=u
+    | FILE EQUALS expr_f90              // FILE=fn
+    | IOSTAT EQUALS variable_f90        // IOSTAT=ios
+    | ERR EQUALS label_f90              // ERR=s
+    | EXIST EQUALS variable_f90         // EXIST=ex
+    | OPENED EQUALS variable_f90        // OPENED=od
+    | ACCESS EQUALS variable_f90        // ACCESS=acc
+    | SEQUENTIAL EQUALS variable_f90    // SEQUENTIAL=seq
+    | DIRECT EQUALS variable_f90        // DIRECT=dir
+    | FORM EQUALS variable_f90          // FORM=fm
+    | RECL EQUALS variable_f90          // RECL=rl
+    | NEXTREC EQUALS variable_f90       // NEXTREC=nr
+    | BLANK EQUALS variable_f90         // BLANK=blnk
+    | POSITION EQUALS variable_f90      // POSITION=pos (F90)
+    | ACTION EQUALS variable_f90        // ACTION=act (F90)
+    | READ EQUALS variable_f90          // READ=rd (F90)
+    | WRITE EQUALS variable_f90         // WRITE=wr (F90)
+    | READWRITE EQUALS variable_f90     // READWRITE=rw (F90)
+    | DELIM EQUALS variable_f90         // DELIM=del (F90)
+    | PAD EQUALS variable_f90           // PAD=pad (F90)
+    | io_specifier_name EQUALS variable_f90  // NAME, NAMED, etc.
+    | expr_f90                          // Positional unit number
+    ;
+
+// I/O specifier names that match via IDENTIFIER to avoid conflicts
+// These include: NAME, NAMED, NUMBER, FORMATTED, UNFORMATTED
+io_specifier_name
+    : IDENTIFIER
+    ;
+
+// File positioning specifier list - ISO/IEC 1539:1991 Section 9.6
+position_spec_list_f90
+    : position_spec_f90 (COMMA position_spec_f90)*
+    ;
+
+// File positioning specifier - ISO/IEC 1539:1991 Section 9.6
+position_spec_f90
+    : UNIT EQUALS expr_f90              // UNIT=u
+    | IOSTAT EQUALS variable_f90        // IOSTAT=ios
+    | ERR EQUALS label_f90              // ERR=s
+    | expr_f90                          // Positional unit number
     ;

--- a/grammars/src/Fortran90Lexer.g4
+++ b/grammars/src/Fortran90Lexer.g4
@@ -377,6 +377,57 @@ ERR             : ('e'|'E') ('r'|'R') ('r'|'R') ;
 WHILE           : ('w'|'W') ('h'|'H') ('i'|'I') ('l'|'L') ('e'|'E') ;
 
 // ====================================================================
+// FILE I/O SPECIFIER KEYWORDS - ISO/IEC 1539:1991 Section 9.7 (OPEN/CLOSE/INQUIRE)
+// ====================================================================
+//
+// ISO/IEC 1539:1991 Section 9.7 defines file connection statement specifiers.
+// These tokens enable proper parsing of OPEN, CLOSE, and INQUIRE statements.
+// NOTE: These are context-sensitive keywords; they can still be used as identifiers
+// outside of I/O statements. The parser handles this via alternative matching.
+
+// FILE= specifier - ISO/IEC 1539:1991 Section 9.7.1.5
+FILE            : F I L E ;
+// STATUS= specifier - ISO/IEC 1539:1991 Section 9.7.1.6
+STATUS          : S T A T U S ;
+// ACCESS= specifier - ISO/IEC 1539:1991 Section 9.7.1.8
+ACCESS          : A C C E S S ;
+// FORM= specifier - ISO/IEC 1539:1991 Section 9.7.1.9
+FORM            : F O R M ;
+// RECL= specifier - ISO/IEC 1539:1991 Section 9.7.1.10
+RECL            : R E C L ;
+// BLANK= specifier - ISO/IEC 1539:1991 Section 9.7.1.11
+BLANK           : B L A N K ;
+// POSITION= specifier - ISO/IEC 1539:1991 Section 9.7.1.12 (F90)
+POSITION        : P O S I T I O N ;
+// ACTION= specifier - ISO/IEC 1539:1991 Section 9.7.1.13 (F90)
+ACTION          : A C T I O N ;
+// DELIM= specifier - ISO/IEC 1539:1991 Section 9.7.1.14 (F90)
+DELIM           : D E L I M ;
+// PAD= specifier - ISO/IEC 1539:1991 Section 9.7.1.15 (F90)
+PAD             : P A D ;
+// EXIST= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.4
+EXIST           : E X I S T ;
+// OPENED= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.5
+OPENED          : O P E N E D ;
+// SEQUENTIAL= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.9
+SEQUENTIAL      : S E Q U E N T I A L ;
+// DIRECT= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.10
+DIRECT          : D I R E C T ;
+// NEXTREC= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.13
+NEXTREC         : N E X T R E C ;
+// READWRITE= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.17 (F90)
+READWRITE       : R E A D W R I T E ;
+
+// NOTE: The following are intentionally NOT defined as separate tokens because
+// they conflict with existing tokens or have common use as identifiers:
+// - NAME (conflicts with derived type component names)
+// - NAMED (would prevent use as identifier)
+// - NUMBER (would prevent use as identifier)
+// - FORMATTED (conflicts with write(formatted) generic binding)
+// - UNFORMATTED (conflicts with write(unformatted) generic binding)
+// These are matched via IDENTIFIER in the parser rules.
+
+// ====================================================================
 // FORTRAN 90 OPERATORS - ISO/IEC 1539:1991 Section 3.2 and 7.2
 // ====================================================================
 //

--- a/grammars/src/Fortran90Parser.g4
+++ b/grammars/src/Fortran90Parser.g4
@@ -191,6 +191,12 @@ executable_stmt
     | read_stmt_f90                  // Section 9.4 - Enhanced I/O
     | write_stmt_f90                 // Section 9.4 - Enhanced I/O
     | print_stmt_f90                 // Section 9.4 - F77-inherited print
+    | open_stmt_f90                  // Section 9.7.1 - File connection (R904)
+    | close_stmt_f90                 // Section 9.7.2 - File disconnection (R908)
+    | inquire_stmt_f90               // Section 9.7.3 - File inquiry (R929)
+    | backspace_stmt_f90             // Section 9.6.1 - File positioning (R923)
+    | endfile_stmt_f90               // Section 9.6.2 - File positioning (R924)
+    | rewind_stmt_f90                // Section 9.6.3 - File positioning (R925)
     | allocate_stmt                  // Section 6.3.1 - F90 memory management
     | deallocate_stmt                // Section 6.3.3 - F90 memory management
     | nullify_stmt                   // Section 6.3.2 - F90 pointer nullification

--- a/tests/fixtures/Fortran90/test_file_io_statements/advanced_io_specs.f90
+++ b/tests/fixtures/Fortran90/test_file_io_statements/advanced_io_specs.f90
@@ -1,0 +1,21 @@
+program test_advanced_io
+    implicit none
+    integer :: unit_num, ios, reclen, nextrec_val
+    logical :: exists, opened_flag
+    character(len=100) :: fname, access_type, form_type, seq_type, direct_type
+
+    unit_num = 30
+
+    open(unit=unit_num, file='direct.dat', access='direct', recl=100, iostat=ios)
+
+    if (ios == 0) then
+        inquire(unit=unit_num, exist=exists, opened=opened_flag)
+        inquire(unit=unit_num, access=access_type, form=form_type, recl=reclen)
+        inquire(file='direct.dat', sequential=seq_type, direct=direct_type)
+        close(unit=unit_num, status='delete', iostat=ios)
+    end if
+
+    open(unit=40, file='formatted.txt', status='replace', form='formatted')
+    close(40)
+
+end program

--- a/tests/fixtures/Fortran90/test_file_io_statements/file_positioning.f90
+++ b/tests/fixtures/Fortran90/test_file_io_statements/file_positioning.f90
@@ -1,0 +1,29 @@
+program test_file_positioning
+    implicit none
+    integer :: unit_num, ios, i
+    real :: x, values(5)
+
+    unit_num = 20
+    open(unit=unit_num, file='sequential.dat', status='replace', iostat=ios)
+
+    do i = 1, 5
+        x = i * 1.5
+        write(unit_num, *) x
+    end do
+
+    rewind(unit_num)
+
+    read(unit_num, *) values(1)
+
+    backspace(unit_num)
+    read(unit_num, *) values(1)
+
+    endfile(unit_num)
+
+    rewind(unit=unit_num, iostat=ios)
+    backspace(unit=unit_num, iostat=ios)
+    endfile(unit=unit_num, iostat=ios)
+
+    close(unit_num)
+
+end program

--- a/tests/fixtures/Fortran90/test_file_io_statements/open_close_inquire.f90
+++ b/tests/fixtures/Fortran90/test_file_io_statements/open_close_inquire.f90
@@ -1,0 +1,29 @@
+program test_file_io
+    implicit none
+    integer :: unit_num, ios
+    logical :: file_exists, is_opened
+    character(len=100) :: filename
+
+    unit_num = 10
+    filename = 'test_data.txt'
+
+    inquire(file=filename, exist=file_exists)
+
+    if (file_exists) then
+        open(unit=unit_num, file=filename, status='old', iostat=ios)
+        if (ios == 0) then
+            write(unit_num, *) 'Hello from Fortran 90'
+            close(unit=unit_num)
+        end if
+    else
+        open(unit=unit_num, file=filename, status='new', iostat=ios)
+        if (ios == 0) then
+            write(unit_num, *) 'New file created'
+            close(unit=unit_num, status='keep')
+        end if
+    end if
+
+    inquire(unit=unit_num, opened=is_opened)
+    inquire(file=filename, number=unit_num)
+
+end program

--- a/tests/test_comprehensive_parsing.py
+++ b/tests/test_comprehensive_parsing.py
@@ -156,12 +156,43 @@ class TestUnifiedGrammarArchitecture:
             "test_comprehensive_parsing",
             "mixed_format_program.f90",
         )
-        
+
         tree, errors, exception = self.parse_fortran_code(mixed_code.strip(), "Fortran90")
         # Allow parsing errors in mixed format integration tests
         if errors > 0:
             print(f"Warning: Mixed format test had {errors} parsing errors")
         assert tree is not None or errors > 0, "Mixed format test should parse or fail gracefully"
+
+    def test_file_io_statements(self):
+        """Test F90 file I/O statements (OPEN, CLOSE, INQUIRE, REWIND, BACKSPACE, ENDFILE).
+
+        ISO/IEC 1539:1991 Section 9 defines file I/O:
+        - R904 open-stmt: OPEN statement for file connection
+        - R908 close-stmt: CLOSE statement for file disconnection
+        - R923 backspace-stmt: BACKSPACE for file positioning
+        - R924 endfile-stmt: ENDFILE for file positioning
+        - R925 rewind-stmt: REWIND for file positioning
+        - R929 inquire-stmt: INQUIRE for file inquiry
+
+        Fixes #315: F90 file I/O statements integration.
+        """
+        test_files = [
+            "open_close_inquire.f90",
+            "file_positioning.f90",
+            "advanced_io_specs.f90",
+        ]
+
+        for filename in test_files:
+            code = load_fixture(
+                "Fortran90",
+                "test_file_io_statements",
+                filename,
+            )
+
+            tree, errors, exception = self.parse_fortran_code(code.strip(), "Fortran90")
+            assert tree is not None, f"{filename} failed to parse: {exception}"
+            assert errors == 0, f"{filename} had {errors} parsing errors"
+
 
 if __name__ == "__main__":
     # Run tests if called directly


### PR DESCRIPTION
## Summary
- Wire OPEN, CLOSE, INQUIRE, BACKSPACE, ENDFILE, REWIND statements into Fortran90Parser `executable_stmt` rule
- Add F90-specific parser rules (`open_stmt_f90`, `close_stmt_f90`, etc.) with proper token handling
- Add lexer tokens for I/O specifiers: FILE, STATUS, ACCESS, FORM, RECL, BLANK, POSITION, ACTION, DELIM, PAD, EXIST, OPENED, SEQUENTIAL, DIRECT, NEXTREC, READWRITE
- Add test fixtures for file I/O statements

## ISO Standard References
- ISO/IEC 1539:1991 Section 9.7.1: OPEN statement (R904)
- ISO/IEC 1539:1991 Section 9.7.2: CLOSE statement (R908)
- ISO/IEC 1539:1991 Section 9.7.3: INQUIRE statement (R929)
- ISO/IEC 1539:1991 Section 9.6.1: BACKSPACE statement (R923)
- ISO/IEC 1539:1991 Section 9.6.2: ENDFILE statement (R924)
- ISO/IEC 1539:1991 Section 9.6.3: REWIND statement (R925)

## Verification
```
$ make test 2>&1 | tail -5
tests/LazyFortran2025/test_lfmt_lflint.py::test_lflint_cli_reports_and_sets_exit_code PASSED [100%]

================= 1061 passed, 1 skipped, 3 xfailed in 56.77s ==================

✅ All tests completed!
```

## Test plan
- [x] All existing tests pass
- [x] New test fixtures for OPEN, CLOSE, INQUIRE statements
- [x] New test fixtures for BACKSPACE, ENDFILE, REWIND statements
- [x] Verify F90-specific tokens are properly recognized