### PR TITLE
fix: remove dead parser rules from Fortran2023Parser.g4 (fixes #471)

### DIFF
--- a/grammars/src/Fortran2023Parser.g4
+++ b/grammars/src/Fortran2023Parser.g4
@@ -53,24 +53,6 @@ external_subprogram_f2023
     ;
 
 // ============================================================================
-// FORTRAN 2023 SPECIFICATION PART (ISO/IEC 1539-1:2023 Section 8)
-// ============================================================================
-
-// J3/22-007 R504: specification-part
-// F2023 specification part with enhancements
-specification_part_f2023
-    : (specification_item_f2023)*
-    ;
-
-// J3/22-007 R507: declaration-construct
-// F2023 specification items
-specification_item_f2023
-    : enum_def_f2023               // NEW in F2023 (Section 7.8)
-    | type_declaration_stmt_f2023
-    | NEWLINE
-    ;
-
-// ============================================================================
 // ENUMERATION TYPES (ISO/IEC 1539-1:2023 Section 7.8)
 // ============================================================================
 //
@@ -215,14 +197,8 @@ binary_op_f2023
     ;
 
 // ============================================================================
-// EXECUTION PART (ISO/IEC 1539-1:2023 Section 11)
+// EXECUTABLE STATEMENTS (ISO/IEC 1539-1:2023 Section 11, R514)
 // ============================================================================
-
-// J3/22-007 R509: execution-part
-// F2023 execution part with enhancements
-execution_part_f2023
-    : (executable_stmt_f2023)*
-    ;
 
 // J3/22-007 R514: executable-construct (simplified F2023 overlay)
 // F2023 executable statements
@@ -567,12 +543,6 @@ notify_wait_stmt_f2023
 // notify-variable is a coarray variable of type NOTIFY_TYPE
 notify_variable_f2023
     : IDENTIFIER                   // Variable of NOTIFY_TYPE
-    ;
-
-// NOTIFY_TYPE declaration statement
-// ISO/IEC 1539-1:2023 Section 16.5.9: NOTIFY_TYPE derived type
-notify_type_declaration_stmt_f2023
-    : TYPE LPAREN NOTIFY_TYPE RPAREN DOUBLE_COLON entity_decl_list NEWLINE
     ;
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Removed four unused parser rules from Fortran2023Parser.g4 that added maintenance burden without providing functionality.

**Dead code removed:**
- `specification_part_f2023` (never referenced)
- `specification_item_f2023` (never referenced)
- `execution_part_f2023` (never referenced)
- `notify_type_declaration_stmt_f2023` (never referenced)

**What was preserved:**
- `program_unit_f2023` - IS used as entry point in LazyFortran2025Parser.g4

## Verification
- Ran `make test`: All 1114 tests pass with 0 regressions
- F2023 features continue to parse correctly via inherited F2018 rules
- main_program_f2023 correctly inherits from main_program_f2018

## Test Command Output
```
================== 1114 passed, 1 skipped in 73.94s (0:01:13) ==================
✅ All tests completed!
```