### PR TITLE
fix: remove unused DO_CONCURRENT token from Fortran2008Lexer (fixes #470)

### DIFF
--- a/grammars/src/Fortran2008Lexer.g4
+++ b/grammars/src/Fortran2008Lexer.g4
@@ -108,7 +108,6 @@ END_SUBMODULE    : E N D WS+ S U B M O D U L E ;
 // - R818: loop-control -> ... | CONCURRENT concurrent-header
 // - R819: concurrent-header -> (concurrent-spec [, scalar-mask-expr])
 // DO CONCURRENT indicates iterations may execute in any order or concurrently.
-DO_CONCURRENT    : D O '_' C O N C U R R E N T ;
 CONCURRENT       : C O N C U R R E N T ;
 
 // ============================================================================

--- a/tests/Fortran2023/test_fortran_2023_comprehensive.py
+++ b/tests/Fortran2023/test_fortran_2023_comprehensive.py
@@ -705,7 +705,7 @@ class TestFortran2023Foundation:
             # F2003 OOP
             'CLASS', 'EXTENDS', 'PROCEDURE', 'ABSTRACT',
             # F2008 parallel programming
-            'CONCURRENT', 'CONTIGUOUS', 'DO_CONCURRENT',
+            'CONCURRENT', 'CONTIGUOUS',
             # F2018 teams and events
             'CO_SUM', 'SELECT_RANK', 'FORM_TEAM',
             # F2023 enhancements


### PR DESCRIPTION
## Summary
- Removed unused `DO_CONCURRENT` compound token from `Fortran2008Lexer.g4`
- Updated test to remove reference to dead token
- ISO/IEC 1539-1:2010 Section 8.1.6.6 specifies using separate `DO` and `CONCURRENT` tokens, not a compound token

## Verification
```
make test
✅ 1114 passed, 1 skipped in 72.61s
```

All tests pass including:
- Fortran 2008 DO CONCURRENT test fixtures
- Fortran 2023 comprehensive test suite (removed dead token reference)
- Full grammar suite from FORTRAN 1957 through F2023