### PR TITLE
fix: F2023 degree-based trig intrinsics (fixes #330)

### DIFF
--- a/grammars/src/Fortran2023Lexer.g4
+++ b/grammars/src/Fortran2023Lexer.g4
@@ -83,6 +83,31 @@ IEEE_MIN_MAG     : I E E E '_' M I N '_' M A G ;
 LOGICAL_KINDS    : L O G I C A L '_' K I N D S ;
 CHARACTER_KINDS  : C H A R A C T E R '_' K I N D S ;
 
+// ----------------------------------------------------------------------------
+// Degree-based Trigonometric Intrinsics (NEW in F2023)
+// ISO/IEC 1539-1:2023 Section 16.9: Intrinsic procedures
+// J3/22-007 Section 16.9.3, 16.9.17, 16.9.21, 16.9.22, 16.9.51, 16.9.170,
+// 16.9.186
+// ----------------------------------------------------------------------------
+
+// Inverse trigonometric functions returning degrees
+// ACOSD(X): Arc cosine in degrees (Section 16.9.3)
+ACOSD            : A C O S D ;
+// ASIND(X): Arc sine in degrees (Section 16.9.17)
+ASIND            : A S I N D ;
+// ATAND(X) or ATAND(Y,X): Arc tangent in degrees (Section 16.9.21)
+ATAND            : A T A N D ;
+// ATAN2D(Y,X): Arc tangent of Y/X in degrees (Section 16.9.22)
+ATAN2D           : A T A N '2' D ;
+
+// Trigonometric functions with argument in degrees
+// COSD(X): Cosine with argument in degrees (Section 16.9.51)
+COSD             : C O S D ;
+// SIND(X): Sine with argument in degrees (Section 16.9.170)
+SIND             : S I N D ;
+// TAND(X): Tangent with argument in degrees (Section 16.9.186)
+TAND             : T A N D ;
+
 // Fragments are inherited from Fortran2018Lexer - no need to duplicate
 
 // ============================================================================

--- a/grammars/src/Fortran2023Parser.g4
+++ b/grammars/src/Fortran2023Parser.g4
@@ -418,6 +418,14 @@ identifier_or_keyword
     | ENUMERATOR   // ENUMERATOR can be used as a name
     | PENDING      // PENDING can be used as enumerator name
     | ENUM         // ENUM can be used as a name
+    // F2023 degree-based trigonometric intrinsics (Section 16.9)
+    | ACOSD        // ACOSD can be used as function name
+    | ASIND        // ASIND can be used as function name
+    | ATAND        // ATAND can be used as function name
+    | ATAN2D       // ATAN2D can be used as function name
+    | COSD         // COSD can be used as function name
+    | SIND         // SIND can be used as function name
+    | TAND         // TAND can be used as function name
     ;
 
 // ============================================================================

--- a/tests/fixtures/Fortran2023/test_fortran_2023_comprehensive/degree_trig_intrinsics.f90
+++ b/tests/fixtures/Fortran2023/test_fortran_2023_comprehensive/degree_trig_intrinsics.f90
@@ -1,0 +1,20 @@
+program degree_trig_intrinsics
+    implicit none
+    real :: angle_deg, result, x, y
+
+    angle_deg = 45.0
+
+    result = sind(angle_deg)
+    result = cosd(angle_deg)
+    result = tand(angle_deg)
+
+    result = asind(0.5)
+    result = acosd(0.5)
+    result = atand(1.0)
+
+    x = 1.0
+    y = 1.0
+    result = atand(y, x)
+    result = atan2d(y, x)
+
+end program degree_trig_intrinsics


### PR DESCRIPTION
## Summary

- Add lexer tokens for F2023 degree-based trigonometric intrinsics (ACOSD, ASIND, ATAND, ATAN2D, COSD, SIND, TAND)
- Add parser rules allowing these tokens as function names in identifier_or_keyword
- Add test fixture exercising all 7 degree-based trig intrinsics
- Add comprehensive lexer and parser tests including case-insensitive matching

## ISO Reference

ISO/IEC 1539-1:2023 Section 16.9:

| Intrinsic | ISO Section | Description |
|-----------|-------------|-------------|
| ACOSD | 16.9.3 | Arc cosine in degrees |
| ASIND | 16.9.17 | Arc sine in degrees |
| ATAND | 16.9.21 | Arc tangent in degrees |
| ATAN2D | 16.9.22 | Arc tangent of Y/X in degrees |
| COSD | 16.9.51 | Cosine with argument in degrees |
| SIND | 16.9.170 | Sine with argument in degrees |
| TAND | 16.9.186 | Tangent with argument in degrees |

## Verification

```
$ python -m pytest tests/Fortran2023/ -v --tb=short
24 passed in 3.61s

$ python -m pytest tests/ -v --tb=short
1068 passed, 1 skipped, 3 xfailed in 60.86s
```

## Test Plan

- [x] All 7 degree-based trig intrinsic lexer tokens recognized
- [x] Case-insensitive matching verified (sind, SIND, Sind all work)
- [x] Parser integration test with degree_trig_intrinsics.f90 fixture
- [x] Standards chain test updated to verify all new tokens
- [x] No regressions in full test suite (1068 passed)