### PR TITLE
fix: remove unused ENDBLOCK token from Fortran2003Lexer (fixes #469)

### DIFF
--- a/grammars/src/Fortran2003Lexer.g4
+++ b/grammars/src/Fortran2003Lexer.g4
@@ -158,13 +158,16 @@ ASSOCIATE        : A S S O C I A T E ;
 ENDASSOCIATE     : E N D A S S O C I A T E ;
 
 // ====================================================================
-// BLOCK CONSTRUCT (ISO/IEC 1539-1:2004 Section 8.1.4)
+// BLOCK CONSTRUCT (ISO/IEC 1539-1:2010 Section 8.1.4)
 // ====================================================================
 //
-// F2003 introduces BLOCK for local scoping.
+// NOTE: The standalone BLOCK construct was introduced in Fortran 2008
+// (ISO/IEC 1539-1:2010), NOT Fortran 2003. The BLOCK token is inherited
+// for compatibility, but the ENDBLOCK token (which was previously here)
+// has been removed as it is not used (parsers use "END BLOCK" instead).
+// See issue #469 for details.
 
 BLOCK            : B L O C K ;
-ENDBLOCK         : E N D B L O C K ;
 
 // Enhanced WHERE (Section 7.4.3)
 MASKED           : M A S K E D ;


### PR DESCRIPTION
## Summary

Removes the unused `ENDBLOCK` token from `Fortran2003Lexer.g4` that was never consumed by the parser. Both Fortran 2003 and Fortran 2008 parsers correctly use the two-token sequence `END BLOCK` instead of the single-token `ENDBLOCK` keyword.

Additionally corrects the historical record: the BLOCK construct was introduced in **Fortran 2008** (ISO/IEC 1539-1:2010 Section 8.1.4), not Fortran 2003. The BLOCK token remains in the F2003 lexer for compatibility, but the dead-code ENDBLOCK token has been removed.

## Verification

- **Test Results**: All 1114 tests pass
- **No Parser Rules Use ENDBLOCK**: Verified with grep across all parser files
- **Commit**: `fix: remove unused ENDBLOCK token from Fortran2003Lexer (fixes #469)`

## Impact

Dead code cleanup - minimal functional impact. Removes an unused lexer token that has been dead code since issue #442 was resolved.