### PR TITLE
fix: Connect F2018 intrinsics to primary rule (fixes #430)

### DIFF
--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -603,6 +603,25 @@ array_expr
     : expr_f90                       // Array expression
     ;
 
+// ISO/IEC 1539-1:2018 R1023: primary (override to include F2018 intrinsics)
+// Override F2008 primary to include F2018 intrinsic function calls
+primary
+    : identifier_or_keyword (PERCENT identifier_or_keyword)*
+    | identifier_or_keyword LPAREN actual_arg_list? RPAREN
+    | identifier_or_keyword DOUBLE_QUOTE_STRING
+    | identifier_or_keyword SINGLE_QUOTE_STRING
+    | intrinsic_function_call_f2018
+    | ieee_constant
+    | INTEGER_LITERAL
+    | LABEL
+    | REAL_LITERAL
+    | SINGLE_QUOTE_STRING
+    | DOUBLE_QUOTE_STRING
+    | '*'
+    | array_constructor
+    | LPAREN primary RPAREN
+    ;
+
 // ============================================================================
 // UTILITY RULES - Override F2008 rules for F2018 entry points
 // ============================================================================

--- a/tests/Fortran2018/test_issue430_f2018_intrinsics_in_expressions.py
+++ b/tests/Fortran2018/test_issue430_f2018_intrinsics_in_expressions.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Issue #430 - F2018 Intrinsics in Expression Parsing Tests
+
+Tests that F2018 intrinsic function calls can be parsed in expression contexts
+after the primary rule override connects intrinsic_function_call_f2018.
+
+ISO/IEC 1539-1:2018 Section 16.9: Intrinsic procedures
+ISO/IEC 1539-1:2018 R1023: Primary expressions must include function references
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure we can import shared test fixtures utilities
+sys.path.append(str(Path(__file__).parent.parent))
+from fixture_utils import load_fixture
+
+# Add grammars directory to Python path for generated parsers
+sys.path.append(str(Path(__file__).parent.parent.parent / "grammars/generated/modern"))
+
+from antlr4 import *
+from Fortran2018Lexer import Fortran2018Lexer
+from Fortran2018Parser import Fortran2018Parser
+
+
+class TestF2018IntrinsicsInExpressions:
+    """Test F2018 intrinsic function calls in expression contexts"""
+
+    def parse_code(self, code):
+        """Parse F2018 code and return (tree, error_count)"""
+        try:
+            input_stream = InputStream(code)
+            lexer = Fortran2018Lexer(input_stream)
+            parser = Fortran2018Parser(CommonTokenStream(lexer))
+            tree = parser.program_unit_f2018()
+            errors = parser.getNumberOfSyntaxErrors()
+            return tree, errors
+        except Exception as e:
+            return None, 999
+
+    def test_image_status_in_expression(self):
+        """IMAGE_STATUS intrinsic must parse in expressions (ISO 16.9.81)"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "image_status_expression.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "IMAGE_STATUS expression parsing should not crash"
+        assert errors == 0, f"IMAGE_STATUS in expression should parse with 0 errors, got {errors}"
+
+    def test_failed_images_in_expression(self):
+        """FAILED_IMAGES intrinsic must parse in expressions (ISO 16.9.73)"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "failed_images_expression.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "FAILED_IMAGES expression parsing should not crash"
+        assert errors == 0, f"FAILED_IMAGES in expression should parse with 0 errors, got {errors}"
+
+    def test_stopped_images_in_expression(self):
+        """STOPPED_IMAGES intrinsic must parse in expressions (ISO 16.9.182)"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "stopped_images_expression.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "STOPPED_IMAGES expression parsing should not crash"
+        assert errors == 0, f"STOPPED_IMAGES in expression should parse with 0 errors, got {errors}"
+
+    def test_coshape_in_expression(self):
+        """COSHAPE intrinsic must parse in expressions (ISO 16.9.52)"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "coshape_expression.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "COSHAPE expression parsing should not crash"
+        assert errors == 0, f"COSHAPE in expression should parse with 0 errors, got {errors}"
+
+    def test_team_number_in_expression(self):
+        """TEAM_NUMBER intrinsic must parse in expressions (ISO 16.9.187)"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "team_number_expression.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "TEAM_NUMBER expression parsing should not crash"
+        assert errors == 0, f"TEAM_NUMBER in expression should parse with 0 errors, got {errors}"
+
+    def test_out_of_range_in_expression(self):
+        """OUT_OF_RANGE intrinsic must parse in expressions (ISO 16.9.140)"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "out_of_range_expression.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "OUT_OF_RANGE expression parsing should not crash"
+        assert errors == 0, f"OUT_OF_RANGE in expression should parse with 0 errors, got {errors}"
+
+    def test_reduce_in_expression(self):
+        """REDUCE intrinsic must parse in expressions (ISO 16.9.161)"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "reduce_expression.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "REDUCE expression parsing should not crash"
+        assert errors == 0, f"REDUCE in expression should parse with 0 errors, got {errors}"
+
+    def test_combined_f2018_intrinsics_in_expressions(self):
+        """Multiple F2018 intrinsics parse correctly in various expression contexts"""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue430_f2018_intrinsics_in_expressions",
+            "combined_f2018_intrinsics_expressions.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "Combined F2018 intrinsics expression parsing should not crash"
+        assert errors == 0, f"Combined F2018 intrinsics in expressions should parse with 0 errors, got {errors}"

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/combined_f2018_intrinsics_expressions.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/combined_f2018_intrinsics_expressions.f90
@@ -1,0 +1,34 @@
+program test_combined_f2018_intrinsics_expressions
+    ! ISO/IEC 1539-1:2018 Section 16.9: Combined F2018 intrinsic function tests
+    ! Test multiple F2018 intrinsics in various expression contexts
+    implicit none
+
+    integer :: status, img_id, team_id, dim_size, arr_size
+    integer, allocatable :: failed_ids(:), stopped_ids(:)
+    real :: value
+    integer :: ivalue
+    integer :: arr[*]
+
+    img_id = 2
+    value = 1.5e38
+
+    ! All F2018 intrinsics must parse in expression contexts
+    ! (This comprehensive test exercises multiple intrinsics together)
+
+    ! Image status functions in expressions
+    status = IMAGE_STATUS(img_id)
+
+    if (size(FAILED_IMAGES()) > 0 .and. size(STOPPED_IMAGES()) > 0) then
+        print *, "Mixed image status check"
+    end if
+
+    ! Collective functions in expressions
+    team_id = TEAM_NUMBER()
+    dim_size = size(COSHAPE(arr))
+
+    ! Math functions in expressions
+    if (OUT_OF_RANGE(value, ivalue)) then
+        print *, "Numeric range check"
+    end if
+
+end program test_combined_f2018_intrinsics_expressions

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/coshape_expression.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/coshape_expression.f90
@@ -1,0 +1,15 @@
+program test_coshape_expression
+    ! ISO/IEC 1539-1:2018 Section 16.9.52: COSHAPE
+    ! Test COSHAPE intrinsic in expression context
+    implicit none
+    integer :: arr[*]
+    integer, allocatable :: shape_result(:)
+
+    ! COSHAPE must parse as primary in expression
+    shape_result = COSHAPE(arr)
+
+    if (size(COSHAPE(arr)) > 0) then
+        print *, "Coarray shape determined"
+    end if
+
+end program test_coshape_expression

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/failed_images_expression.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/failed_images_expression.f90
@@ -1,0 +1,14 @@
+program test_failed_images_expression
+    ! ISO/IEC 1539-1:2018 Section 16.9.73: FAILED_IMAGES
+    ! Test FAILED_IMAGES intrinsic in expression context
+    implicit none
+    integer, allocatable :: failed_ids(:)
+
+    ! FAILED_IMAGES must parse as primary in expression
+    failed_ids = FAILED_IMAGES()
+
+    if (size(FAILED_IMAGES()) > 0) then
+        print *, "Some images have failed"
+    end if
+
+end program test_failed_images_expression

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/image_status_expression.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/image_status_expression.f90
@@ -1,0 +1,16 @@
+program test_image_status_expression
+    ! ISO/IEC 1539-1:2018 Section 16.9.81: IMAGE_STATUS
+    ! Test IMAGE_STATUS intrinsic in expression context
+    implicit none
+    integer :: status, img_id
+
+    img_id = 2
+
+    ! IMAGE_STATUS must parse as primary in expression
+    status = IMAGE_STATUS(img_id)
+
+    if (IMAGE_STATUS(img_id) == 0) then
+        print *, "Image is executing"
+    end if
+
+end program test_image_status_expression

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/out_of_range_expression.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/out_of_range_expression.f90
@@ -1,0 +1,15 @@
+program test_out_of_range_expression
+    ! ISO/IEC 1539-1:2018 Section 16.9.140: OUT_OF_RANGE
+    ! Test OUT_OF_RANGE intrinsic in expression context
+    implicit none
+    real :: value
+    integer :: ivalue
+
+    value = 1.5e38
+
+    ! OUT_OF_RANGE must parse as primary in expression
+    if (OUT_OF_RANGE(value, ivalue)) then
+        print *, "Value is out of range for integer"
+    end if
+
+end program test_out_of_range_expression

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/reduce_expression.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/reduce_expression.f90
@@ -1,0 +1,13 @@
+program test_reduce_expression
+    ! ISO/IEC 1539-1:2018 Section 16.9.161: REDUCE
+    ! Test REDUCE intrinsic in expression context
+    implicit none
+    integer :: arr(10), result_val
+
+    arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    ! REDUCE must parse as primary in expression (with operation_spec)
+    ! Note: REDUCE requires operation-spec which is part of the grammar
+    result_val = REDUCE(arr, my_add_op)
+
+end program test_reduce_expression

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/stopped_images_expression.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/stopped_images_expression.f90
@@ -1,0 +1,14 @@
+program test_stopped_images_expression
+    ! ISO/IEC 1539-1:2018 Section 16.9.182: STOPPED_IMAGES
+    ! Test STOPPED_IMAGES intrinsic in expression context
+    implicit none
+    integer, allocatable :: stopped_ids(:)
+
+    ! STOPPED_IMAGES must parse as primary in expression
+    stopped_ids = STOPPED_IMAGES()
+
+    if (size(STOPPED_IMAGES()) > 0) then
+        print *, "Some images have stopped"
+    end if
+
+end program test_stopped_images_expression

--- a/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/team_number_expression.f90
+++ b/tests/fixtures/Fortran2018/test_issue430_f2018_intrinsics_in_expressions/team_number_expression.f90
@@ -1,0 +1,14 @@
+program test_team_number_expression
+    ! ISO/IEC 1539-1:2018 Section 16.9.187: TEAM_NUMBER
+    ! Test TEAM_NUMBER intrinsic in expression context
+    implicit none
+    integer :: team_id
+
+    ! TEAM_NUMBER must parse as primary in expression
+    team_id = TEAM_NUMBER()
+
+    if (TEAM_NUMBER() == 1) then
+        print *, "Running on team 1"
+    end if
+
+end program test_team_number_expression


### PR DESCRIPTION
## Summary

Fix issue #430: Fortran 2018 intrinsic function calls were unparseable in expression contexts because the `intrinsic_function_call_f2018` rule was never connected to the expression parsing hierarchy.

- **Root cause**: F2018 grammar defined `intrinsic_function_call_f2018` with all new F2018 intrinsics but the rule was never wired into the `primary` rule, making ALL F2018 intrinsics inaccessible in expressions
- **Solution**: Add `primary` rule override to `Fortran2018Parser.g4` that includes `intrinsic_function_call_f2018`
- **Impact**: All F2018 intrinsic functions now properly parse in expression contexts per ISO/IEC 1539-1:2018 R1023

## Implementation Details

- Override `primary` rule in Fortran2018Parser.g4 to include `intrinsic_function_call_f2018`
- Follows exact same structure as F2008's `primary` rule override (grammars/src/Fortran2008Parser.g4:856)

## Test Coverage

- Added 8 comprehensive test cases covering all F2018 intrinsic functions:
  - IMAGE_STATUS (ISO 16.9.81)
  - FAILED_IMAGES (ISO 16.9.73)
  - STOPPED_IMAGES (ISO 16.9.182)
  - COSHAPE (ISO 16.9.52)
  - TEAM_NUMBER (ISO 16.9.187)
  - OUT_OF_RANGE (ISO 16.9.140)
  - REDUCE (ISO 16.9.161)
  - Combined intrinsics in mixed expression contexts

## Verification

```bash
$ python -m pytest tests/Fortran2018/test_issue430_f2018_intrinsics_in_expressions.py -v
======================== 8 passed in 3.00s =========================

$ python -m pytest tests/Fortran2018/ -v
======================== 132 passed in 11.51s ========================
```

All F2018 tests pass, confirming no regressions were introduced.