### PR TITLE
fix: implement F2023 ENUM TYPE optional name on END ENUM (fixes #328)

### DIFF
--- a/grammars/src/Fortran2023Parser.g4
+++ b/grammars/src/Fortran2023Parser.g4
@@ -116,7 +116,14 @@ enumerator_f2023
 // J3/22-007 R763: end-enum-stmt
 // end-enum-stmt is END ENUM [ enum-type-name ]
 end_enum_stmt_f2023
-    : END ENUM NEWLINE
+    : END ENUM IDENTIFIER? NEWLINE
+    ;
+
+// Override F2008 end-enum-stmt to support F2023 optional type name
+// ISO/IEC 1539-1:2023 R771: end-enum-type-stmt is END ENUM [ enum-type-name ]
+// In F2023, END ENUM may include the optional enum-type-name for clarity
+end_enum_stmt_f2008
+    : END ENUM identifier_or_keyword? NEWLINE
     ;
 
 // ============================================================================

--- a/tests/fixtures/Fortran2023/test_fortran_2023_comprehensive/enum_program.f90
+++ b/tests/fixtures/Fortran2023/test_fortran_2023_comprehensive/enum_program.f90
@@ -1,10 +1,21 @@
 program test_enum
+    ! F2023 R766-R771: enum-type-def with optional enum-type-name on end-enum-stmt
+    ! R767: enum-type-stmt is ENUM, BIND(C) :: enum-type-name
+    ! R771: end-enum-type-stmt is END ENUM [ enum-type-name ]
+
+    ! BIND(C) enum with optional type name on END ENUM (F2023 feature)
     enum, bind(c) :: color_type
         enumerator :: red = 1, green = 2, blue = 3
-    end enum
+    end enum color_type
 
+    ! Fortran-specific enum without BIND(C), with type name
     enum :: status
         enumerator :: success, failure, pending
+    end enum status
+
+    ! Backwards-compatible: enum without type name on END ENUM
+    enum, bind(c) :: error_code
+        enumerator :: ok = 0, warning = 1, error = 2
     end enum
 end program test_enum
 


### PR DESCRIPTION
## Summary

Implements F2023 ENUM TYPE optional enum-type-name on END ENUM statement per ISO/IEC 1539-1:2023 R771.

- Override `end_enum_stmt_f2008` in F2023 parser to accept optional identifier
- Update `end_enum_stmt_f2023` to accept `IDENTIFIER?` for type name
- Update test fixture to exercise F2023 syntax with type name and backwards-compatible syntax

## ISO Reference

ISO/IEC 1539-1:2023 Section 7.6:
- R771: `end-enum-type-stmt` is `END ENUM [ enum-type-name ]`

## Test plan

- [x] Run `make test` - all 1072 tests pass
- [x] Test parsing with enum-type-name: `end enum color_t`
- [x] Test parsing without type name: `end enum` (backwards compatible)
