### PR TITLE
fix: Implement IS_CONTIGUOUS intrinsic inquiry function in Fortran 2008 (fixes #452)

### DIFF
--- a/grammars/src/Fortran2008Lexer.g4
+++ b/grammars/src/Fortran2008Lexer.g4
@@ -173,6 +173,10 @@ FINDLOC          : F I N D L O C ;
 // - STORAGE_SIZE(A[,KIND]): Storage size in bits (Section 13.7.163)
 STORAGE_SIZE     : S T O R A G E '_' S I Z E ;
 
+// Array contiguity inquiry function (Section 13.7.87)
+// - IS_CONTIGUOUS(ARRAY): Inquire if array is contiguous in memory (Section 13.7.87)
+IS_CONTIGUOUS    : I S '_' C O N T I G U O U S ;
+
 // Bit shift intrinsics (Section 13.7.158-13.7.160)
 // - SHIFTA(I,SHIFT): Arithmetic right shift (Section 13.7.158)
 // - SHIFTL(I,SHIFT): Logical left shift (Section 13.7.159)

--- a/grammars/src/Fortran2008Parser.g4
+++ b/grammars/src/Fortran2008Parser.g4
@@ -791,9 +791,10 @@ array_function_call
 // Image inquiry function calls (ISO/IEC 1539-1:2010 Section 13.7)
 // Coarray image inquiry and storage inquiry
 image_function_call
-    : THIS_IMAGE LPAREN actual_arg_list? RPAREN  // Section 13.7.165
-    | NUM_IMAGES LPAREN actual_arg_list? RPAREN  // Section 13.7.121
-    | STORAGE_SIZE LPAREN actual_arg_list RPAREN // Section 13.7.163
+    : THIS_IMAGE LPAREN actual_arg_list? RPAREN      // Section 13.7.165
+    | NUM_IMAGES LPAREN actual_arg_list? RPAREN      // Section 13.7.121
+    | STORAGE_SIZE LPAREN actual_arg_list RPAREN     // Section 13.7.163
+    | IS_CONTIGUOUS LPAREN actual_arg_list RPAREN    // Section 13.7.87
     ;
 
 // Compiler inquiry function calls (ISO/IEC 1539-1:2010 Section 13.7.41-42)

--- a/tests/fixtures/Fortran2008/test_basic_f2008_features/is_contiguous_inquiry.f90
+++ b/tests/fixtures/Fortran2008/test_basic_f2008_features/is_contiguous_inquiry.f90
@@ -1,0 +1,43 @@
+program test_is_contiguous
+    implicit none
+
+    ! Test 1: Contiguous target array
+    real, target :: target_array(100)
+    real, pointer :: ptr_contiguous(:)
+    integer :: i
+
+    ! Initialize array with simple loop
+    do i = 1, 100
+        target_array(i) = real(i)
+    end do
+
+    ! Test contiguous pointer association
+    ptr_contiguous => target_array
+    if (is_contiguous(ptr_contiguous)) then
+        print *, "Test 1 PASS: Contiguous pointer detected"
+    else
+        print *, "Test 1 FAIL: Should be contiguous"
+    end if
+
+    ! Test intrinsic is_contiguous in logical expressions
+    if (is_contiguous(target_array)) then
+        print *, "Test 2 PASS: Target array is contiguous"
+    else
+        print *, "Test 2 FAIL: Target should be contiguous"
+    end if
+
+    call test_assumed_shape(target_array)
+
+contains
+
+    subroutine test_assumed_shape(arr)
+        real, intent(in) :: arr(:)
+
+        if (is_contiguous(arr)) then
+            print *, "Test assumed-shape: Array is contiguous"
+        else
+            print *, "Test assumed-shape: Array is NOT contiguous"
+        end if
+    end subroutine test_assumed_shape
+
+end program test_is_contiguous


### PR DESCRIPTION
## Summary

Implements the IS_CONTIGUOUS intrinsic inquiry function per ISO/IEC 1539-1:2010 Section 13.7.87.

IS_CONTIGUOUS(ARRAY) returns a logical value indicating whether ARRAY occupies a contiguous block of memory. This is essential for runtime verification of memory layout, particularly important for:
- Performance-sensitive code requiring contiguous memory
- C interoperability checks
- Pointer safety validation with assumed-shape dummy arguments

## Implementation

- Added IS_CONTIGUOUS token to Fortran2008Lexer.g4 (line 176-178)
- Added IS_CONTIGUOUS to image_function_call rule in Fortran2008Parser.g4 (line 797)
- Created comprehensive test fixture demonstrating usage patterns

## Verification

- All 1152 tests pass
- New test fixture exercises IS_CONTIGUOUS with:
  - Contiguous pointer associations
  - Contiguous target arrays
  - Assumed-shape dummy arguments

## Test Results

================== 1152 passed, 1 skipped in 76.87s (0:01:16) ==================

ISO/IEC 1539-1:2010 Compliance: STANDARD-COMPLIANT - Fully implements Section 13.7.87 specification.