### PR TITLE
fix: implement F2008 bitwise shift/mask intrinsics (fixes #325)

### DIFF
--- a/grammars/src/Fortran2008Lexer.g4
+++ b/grammars/src/Fortran2008Lexer.g4
@@ -170,6 +170,20 @@ FINDLOC          : F I N D L O C ;
 // - STORAGE_SIZE(A[,KIND]): Storage size in bits (Section 13.7.163)
 STORAGE_SIZE     : S T O R A G E '_' S I Z E ;
 
+// Bit shift intrinsics (Section 13.7.158-13.7.160)
+// - SHIFTA(I,SHIFT): Arithmetic right shift (Section 13.7.158)
+// - SHIFTL(I,SHIFT): Logical left shift (Section 13.7.159)
+// - SHIFTR(I,SHIFT): Logical right shift (Section 13.7.160)
+SHIFTA           : S H I F T A ;
+SHIFTL           : S H I F T L ;
+SHIFTR           : S H I F T R ;
+
+// Bit mask intrinsics (Section 13.7.110-13.7.111)
+// - MASKL(I[,KIND]): Left-justified bit mask (Section 13.7.110)
+// - MASKR(I[,KIND]): Right-justified bit mask (Section 13.7.111)
+MASKL            : M A S K L ;
+MASKR            : M A S K R ;
+
 // ============================================================================
 // ENHANCED INTEGER/REAL KINDS (ISO/IEC 1539-1:2010 Section 13.8.2)
 // ============================================================================

--- a/grammars/src/Fortran2008Parser.g4
+++ b/grammars/src/Fortran2008Parser.g4
@@ -752,6 +752,8 @@ intrinsic_function_call_f2008
     | math_function_call              // Error/gamma functions (Section 13.7)
     | array_function_call             // Array functions (Section 13.7)
     | image_function_call             // Image intrinsics (Section 13.7)
+    | bit_shift_function_call         // Bit shift intrinsics (Section 13.7.158-160)
+    | bit_mask_function_call          // Bit mask intrinsics (Section 13.7.110-111)
     ;
 
 // Bessel function calls (ISO/IEC 1539-1:2010 Section 13.7.22-27)
@@ -788,6 +790,21 @@ image_function_call
     : THIS_IMAGE LPAREN actual_arg_list? RPAREN  // Section 13.7.165
     | NUM_IMAGES LPAREN actual_arg_list? RPAREN  // Section 13.7.121
     | STORAGE_SIZE LPAREN actual_arg_list RPAREN // Section 13.7.163
+    ;
+
+// Bit shift intrinsic function calls (ISO/IEC 1539-1:2010 Section 13.7.158-160)
+// Logical and arithmetic bit shift operations
+bit_shift_function_call
+    : SHIFTA LPAREN actual_arg_list RPAREN       // Section 13.7.158
+    | SHIFTL LPAREN actual_arg_list RPAREN       // Section 13.7.159
+    | SHIFTR LPAREN actual_arg_list RPAREN       // Section 13.7.160
+    ;
+
+// Bit mask intrinsic function calls (ISO/IEC 1539-1:2010 Section 13.7.110-111)
+// Bit mask generation functions
+bit_mask_function_call
+    : MASKL LPAREN actual_arg_list RPAREN        // Section 13.7.110
+    | MASKR LPAREN actual_arg_list RPAREN        // Section 13.7.111
     ;
 
 // ============================================================================
@@ -898,4 +915,10 @@ identifier_or_keyword
     | ERROR_STOP   // ERROR_STOP is compound keyword, not typically used as name
     | LOCK         // LOCK can be used as variable name
     | UNLOCK       // UNLOCK can be used as variable name
+    // F2008 bit manipulation intrinsics (Section 13.7.110-111, 13.7.158-160)
+    | SHIFTA       // SHIFTA can be used as variable name
+    | SHIFTL       // SHIFTL can be used as variable name
+    | SHIFTR       // SHIFTR can be used as variable name
+    | MASKL        // MASKL can be used as variable name
+    | MASKR        // MASKR can be used as variable name
     ;

--- a/tests/fixtures/Fortran2008/test_basic_f2008_features/bit_shift_intrinsics.f90
+++ b/tests/fixtures/Fortran2008/test_basic_f2008_features/bit_shift_intrinsics.f90
@@ -1,0 +1,14 @@
+module test_bit_shift
+    implicit none
+contains
+    subroutine test_shift_functions()
+        integer :: i, j, result_val
+        i = 16
+        j = 2
+        result_val = shiftl(1, 4)
+        result_val = shiftr(i, j)
+        result_val = shifta(i, j)
+        result_val = maskl(8)
+        result_val = maskr(8)
+    end subroutine test_shift_functions
+end module test_bit_shift


### PR DESCRIPTION
## Summary

Implement F2008 bitwise shift and mask intrinsic functions per ISO/IEC 1539-1:2010:

- SHIFTL(I, SHIFT): Logical left shift (Section 13.7.159)
- SHIFTR(I, SHIFT): Logical right shift (Section 13.7.160)
- SHIFTA(I, SHIFT): Arithmetic right shift (Section 13.7.158)
- MASKL(I[, KIND]): Left-justified bit mask (Section 13.7.110)
- MASKR(I[, KIND]): Right-justified bit mask (Section 13.7.111)

## Changes

- Add lexer tokens in Fortran2008Lexer.g4
- Add parser rules `bit_shift_function_call` and `bit_mask_function_call`
- Wire into `intrinsic_function_call_f2008` rule
- Add tokens to `identifier_or_keyword` for flexibility
- Add test fixture `bit_shift_intrinsics.f90`

## Verification

```
$ make test 2>&1 | tail -5
tests/LazyFortran2025/test_lfmt_lflint.py::test_lfmt_cli_formats_file_in_place PASSED [ 99%]
tests/LazyFortran2025/test_lfmt_lflint.py::test_lflint_cli_reports_and_sets_exit_code PASSED [100%]

================= 1062 passed, 1 skipped, 3 xfailed in 57.77s ==================
```

Direct parsing test:
```python
>>> result_val = shiftl(1, 4)
>>> result_val = shiftr(i, j)
>>> result_val = shifta(i, j)
>>> result_val = maskl(8)
>>> result_val = maskr(8)
# All parse with 0 syntax errors
```

## Test plan

- [x] All existing tests pass (1062 passed)
- [x] New fixture parses without errors
- [x] No regressions in F2008 or downstream grammars
