### PR TITLE
fix: simplify design doc and use light theme (fixes #371)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Lazy Fortran 2025 Design (WORK IN PROGRESS)</title>
+  <title>Lazy Fortran 2025 Design</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     :root {
-      color-scheme: light dark;
-      --lf-bg: #0b1020;
-      --lf-fg: #f5f7ff;
-      --lf-accent: #ffcc66;
-      --lf-muted: #9ca3af;
-      --lf-code-bg: #111827;
-      --lf-border: #374151;
+      --lf-bg: #ffffff;
+      --lf-fg: #1a1a1a;
+      --lf-accent: #2563eb;
+      --lf-muted: #6b7280;
+      --lf-code-bg: #f3f4f6;
+      --lf-border: #d1d5db;
+      --lf-card-bg: #fafafa;
     }
 
     * {
@@ -23,7 +23,7 @@
       margin: 0;
       font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text",
         "Segoe UI", sans-serif;
-      background: radial-gradient(circle at top left, #111827 0, #020617 50%);
+      background: var(--lf-bg);
       color: var(--lf-fg);
       min-height: 100vh;
     }
@@ -43,7 +43,8 @@
     header h1 {
       margin: 0 0 0.35rem;
       font-size: clamp(1.75rem, 2.4vw, 2.25rem);
-      letter-spacing: 0.03em;
+      letter-spacing: 0.02em;
+      color: var(--lf-accent);
     }
 
     header p {
@@ -60,7 +61,7 @@
       margin-top: 0.6rem;
       border-radius: 999px;
       border: 1px solid var(--lf-border);
-      background: rgba(15, 23, 42, 0.8);
+      background: var(--lf-card-bg);
       color: var(--lf-muted);
       font-size: 0.78rem;
       text-transform: uppercase;
@@ -71,8 +72,8 @@
       width: 6px;
       height: 6px;
       border-radius: 999px;
-      background: var(--lf-accent);
-      box-shadow: 0 0 0 3px rgba(255, 204, 102, 0.25);
+      background: #f59e0b;
+      box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.25);
     }
 
     nav {
@@ -89,7 +90,7 @@
       padding: 0.4rem 0.75rem;
       border-radius: 999px;
       border: 1px solid var(--lf-border);
-      background: rgba(15, 23, 42, 0.65);
+      background: var(--lf-card-bg);
       color: var(--lf-muted);
       text-decoration: none;
       font-size: 0.85rem;
@@ -106,13 +107,13 @@
       border-color: var(--lf-accent);
       color: var(--lf-fg);
       transform: translateY(-1px);
-      background: rgba(15, 23, 42, 0.9);
+      background: #fff;
     }
 
     nav a .pill {
       padding: 0.1rem 0.5rem;
       border-radius: 999px;
-      background: rgba(148, 163, 184, 0.18);
+      background: #e5e7eb;
       font-size: 0.78rem;
       color: var(--lf-muted);
     }
@@ -120,11 +121,9 @@
     main {
       border-radius: 1rem;
       padding: 1.75rem 1.5rem 1.5rem;
-      background: radial-gradient(circle at top left, #111827 0, #020617 60%);
-      border: 1px solid rgba(55, 65, 81, 0.9);
-      box-shadow:
-        0 18px 45px rgba(15, 23, 42, 0.85),
-        0 0 0 1px rgba(15, 23, 42, 0.8);
+      background: var(--lf-card-bg);
+      border: 1px solid var(--lf-border);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
     }
 
     .status-bar {
@@ -134,16 +133,16 @@
       gap: 0.75rem;
       margin-bottom: 1.25rem;
       padding-bottom: 0.75rem;
-      border-bottom: 1px dashed rgba(75, 85, 99, 0.8);
+      border-bottom: 1px dashed var(--lf-border);
       font-size: 0.8rem;
       color: var(--lf-muted);
     }
 
     .status-bar code {
-      background: rgba(15, 23, 42, 0.85);
+      background: var(--lf-code-bg);
       padding: 0.1rem 0.4rem;
       border-radius: 0.4rem;
-      border: 1px solid rgba(55, 65, 81, 0.9);
+      border: 1px solid var(--lf-border);
       font-size: 0.78rem;
     }
 
@@ -162,10 +161,12 @@
 
     #content h1 {
       font-size: 1.55rem;
+      color: var(--lf-accent);
     }
 
     #content h2 {
       font-size: 1.25rem;
+      color: #374151;
     }
 
     #content h3 {
@@ -174,7 +175,7 @@
 
     #content p {
       margin: 0.4rem 0;
-      color: rgba(229, 231, 235, 0.95);
+      color: #374151;
     }
 
     #content a {
@@ -201,7 +202,7 @@
       padding: 0.1rem 0.25rem;
       border-radius: 0.25rem;
       font-size: 0.85rem;
-      border: 1px solid rgba(55, 65, 81, 0.9);
+      border: 1px solid var(--lf-border);
     }
 
     #content pre {
@@ -210,13 +211,36 @@
       border-radius: 0.5rem;
       overflow-x: auto;
       font-size: 0.85rem;
-      border: 1px solid rgba(55, 65, 81, 0.9);
+      border: 1px solid var(--lf-border);
     }
 
     #content pre code {
       background: transparent;
       padding: 0;
       border: 0;
+    }
+
+    #content table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 0.75rem 0;
+      font-size: 0.9rem;
+    }
+
+    #content th,
+    #content td {
+      border: 1px solid var(--lf-border);
+      padding: 0.5rem 0.75rem;
+      text-align: left;
+    }
+
+    #content th {
+      background: #e5e7eb;
+      font-weight: 600;
+    }
+
+    #content tr:nth-child(even) {
+      background: #f9fafb;
     }
 
     .loading,
@@ -226,7 +250,7 @@
     }
 
     .error {
-      color: #f97373;
+      color: #dc2626;
     }
 
     footer {
@@ -250,12 +274,12 @@
 <body>
   <div class="shell">
     <header>
-      <h1>Lazy Fortran 2025 Design</h1>
-      <p>Grammar-driven design notes for the LazyFortran2025 standard.</p>
+      <h1>Lazy Fortran 2025</h1>
+      <p>Design specification for the LazyFortran2025 language extension.</p>
       <p>Rendered from the Markdown sources in this repository.</p>
       <div class="badge">
         <span class="dot"></span>
-        <span>WORK IN PROGRESS &mdash; design may change</span>
+        <span>Draft - design may change</span>
       </div>
     </header>
 
@@ -265,39 +289,34 @@
         <span class="pill">lazy-fortran/standard</span>
       </a>
       <a href="lazyfortran2025-design.md">
-        <strong>Feature overview</strong>
+        <strong>Design Spec</strong>
         <span class="pill">LF-0001</span>
       </a>
       <a href="slides/html/">
         <strong>Open Issues Slides</strong>
         <span class="pill">Discussion</span>
       </a>
-      <a href="UNIFIED_ARCHITECTURE.md">
-        <strong>Grammar architecture</strong>
-        <span class="pill">Background</span>
-      </a>
     </nav>
 
     <main>
       <div class="status-bar">
         <div>
-          Source document:
+          Source:
           <code>docs/lazyfortran2025-design.md</code>
         </div>
         <div>
-          Site root:
+          Site:
           <code>https://lazy-fortran.github.io/standard/</code>
         </div>
       </div>
 
       <article id="content" class="loading">
-        Loading Lazy Fortran 2025 design document&hellip;
+        Loading Lazy Fortran 2025 design document...
       </article>
     </main>
 
     <footer>
-      Built automatically from the Lazy Fortran documentation in this
-      repository. See the GitHub Actions log for deployment details.
+      Built from the Lazy Fortran documentation repository.
     </footer>
   </div>
 
@@ -317,14 +336,14 @@
           target.classList.remove("loading", "error");
           target.innerHTML = marked.parse(markdown, { mangle: false, headerIds: true });
         } catch (error) {
-          console.error("Failed to load Lazy Fortran design doc:", error);
+          console.error("Failed to load design doc:", error);
           target.classList.remove("loading");
           target.classList.add("error");
           target.innerHTML =
-            "Failed to load the Lazy Fortran design document from <code>" +
+            "Failed to load the design document from <code>" +
             sourcePath +
-            "</code>. You can still view the raw Markdown " +
-            '<a href="lazyfortran2025-design.md">directly on GitHub Pages</a>.';
+            "</code>. View the raw Markdown " +
+            '<a href="lazyfortran2025-design.md">directly</a>.';
         }
       }
 
@@ -334,10 +353,9 @@
         target.classList.remove("loading");
         target.classList.add("error");
         target.textContent =
-          "Unable to load the Markdown renderer for the Lazy Fortran design document.";
+          "Unable to load the Markdown renderer.";
       }
     })();
   </script>
 </body>
 </html>
-

--- a/docs/lazyfortran2025-design.md
+++ b/docs/lazyfortran2025-design.md
@@ -1,766 +1,275 @@
 # Lazy Fortran 2025
 
-**DRAFT - Working Document**
-
-> **Document type:** Working Draft
-> **Base standard:** ISO/IEC 1539-1:2023 (Fortran 2023)
-> **Status:** This document is a draft specification. All provisions are subject to change.
+**Status:** Draft
+**Base standard:** Fortran 2023 (ISO/IEC 1539-1:2023)
 
 ---
 
-## Foreword
+## Summary
 
-This document specifies Lazy Fortran 2025, a superset extension to the Fortran programming language. It is designed to be read in conjunction with ISO/IEC 1539-1:2023 (Fortran 2023), which serves as the normative base standard.
+Lazy Fortran 2025 extends Fortran 2023 with automatic type inference, intent deduction, and generic programming. The goal is reduced boilerplate while maintaining compatibility with standard Fortran compilers through a source-to-source standardizer.
 
-This document does not duplicate the text of ISO/IEC 1539-1:2023. Where this document is silent, the provisions of ISO/IEC 1539-1:2023 apply. All syntax and semantics defined in ISO/IEC 1539-1:2023 remain in effect unless explicitly modified by this document.
+Key features:
+- **Type inference** - variables get their type from first assignment
+- **Intent inference** - argument intents derived from usage analysis
+- **Generics** - templates and traits for type-safe polymorphism
+- **Monomorphization** - automatic generation of specialized code
 
-Readers should have access to ISO/IEC 1539-1:2023 for complete understanding of the base language features.
-
----
-
-## Contents
-
-[Foreword](#foreword)
-
-1. [Scope](#1-scope)
-2. [Normative references](#2-normative-references)
-3. [Terms and definitions](#3-terms-and-definitions)
-4. [Conformance](#4-conformance)
-5. [Type system](#5-type-system)
-6. [Generic programming](#6-generic-programming)
-7. [Automatic specialization](#7-automatic-specialization)
-8. [Application binary interface](#8-application-binary-interface)
-9. [Standardizer](#9-standardizer)
-
-Annex A. [References](#annex-a-references)
+All standard Fortran 2023 programs remain valid Lazy Fortran programs.
 
 ---
 
-## 1 Scope
+## Type Inference
 
-1.1 This document specifies extensions to the Fortran programming language as defined by ISO/IEC 1539-1:2023.
+### First Assignment Rule
 
-1.2 The extensions specified in this document constitute Lazy Fortran 2025, a strict superset of ISO/IEC 1539-1:2023.
-
-1.3 This document adds the following facilities to the base language:
-  - (a) automatic type inference (Section 5);
-  - (b) generic programming constructs (Section 6);
-  - (c) automatic specialization (monomorphization) (Section 7).
-
-1.4 Lazy Fortran source files use the `.lf` extension and can be transformed to standard-conforming Fortran by a standardizer.
-
-1.5 This document does not specify:
-  - (a) the mechanism by which Lazy Fortran programs are transformed or executed;
-  - (b) the method of transcription of Lazy Fortran programs for execution;
-  - (c) the operations required for setup and control of the use of Lazy Fortran programs.
-
-1.6 For all matters not explicitly addressed in this document, ISO/IEC 1539-1:2023 applies.
-
----
-
-## 2 Normative references
-
-2.1 The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.
-
-2.2 ISO/IEC 1539-1:2023, *Information technology — Programming languages — Fortran — Part 1: Base language*
-
-> **NOTE:** ISO/IEC 1539-1:2023 is the base standard for this document. All provisions of ISO/IEC 1539-1:2023 apply to Lazy Fortran 2025 unless explicitly modified by this document.
-
----
-
-## 3 Terms and definitions
-
-3.1 For the purposes of this document, the terms and definitions given in ISO/IEC 1539-1:2023 Clause 3 apply, together with the following.
-
-3.2 ISO/IEC 1539-1:2023 Clause 3 contains terms and definitions that are applicable but not duplicated here.
-
-3.3 **automatic type inference**
-determination of variable types from their usage context without explicit declaration
-
-3.4 **first assignment rule**
-the rule that an undeclared variable's type is determined by its first assignment
-
-3.5 **monomorphization**
-generation of specialized code for each concrete type combination used with a generic procedure
-
-3.6 **specialization**
-a specific instantiation of a generic procedure for particular concrete types
-
-3.7 **standardizer**
-a tool that transforms Lazy Fortran source to standard-conforming Fortran
-
-3.8 **trait**
-a named collection of procedure signatures that types can implement
-
-3.9 **type set**
-a constraint specifying a set of types that a generic parameter may take
-
----
-
-## 4 Conformance
-
-4.1 **Fortran compatibility**
-
-4.1.1 A conforming Lazy Fortran processor shall be capable of processing any standard-conforming Fortran 2023 program.
-
-4.1.2 The output of a conforming standardizer shall be a standard-conforming Fortran program.
-
-4.2 **ISO behavior changes**
-
-4.2.1 The following features differ from standard Fortran behavior:
-
-| Section | Feature | ISO Fortran Behavior | Lazy Fortran Behavior |
-|---------|---------|---------------------|----------------------|
-| 5.1 | Type inference | Explicit declarations or I-N naming | First assignment determines type |
-| 5.3 | Default intent | No default (arguments modifiable) | See 5.3.3 |
-
----
-
-## 5 Type system
-
-### 5.1 Automatic type inference
-
-5.1.1 **General**
-
-5.1.1.1 Lazy Fortran 2025 uses automatic type inference to determine variable types from usage context.
-
-5.1.1.2 This replaces the legacy implicit typing rules (I-N integer, otherwise real) with a first-assignment-wins rule.
-
-> **NOTE 1:** This is an **ISO BEHAVIOR CHANGE**. Standard Fortran requires explicit type declarations or uses the I-N naming convention.
-
-5.1.2 **First assignment rule**
-
-5.1.2.1 The type of an undeclared variable is determined by its first assignment.
-
-5.1.2.2 The kind of inferred numeric types follows the rules below.
-
-> **OPEN ISSUE 1: Default numeric kinds**
->
-> What kind should inferred numeric literals have?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | ISO defaults (`real(4)`, `integer(4)`) | Compatible, predictable, smaller memory | Precision loss, overflow at ~2B |
-> | B | Double precision (`real(8)`, `integer(8)`) | Safer for scientific computing | Breaks ISO expectations, 2x memory |
-> | C | Context-dependent | Adapts to usage | Unpredictable |
-
-5.1.2.3 The following assignments establish types:
+Variables get their type from the first value assigned:
 
 ```fortran
-x = 4              ! x is integer
-y = 3.14           ! y is real
-z = (1.0, 2.0)     ! z is complex
-flag = .true.      ! flag is logical
-s = "hello"        ! s is character(len=5)
-obj = create_particle()  ! obj has return type of create_particle
+x = 42             ! integer
+y = 3.14           ! real
+z = (1.0, 2.0)     ! complex
+flag = .true.      ! logical
+s = "hello"        ! character(len=5)
+p = particle_t()   ! derived type from constructor
 ```
 
-5.1.2.4 Subsequent assignments to the same variable use standard Fortran coercion rules.
+Subsequent assignments use standard Fortran coercion rules.
 
-5.1.2.5 Logical literals (`.true.`, `.false.`) establish logical type.
+### Arrays
 
-5.1.2.6 Complex literals of the form `(real-part, imag-part)` establish complex type. The kind is determined by the component literals according to ISO/IEC 1539-1:2023.
-
-5.1.2.7 String literals establish character type. The handling of length is subject to the following consideration.
-
-> **OPEN ISSUE 10: Character length inference**
->
-> How should character length be handled when multiple assignments have different lengths?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | First assignment wins | Consistent with other types | Truncation on longer strings |
-> | B | Maximum length seen | No truncation | May waste memory |
-> | C | Allocatable deferred-length | Fully dynamic | More complex, allocation overhead |
-
-5.1.3 **Array bounds inference**
-
-5.1.3.1 Allocatable arrays have bounds inferred from `allocate` statements or array constructors.
-
-5.1.3.2 Examples:
+Array types come from constructors or allocate statements:
 
 ```fortran
-arr = [1, 2, 3]           ! rank-1, 3 elements
+arr = [1, 2, 3]           ! rank-1 integer array, 3 elements
 allocate(matrix(n, m))    ! rank-2, runtime bounds
 ```
 
-5.1.4 **Interaction with implicit none**
+### Interaction with implicit none
 
-5.1.4.1 When `implicit none` is present, undeclared names are errors and inference is disabled.
+When `implicit none` is present, undeclared names are errors and inference is disabled. This preserves compatibility with strict coding styles.
 
-5.1.4.2 This preserves compatibility with strict coding styles.
+### Open Issues
 
-5.1.5 **Inference from intent(out) arguments**
-
-5.1.5.1 Whether undeclared variables passed to `intent(out)` arguments are automatically declared is subject to the following consideration.
-
-> **OPEN ISSUE 2: Inference from intent(out) arguments**
->
-> Should `call init(p)` automatically declare `p` based on `intent(out)` signature?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | No (assignment only) | Simple local analysis | Doesn't support idiomatic patterns |
-> | B | Yes (inspect callee) | Supports `intent(out)` patterns | Requires cross-procedure analysis |
-
-5.1.6 **Declaration placement**
-
-5.1.6.1 Whether explicit declarations may appear anywhere in a block or only at the beginning is subject to the following consideration.
-
-> **OPEN ISSUE 3: Declaration placement**
->
-> Should explicit declarations be allowed anywhere or only at block beginning?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | Block beginning only | Clean structure | Variables far from first use |
-> | B | Anywhere | Declare near use | Scattered, redundant with inference |
-
-5.1.7 **Pointer attribute inference**
-
-5.1.7.1 Whether pointer assignment (`p => target`) should automatically infer the `pointer` attribute is subject to the following consideration.
-
-> **OPEN ISSUE 11: Pointer and target attribute inference**
->
-> Should `p => x` automatically declare `p` with `pointer` and `x` with `target`?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | No inference | Clear intent, no hidden semantics | Verbose |
-> | B | Infer `pointer` only | Concise for pointer | Target must be explicit |
-> | C | Infer both `pointer` and `target` | Fully automatic | Hides semantics, may surprise |
-
-5.1.8 **Allocatable attribute inference**
-
-5.1.8.1 Whether `allocate` statements should automatically infer the `allocatable` attribute is subject to the following consideration.
-
-> **OPEN ISSUE 12: Allocatable attribute inference**
->
-> Should `allocate(arr(n))` automatically declare `arr` with the `allocatable` attribute?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | No (require explicit) | Clear intent, no hidden semantics | Verbose |
-> | B | Yes (infer from `allocate`) | Concise, matches usage | Hides allocation semantics |
-
-5.1.9 **Function result type inference**
-
-5.1.9.1 Function return types may be inferred from the function body or from call sites.
-
-5.1.9.2 Example:
-
-```fortran
-function add(a, b)
-    add = a + b       ! return type inferred from expression
-end function
-```
-
-5.1.9.3 The mechanism for inferring function result types is subject to the following consideration.
-
-> **OPEN ISSUE 13: Function result type inference**
->
-> How should function return types be inferred?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | Body only | Local analysis, predictable | May miss context from call sites |
-> | B | Call site only | Adapts to usage | Requires whole-program analysis |
-> | C | Body first, call site fallback | Best of both | Complex precedence rules |
-> | D | Must match (error on conflict) | Catches inconsistencies | Stricter, may reject valid code |
-
-5.1.10 **Derived type inference**
-
-5.1.10.1 Variables may be inferred to have derived (user-defined) types from constructor calls or assignments.
-
-5.1.10.2 Example:
-
-```fortran
-p = particle_t(1.0, 2.0, 3.0)   ! p inferred as type(particle_t)
-```
-
-5.1.10.3 The handling of derived type inference is subject to the following consideration.
-
-> **OPEN ISSUE 14: Derived type inference**
->
-> How should derived type inference interact with module scope?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | Type must be in scope | Simple, explicit USE required | Verbose |
-> | B | Auto-USE if type found | Convenient | Hidden dependencies, may be ambiguous |
-> | C | Derived types require explicit declaration | Safe, no inference for complex types | Inconsistent with other inference |
-
-5.1.11 **Fallback type for unresolved inference**
-
-5.1.11.1 When type inference cannot determine a variable's type, a fallback behavior is required.
-
-> **OPEN ISSUE 15: Fallback type for unresolved inference**
->
-> What should happen when a variable's type cannot be inferred?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | Compile error | Catches ambiguities early | May reject valid code |
-> | B | Default to `real(8)` | Matches fortfront, safe for numerics | Silent assumption, may surprise |
-> | C | Default to ISO default kind | Consistent with standard | Precision loss |
-
-### 5.2 Expression type rules
-
-5.2.1 Expression type determination follows ISO/IEC 1539-1:2023 Clause 10.1.5 (Numeric intrinsic operations).
-
-5.2.2 When automatic type inference determines a variable's type from an expression, the type is determined according to the rules specified in ISO/IEC 1539-1:2023.
-
-5.2.3 Mixed numeric array constructors follow ISO/IEC 1539-1:2023 type promotion rules.
-
-5.2.4 Example: `[1, 2.0, 3]` promotes all elements to real, resulting in a real array.
-
-### 5.3 Intent inference
-
-5.3.1 **General**
-
-5.3.1.1 Procedure argument intents may be inferred from usage analysis.
-
-> **NOTE 2:** This is an **ISO BEHAVIOR CHANGE**. Standard Fortran has no default intent - arguments without explicit intent can be read and modified.
-
-5.3.2 **Usage-based inference**
-
-5.3.2.1 Arguments that are only read within a procedure are inferred as `intent(in)`.
-
-5.3.2.2 Arguments that are modified are inferred as `intent(inout)` or `intent(out)` based on whether the input value is used.
-
-5.3.3 **Default intent**
-
-5.3.3.1 The default intent when usage analysis is inconclusive is subject to the following consideration.
-
-> **OPEN ISSUE 4: Default intent for procedure arguments**
->
-> What should be the default intent when not explicitly specified?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | `intent(in)` default | Safe, prevents accidents | Breaks code relying on implicit inout |
-> | B | `intent(inout)` default | Closer to ISO | Still error-prone |
-> | C | No default (require explicit) | Forces clarity | Verbose |
+| Issue | Question | Options |
+|-------|----------|---------|
+| 1 | Default numeric kinds? | A: ISO default (real(4)) B: Double precision (real(8)) C: Context-dependent |
+| 10 | Character length handling? | A: First assignment wins B: Maximum length seen C: Allocatable deferred-length |
+| 15 | Fallback when type unclear? | A: Compile error B: Default to real(8) C: ISO default kind |
+| 2 | Infer from intent(out)? | A: No (assignment only) B: Yes (inspect callee signature) |
+| 3 | Declaration placement? | A: Block beginning only B: Anywhere in scope |
+| 11 | Infer pointer attribute? | A: No B: From pointer assignment C: Both pointer and target |
+| 12 | Infer allocatable? | A: No B: From allocate statements |
+| 13 | Function result types? | A: Body only B: Call site only C: Body first, call site fallback D: Must match |
+| 14 | Derived type scope? | A: Explicit USE required B: Auto-USE C: Explicit declaration required |
 
 ---
 
-## 6 Generic programming
+## Intent Inference
 
-### 6.1 Overview
-
-6.1.1 Lazy Fortran 2025 supports two approaches to generic programming that may be used together.
-
-6.1.2 Approach A (J3 TEMPLATE) follows the official Fortran 202Y direction.
-
-6.1.3 Approach B (Traits) provides Swift/Rust-inspired ergonomics.
-
-6.1.4 Which approach(es) to adopt is subject to the following consideration.
-
-> **OPEN ISSUE 5: Generics approach**
->
-> Which generics system to adopt?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | J3 TEMPLATE only | Official direction | Verbose |
-> | B | Traits only | Concise, automatic | Not official |
-> | C | Hybrid (both) | Maximum flexibility | Two systems |
-
-6.1.5 The syntax for generic type parameters is subject to the following consideration.
-
-> **OPEN ISSUE 6: Generic parameter syntax**
->
-> What delimiter for generic type parameters?
->
-> | Option | Syntax | Pros | Cons |
-> |--------|--------|------|------|
-> | A | `{T}` | Distinct, J3 inline | Not traditional |
-> | B | `(T)` | Fortran-like | Ambiguous with calls |
-> | C | `<T>` | Familiar to C++/Rust | Conflicts with operators |
-
-### 6.2 TEMPLATE construct (J3 approach)
-
-6.2.1 **Syntax**
-
-6.2.1.1 A template defines a parameterized scope containing procedures:
+Procedure argument intents are derived from usage analysis:
 
 ```fortran
-template template-name ( template-parameter-list )
-   [ type, deferred :: type-parameter ]...
-   [ requires requirement-name ( args ) ]...
-contains
-   procedure-definitions
-end template [ template-name ]
+subroutine process(x, y, z)
+    ! x only read     -> intent(in)
+    ! y modified      -> intent(inout)
+    ! z only written  -> intent(out)
+    y = x + 1
+    z = y * 2
+end subroutine
 ```
 
-6.2.2 **INSTANTIATE statement**
+### Open Issue
 
-6.2.2.1 Templates are instantiated explicitly:
+| Issue | Question | Options |
+|-------|----------|---------|
+| 4 | Default intent when usage is inconclusive? | A: intent(in) B: intent(inout) C: Require explicit |
 
-```fortran
-instantiate template-name ( type-arguments ) [ , rename-list ]
-```
+---
 
-6.2.2.2 Example:
+## Generic Programming
+
+Two complementary approaches are available.
+
+### Templates (J3 Direction)
+
+The TEMPLATE construct defines parameterized procedures:
 
 ```fortran
 template swap_t(T)
-   type, deferred :: T
+    type, deferred :: T
 contains
-   subroutine swap(x, y)
-      type(T), intent(inout) :: x, y
-      type(T) :: tmp
-      tmp = x; x = y; y = tmp
-   end subroutine
+    subroutine swap(x, y)
+        type(T), intent(inout) :: x, y
+        type(T) :: tmp
+        tmp = x; x = y; y = tmp
+    end subroutine
 end template
 
+! Explicit instantiation
 instantiate swap_t(integer), only: swap_int => swap
 instantiate swap_t(real), only: swap_real => swap
-```
 
-6.2.3 **Inline instantiation**
-
-6.2.3.1 Simple template procedures may be instantiated inline:
-
-```fortran
+! Inline instantiation
 call swap{integer}(a, b)
 ```
 
-### 6.3 REQUIREMENT construct
-
-6.3.1 **Syntax**
-
-6.3.1.1 A requirement defines reusable type constraints:
-
-```fortran
-requirement requirement-name ( parameter-list )
-   type, deferred :: type-parameter
-   interface
-      interface-body
-   end interface
-end requirement
-```
-
-6.3.2 **Example**
+Requirements define reusable type constraints:
 
 ```fortran
 requirement r_comparable(T, less_than)
-   type, deferred :: T
-   interface
-      pure logical function less_than(a, b)
-         type(T), intent(in) :: a, b
-      end function
-   end interface
+    type, deferred :: T
+    interface
+        pure logical function less_than(a, b)
+            type(T), intent(in) :: a, b
+        end function
+    end interface
 end requirement
 ```
 
-### 6.4 Traits (Swift/Rust approach)
+### Traits (Swift/Rust Style)
 
-6.4.1 **Type sets**
-
-6.4.1.1 A type set specifies a constraint as a union of types:
+Type sets specify constraints as unions:
 
 ```fortran
 abstract interface :: INumeric
-   integer | real(real64)
+    integer | real(real64)
 end interface INumeric
 ```
 
-6.4.2 **Trait signatures**
-
-6.4.2.1 A trait may specify required procedure signatures:
-
-```fortran
-abstract interface :: ISum
-   function sum{INumeric :: T}(x) result(s)
-      type(T), intent(in) :: x(:)
-      type(T) :: s
-   end function
-end interface ISum
-```
-
-6.4.3 **IMPLEMENTS statement**
-
-6.4.3.1 Types declare trait conformance:
+Types declare trait conformance:
 
 ```fortran
 type, implements(ISum) :: simple_sum_t
 contains
-   procedure, nopass :: sum
+    procedure, nopass :: sum
 end type
-```
 
-6.4.3.2 Retroactive implementation:
-
-```fortran
+! Retroactive conformance
 implements IComparable :: integer
-   procedure :: less_than => builtin_less_than
+    procedure :: less_than => builtin_less_than
 end implements
 ```
 
-6.4.4 **Trait annotation syntax**
+### Combining Approaches
 
-6.4.4.1 An alternative syntax using `@` annotations may be used for trait declarations.
-
-6.4.4.2 Example:
-
-```fortran
-@IComparable
-integer function compare(a, b)
-    integer, intent(in) :: a, b
-    compare = a - b
-end function
-```
-
-6.4.4.3 The annotation syntax is subject to the following consideration.
-
-> **OPEN ISSUE 16: Trait annotation syntax**
->
-> Should `@` annotations be supported for trait declarations?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | No annotations | Fortran-like, consistent | Verbose |
-> | B | `@Trait` syntax | Concise, familiar to Java/Python users | New symbol in Fortran |
-> | C | Both supported | Flexibility | Two ways to do same thing |
-
-### 6.5 Compatibility of approaches
-
-6.5.1 The two approaches are not mutually exclusive and may be combined.
-
-6.5.2 Whether generics support static dispatch, dynamic dispatch, or both is subject to the following consideration.
-
-> **OPEN ISSUE 7: Dispatch mechanism**
->
-> Should generics support both static and dynamic dispatch?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | Static only | Zero overhead | No runtime flexibility |
-> | B | Dynamic only | Runtime polymorphism | Overhead |
-> | C | Both | User chooses | Complex |
-
-6.5.3 Complementary strengths:
-
-| Use Case | Recommended Approach |
-|----------|---------------------|
+| Use Case | Recommended |
+|----------|-------------|
 | Generic containers | J3 TEMPLATE |
 | Numeric algorithms | Traits type sets |
 | Retroactive conformance | Traits IMPLEMENTS |
-| Runtime polymorphism | Traits with `class(ITrait)` |
-| Explicit instantiation control | J3 TEMPLATE |
+| Runtime polymorphism | Traits with class(ITrait) |
+| Explicit instantiation | J3 TEMPLATE |
 | Ergonomic call sites | Traits automatic inference |
 
----
+### Open Issues
 
-## 7 Automatic specialization
-
-### 7.1 General
-
-7.1.1 Lazy Fortran automatically generates specialized (monomorphized) code for each concrete type combination used with a generic procedure.
-
-7.1.2 Generic resolution follows the rules specified in ISO/IEC 1539-1:2023 Clause 15.4.3.4.
-
-### 7.2 Resolution policy
-
-7.2.1 The following resolution rules apply in order:
-
-7.2.1.1 User-written specific procedures take precedence over generated specializations.
-
-7.2.1.2 Among remaining candidates, the most specific candidate wins according to ISO/IEC 1539-1:2023 Clause 15.4.3.4.
-
-7.2.1.3 If two or more candidates remain after applying the rules of ISO/IEC 1539-1:2023, a compile-time ambiguity error is raised.
-
-### 7.3 Specialization scope
-
-7.3.1 Specializations may be generated at module scope, program scope, or link-time depending on implementation.
-
-7.3.2 The scope at which specializations are generated is subject to the following consideration.
-
-> **OPEN ISSUE 8: Specialization scope**
->
-> At what scope should specializations be generated?
->
-> | Option | Description | Pros | Cons |
-> |--------|-------------|------|------|
-> | A | Per-module | Smaller units | May duplicate |
-> | B | Per-program (link-time) | No duplication | Requires LTO |
-> | C | Lazy (on-demand) | Minimal size | Complex build |
+| Issue | Question | Options |
+|-------|----------|---------|
+| 5 | Which generics system? | A: J3 TEMPLATE only B: Traits only C: Hybrid (both) |
+| 6 | Generic parameter delimiter? | A: Braces {T} B: Parentheses (T) C: Angle brackets <T> |
+| 7 | Dispatch mechanism? | A: Static only B: Dynamic only C: Both |
+| 16 | Support @ annotations? | A: No B: Yes C: Both styles |
 
 ---
 
-## 8 Application binary interface
+## Monomorphization
 
-### 8.1 General
+Generic procedures are automatically specialized for each type combination used:
 
-8.1.1 This section specifies the name mangling conventions for interoperability.
+```fortran
+function add(a, b)
+    add = a + b
+end function
 
-8.1.2 The ABI is designed to be compatible with gfortran's conventions where applicable.
+x = add(5, 3)       ! generates add__i32_i32
+y = add(2.5, 1.5)   ! generates add__r64_r64
+```
 
-### 8.2 gfortran ABI reference
+User-written specific procedures take precedence over generated specializations. Ambiguity is a compile-time error.
 
-8.2.1 **Module procedures**
+### Open Issue
 
-8.2.1.1 gfortran mangles module procedures as:
+| Issue | Question | Options |
+|-------|----------|---------|
+| 8 | Specialization scope? | A: Per-module B: Per-program (LTO) C: Lazy (on-demand) |
+
+---
+
+## Application Binary Interface
+
+### gfortran Compatibility
+
+Module procedures follow gfortran conventions:
 
 ```
 __<module-name>_MOD_<procedure-name>
 ```
 
-8.2.1.2 Example: `add` in module `test_mod` becomes `__test_mod_MOD_add`.
+Main program entry is `MAIN__`.
 
-8.2.2 **Internal (contained) procedures**
+### Specialization Mangling
 
-8.2.2.1 gfortran mangles internal procedures as:
-
-```
-<procedure-name>.<unique-number>
-```
-
-8.2.2.2 The unique number ensures distinctness within the compilation unit.
-
-8.2.3 **Main program**
-
-8.2.3.1 The main program entry point is `MAIN__`.
-
-### 8.3 Lazy Fortran specialization mangling
-
-8.3.1 **Naming convention**
-
-8.3.1.1 Specialized procedures use the following name mangling:
+Specialized procedures use kind suffixes:
 
 ```
 <procedure-name>__<kind-suffix-1>_<kind-suffix-2>_...
 ```
 
-8.3.1.2 Each kind suffix encodes the type and kind of a parameter.
+Kind suffix table (bits convention):
 
-8.3.2 **Kind suffixes**
+| Type | Kind | Suffix |
+|------|------|--------|
+| integer | 4 | i32 |
+| integer | 8 | i64 |
+| real | 4 | r32 |
+| real | 8 | r64 |
+| complex | 8 | c128 |
+| logical | 4 | l32 |
+| character | N | chN |
 
-8.3.2.1 The naming convention for kind suffixes is subject to the following consideration.
+Array rank uses `rank<n>` suffix: `sum__r64rank1`
 
-> **OPEN ISSUE 9: Kind suffix convention**
->
-> Should kind suffixes use bits (C-style) or bytes (Fortran kind parameter)?
->
-> | Option | Example | Pros | Cons |
-> |--------|---------|------|------|
-> | A | `i32`, `r64` (bits) | Familiar to C/Rust programmers, current fortfront | Inconsistent with Fortran kind parameters |
-> | B | `i4`, `r8` (bytes) | Matches `integer(4)`, `real(8)` exactly | Less familiar to polyglot programmers |
->
-> Option B aligns with Fortran's kind system where `integer(4)` means 4 bytes, not 4 bits.
-
-8.3.2.2 Kind suffixes (using current bit-based convention):
-
-| Type | Kind | Storage | Suffix |
-|------|------|---------|--------|
-| integer | 1 | 1 byte | i8 |
-| integer | 2 | 2 bytes | i16 |
-| integer | 4 | 4 bytes | i32 |
-| integer | 8 | 8 bytes | i64 |
-| integer | 16 | 16 bytes | i128 |
-| real | 4 | 4 bytes | r32 |
-| real | 8 | 8 bytes | r64 |
-| real | 16 | 16 bytes | r128 |
-| complex | 4 | 8 bytes | c64 |
-| complex | 8 | 16 bytes | c128 |
-| complex | 16 | 32 bytes | c256 |
-| logical | 1 | 1 byte | l8 |
-| logical | 4 | 4 bytes | l32 |
-| character | N | N bytes | chN |
-
-8.3.2.3 Kind suffixes (alternative byte-based convention):
-
-| Type | Kind | Storage | Suffix |
-|------|------|---------|--------|
-| integer | 1 | 1 byte | i1 |
-| integer | 2 | 2 bytes | i2 |
-| integer | 4 | 4 bytes | i4 |
-| integer | 8 | 8 bytes | i8 |
-| integer | 16 | 16 bytes | i16 |
-| real | 4 | 4 bytes | r4 |
-| real | 8 | 8 bytes | r8 |
-| real | 16 | 16 bytes | r16 |
-| complex | 4 | 8 bytes | c4 |
-| complex | 8 | 16 bytes | c8 |
-| complex | 16 | 32 bytes | c16 |
-| logical | 1 | 1 byte | l1 |
-| logical | 4 | 4 bytes | l4 |
-| character | N | N bytes | chN |
-
-8.3.2.4 Array rank is indicated by `rank<n>` suffix:
-
-```
-matmul__r64rank2_r64rank2
-```
-
-8.3.3 **Examples**
-
-8.3.3.1 `add(integer, integer)` → `add__i32_i32`
-
-8.3.3.2 `add(real(8), real(8))` → `add__r64_r64`
-
-8.3.3.3 `sum(real(8), dimension(:))` → `sum__r64rank1`
-
-### 8.4 Module wrapping
-
-8.4.1 When multiple specializations are generated, they are wrapped in an auto-generated module.
-
-8.4.2 The module name follows the pattern `auto_<procedure-name>`.
-
-8.4.3 Example for procedure `add`:
+Multiple specializations are wrapped in a generic interface within an auto-generated module:
 
 ```fortran
 module auto_add
     interface add
         module procedure add__i32_i32, add__r64_r64
-    end interface add
+    end interface
 end module
 ```
 
-8.4.4 The resulting ABI names follow gfortran convention:
+### Open Issue
 
-```
-__auto_add_MOD_add__i32_i32
-__auto_add_MOD_add__r64_r64
-```
+| Issue | Question | Options |
+|-------|----------|---------|
+| 9 | Kind suffix convention? | A: Bits (i32, r64) B: Bytes (i4, r8) |
 
 ---
 
-## 9 Standardizer
+## Standardizer
 
-### 9.1 General
+The standardizer transforms Lazy Fortran (.lf) to standard Fortran (.f90).
 
-9.1.1 The standardizer transforms Lazy Fortran (`.lf`) to standard-conforming Fortran (`.f90`).
+### Transformations
 
-9.1.2 This section describes the transformation mechanics.
+1. **Program wrapping** - Bare statements become `program main`
+2. **Declaration generation** - Inferred types become explicit declarations
+3. **implicit none injection** - Added to all program units
+4. **Intent generation** - Inferred intents become explicit
+5. **Monomorphization** - Generic calls become specialized procedures
 
-### 9.2 Program structure wrapping
+### Example
 
-9.2.1 **Default program unit**
-
-9.2.1.1 When no program unit is specified, the default is `program main`.
-
-9.2.1.2 Bare statements without program structure are wrapped in `program main ... end program`.
-
-9.2.1.3 When the source file contains only procedure definitions (no executable statements at file level), the default is a module named after the file (without extension).
-
-9.2.1.4 Example: `mathlib.lf` containing only functions becomes `module mathlib`.
-
-9.2.2 **Contained procedures**
-
-9.2.2.1 Functions and subroutines at file level are placed in the `contains` section of the default program unit.
-
-9.2.2.2 When the default is a module (9.2.1.3), procedures are placed in the module's `contains` section.
-
-9.2.3 Example:
-
+Input (script.lf):
 ```fortran
-! Input: script.lf
 x = 5
 print *, x
+```
 
-! Output: script.f90
+Output (script.f90):
+```fortran
 program main
     implicit none
     integer :: x
@@ -769,108 +278,10 @@ program main
 end program main
 ```
 
-### 9.3 Declaration generation
-
-9.3.1 Explicit declarations are generated for all inferred variables.
-
-9.3.2 Declarations are placed at block beginning, before executable statements.
-
-9.3.3 Example:
-
-```fortran
-! Inferred declarations
-integer :: x
-real :: y
-integer, dimension(3) :: arr
-```
-
-### 9.4 Implicit none injection
-
-9.4.1 The standardizer injects `implicit none` into all program units.
-
-9.4.2 This ensures type safety in the generated code.
-
-### 9.5 Intent generation
-
-9.5.1 Intent attributes are generated based on usage analysis (see 5.3).
-
-9.5.2 Example:
-
-```fortran
-integer function add(a, b)
-    integer, intent(in) :: a, b   ! Generated
-    add = a + b
-end function
-```
-
-### 9.6 Monomorphization output
-
-9.6.1 **Multiple specializations**
-
-9.6.1.1 When a procedure is called with multiple type signatures, the standardizer:
-
-  - (a) generates specialized procedures with mangled names (see 8.3);
-  - (b) creates a generic interface binding all specializations;
-  - (c) wraps in a module (see 8.4);
-  - (d) injects `use` statement in the calling code.
-
-9.6.1.2 Example:
-
-```fortran
-! Input: script.lf
-function add(a, b)
-    add = a + b
-end function
-x = add(5, 3)
-y = add(2.5, 1.5)
-
-! Output: script.f90
-module auto_add
-    implicit none
-    interface add
-        module procedure add__i32_i32, add__r64_r64
-    end interface add
-contains
-    integer function add__i32_i32(a, b)
-        integer, intent(in) :: a, b
-        add__i32_i32 = a + b
-    end function
-
-    real function add__r64_r64(a, b)
-        real, intent(in) :: a, b
-        add__r64_r64 = a + b
-    end function
-end module auto_add
-
-program main
-    use auto_add
-    implicit none
-    integer :: x
-    real :: y
-    x = add(5, 3)
-    y = add(2.5, 1.5)
-end program main
-```
-
-9.6.2 **Single specialization optimization**
-
-9.6.2.1 When a procedure has only one type signature, no interface or module wrapping is generated.
-
-9.6.2.2 The procedure is placed directly in the `contains` section.
-
 ---
 
-## Annex A References
+## References
 
-### A.1 Normative references
-
-- ISO/IEC 1539-1:2023, *Information technology — Programming languages — Fortran — Part 1: Base language*
-
-### A.2 Informative references
-
-The following documents are referenced for background information only. They do not constitute requirements of this document.
-
-- [J3 Generics Repository](https://github.com/j3-fortran/generics) - Official J3 committee work on generics
-- [J3 Paper 18-281r1](https://j3-fortran.org/doc/year/18/18-281r1.txt) - Simple templates proposal
+- ISO/IEC 1539-1:2023 (Fortran 2023)
+- [J3 Generics Repository](https://github.com/j3-fortran/generics)
 - [J3 Paper 24-107r1](https://j3-fortran.org/doc/year/24/) - TEMPLATE/INSTANTIATE syntax
-- [Traits-for-Fortran](https://github.com/difference-scheme/Traits-for-Fortran) - Swift/Rust-inspired generics proposal


### PR DESCRIPTION
## Summary

- Rewrote `docs/lazyfortran2025-design.md` in modern RFC style (reduced from 877 lines to 288 lines)
- Changed `docs/index.html` from dark theme to clean light theme
- Removed nested ISO section numbers (e.g., `5.1.1.1`) in favor of flat headers
- Preserved all open issue tables and technical content

## Verification

```
make test
============ 1111 passed, 1 skipped, 3 xfailed in 72.55s ============

make lint
Lint completed successfully
```

Slides link (`slides/html/`) is generated by GitHub Actions workflow at deploy time.