### PR TITLE
fix: implement F2008 bitwise reduction intrinsics (fixes #326)

### DIFF
--- a/grammars/src/Fortran2008Lexer.g4
+++ b/grammars/src/Fortran2008Lexer.g4
@@ -184,6 +184,14 @@ SHIFTR           : S H I F T R ;
 MASKL            : M A S K L ;
 MASKR            : M A S K R ;
 
+// Bitwise reduction intrinsics (Section 13.7.79-80, 13.7.94)
+// - IALL(ARRAY[,DIM][,MASK]): Bitwise AND reduction (Section 13.7.79)
+// - IANY(ARRAY[,DIM][,MASK]): Bitwise OR reduction (Section 13.7.80)
+// - IPARITY(ARRAY[,DIM][,MASK]): Bitwise XOR reduction (Section 13.7.94)
+IALL             : I A L L ;
+IANY             : I A N Y ;
+IPARITY          : I P A R I T Y ;
+
 // ============================================================================
 // ENHANCED INTEGER/REAL KINDS (ISO/IEC 1539-1:2010 Section 13.8.2)
 // ============================================================================

--- a/grammars/src/Fortran2008Parser.g4
+++ b/grammars/src/Fortran2008Parser.g4
@@ -754,6 +754,7 @@ intrinsic_function_call_f2008
     | image_function_call             // Image intrinsics (Section 13.7)
     | bit_shift_function_call         // Bit shift intrinsics (Section 13.7.158-160)
     | bit_mask_function_call          // Bit mask intrinsics (Section 13.7.110-111)
+    | bit_reduction_function_call     // Bit reduction (Section 13.7.79-80, 94)
     ;
 
 // Bessel function calls (ISO/IEC 1539-1:2010 Section 13.7.22-27)
@@ -805,6 +806,17 @@ bit_shift_function_call
 bit_mask_function_call
     : MASKL LPAREN actual_arg_list RPAREN        // Section 13.7.110
     | MASKR LPAREN actual_arg_list RPAREN        // Section 13.7.111
+    ;
+
+// Bitwise reduction function calls (ISO/IEC 1539-1:2010 Section 13.7.79-80, 94)
+// Bitwise reduction operations across array elements
+// - IALL(ARRAY[,DIM][,MASK]): Bitwise AND reduction (Section 13.7.79)
+// - IANY(ARRAY[,DIM][,MASK]): Bitwise OR reduction (Section 13.7.80)
+// - IPARITY(ARRAY[,DIM][,MASK]): Bitwise XOR reduction (Section 13.7.94)
+bit_reduction_function_call
+    : IALL LPAREN actual_arg_list RPAREN         // Section 13.7.79
+    | IANY LPAREN actual_arg_list RPAREN         // Section 13.7.80
+    | IPARITY LPAREN actual_arg_list RPAREN      // Section 13.7.94
     ;
 
 // ============================================================================
@@ -921,4 +933,8 @@ identifier_or_keyword
     | SHIFTR       // SHIFTR can be used as variable name
     | MASKL        // MASKL can be used as variable name
     | MASKR        // MASKR can be used as variable name
+    // F2008 bitwise reduction intrinsics (Section 13.7.79-80, 13.7.94)
+    | IALL         // IALL can be used as variable name
+    | IANY         // IANY can be used as variable name
+    | IPARITY      // IPARITY can be used as variable name
     ;

--- a/tests/fixtures/Fortran2008/test_basic_f2008_features/bit_reduction_intrinsics.f90
+++ b/tests/fixtures/Fortran2008/test_basic_f2008_features/bit_reduction_intrinsics.f90
@@ -1,0 +1,19 @@
+module test_bit_reduction
+    implicit none
+contains
+    subroutine test_bitwise_reduction_functions()
+        integer :: arr(4), result_val
+        logical :: mask_arr(4)
+        arr = [15, 7, 3, 1]
+        mask_arr = [.true., .true., .false., .true.]
+        result_val = iall(arr)
+        result_val = iany(arr)
+        result_val = iparity(arr)
+        result_val = iall(arr, dim=1)
+        result_val = iany(arr, dim=1)
+        result_val = iparity(arr, dim=1)
+        result_val = iall(arr, mask=mask_arr)
+        result_val = iany(arr, mask=mask_arr)
+        result_val = iparity(arr, mask=mask_arr)
+    end subroutine test_bitwise_reduction_functions
+end module test_bit_reduction


### PR DESCRIPTION
## Summary

Implement F2008 bitwise reduction intrinsics (IALL, IANY, IPARITY) as specified in ISO/IEC 1539-1:2010 Section 13.7:
- **IALL(ARRAY[,DIM][,MASK])**: Bitwise AND reduction (Section 13.7.79)
- **IANY(ARRAY[,DIM][,MASK])**: Bitwise OR reduction (Section 13.7.80)
- **IPARITY(ARRAY[,DIM][,MASK])**: Bitwise XOR reduction (Section 13.7.94)

## Changes

- Add lexer tokens for IALL, IANY, IPARITY in `Fortran2008Lexer.g4`
- Add `bit_reduction_function_call` parser rule in `Fortran2008Parser.g4`
- Update `intrinsic_function_call_f2008` to include the new intrinsics
- Allow tokens as identifiers in `identifier_or_keyword` rule
- Add test fixture `bit_reduction_intrinsics.f90` exercising all three intrinsics with positional and named arguments

## Verification

```
$ make test
================= 1063 passed, 1 skipped, 3 xfailed in 58.96s ==================
```

Test fixture path: `tests/fixtures/Fortran2008/test_basic_f2008_features/bit_reduction_intrinsics.f90`

## ISO Standard Reference

ISO/IEC 1539-1:2010 Section 13.7.79-80, 13.7.94
