### PR TITLE
fix: Implement NON_INTRINSIC module nature in F2003 USE statement (fixes #444)

### DIFF
--- a/docs/fortran_2003_audit.md
+++ b/docs/fortran_2003_audit.md
@@ -474,10 +474,13 @@ Grammar implementation:
   - `binding_spec` accepts `BIND(C)` and
     `BIND(C, NAME="...")` for procedures.
   - `type_attr_spec` supports `BIND(C)` for derived types.
-  - `use_stmt` recognizes `USE, INTRINSIC :: IEEE_EXCEPTIONS /
-    IEEE_ARITHMETIC / IEEE_FEATURES` with a dedicated `ieee_only_list`
-    (`ieee_entity` rule) that includes exception types, special values,
-    rounding modes, feature names, and generic identifiers.
+  - `use_stmt` recognizes (ISO/IEC 1539-1:2004 R1109-R1110):
+    - `USE, INTRINSIC :: IEEE_EXCEPTIONS / IEEE_ARITHMETIC / IEEE_FEATURES`
+      with a dedicated `ieee_only_list` (`ieee_entity` rule) that includes
+      exception types, special values, rounding modes, feature names, and
+      generic identifiers.
+    - `USE, NON_INTRINSIC :: module-name` (both plain and with ONLY clause)
+      for explicit user-defined module selection.
   - `c_interop_type` lists all the C interop types for use in IMPORT
     and declarations.
   - `ieee_constant`, `ieee_function_call`, `intrinsic_function_call`
@@ -496,6 +499,11 @@ Tests:
   - `test_issue27_ieee_arithmetic.py` exercises:
     - USE of IEEE intrinsic modules and ONLY lists.
     - Selected IEEE constants and inquiry/value functions in expressions.
+- Module nature (R1110):
+  - `test_issue444_non_intrinsic.py` (added in fix #444) exercises:
+    - NON_INTRINSIC with user-defined modules.
+    - NON_INTRINSIC with ONLY clause for selective imports.
+    - Mixing INTRINSIC and NON_INTRINSIC in same program.
 
 Gaps:
 

--- a/grammars/src/Fortran2003Lexer.g4
+++ b/grammars/src/Fortran2003Lexer.g4
@@ -180,6 +180,16 @@ BLOCK            : B L O C K ;
 IMPORT           : I M P O R T ;
 
 // ====================================================================
+// USE STATEMENT MODULE NATURE (ISO/IEC 1539-1:2004 Section 11.2.1)
+// ====================================================================
+//
+// F2003 introduces module-nature specifiers (R1110) for USE statements:
+// - INTRINSIC: marks a module as intrinsic (e.g., IEEE modules)
+// - NON_INTRINSIC: explicitly marks a module as user-defined
+
+NON_INTRINSIC    : N O N '_' I N T R I N S I C ;
+
+// ====================================================================
 // VOLATILE AND PROTECTED (ISO/IEC 1539-1:2004 Section 5.1.2)
 // ====================================================================
 //

--- a/grammars/src/Fortran2003Parser.g4
+++ b/grammars/src/Fortran2003Parser.g4
@@ -1298,6 +1298,9 @@ use_stmt
     | USE COMMA INTRINSIC DOUBLE_COLON ieee_module_name NEWLINE
     | USE COMMA INTRINSIC DOUBLE_COLON ieee_module_name COMMA
       ONLY COLON ieee_only_list NEWLINE
+    | USE COMMA NON_INTRINSIC DOUBLE_COLON IDENTIFIER NEWLINE
+    | USE COMMA NON_INTRINSIC DOUBLE_COLON IDENTIFIER COMMA
+      ONLY COLON only_list NEWLINE
     ;
 
 // ====================================================================

--- a/tests/Fortran2003/test_issue444_non_intrinsic.py
+++ b/tests/Fortran2003/test_issue444_non_intrinsic.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Test suite for Fortran 2003 NON_INTRINSIC module nature (Issue #444).
+Verifies that USE statements with NON_INTRINSIC keyword parse correctly.
+
+Reference: ISO/IEC 1539-1:2004 Section 11.2.1 (R1109, R1110)
+- R1109: use-stmt
+- R1110: module-nature -> INTRINSIC | NON_INTRINSIC
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure we can import shared test fixtures utilities
+sys.path.append(str(Path(__file__).parent.parent))
+from fixture_utils import load_fixture
+
+# Add grammars directory to path
+sys.path.append(str(Path(__file__).parent.parent.parent / "grammars/generated/modern"))
+
+from antlr4 import *
+
+class TestIssue444NonIntrinsic:
+    """Test NON_INTRINSIC module nature in USE statements."""
+
+    def parse_fortran_code(self, code, expect_success=True):
+        """Helper to parse Fortran 2003 code."""
+        try:
+            from Fortran2003Lexer import Fortran2003Lexer
+            from Fortran2003Parser import Fortran2003Parser
+
+            input_stream = InputStream(code)
+            lexer = Fortran2003Lexer(input_stream)
+            parser = Fortran2003Parser(CommonTokenStream(lexer))
+
+            tree = parser.program_unit_f2003()
+            errors = parser.getNumberOfSyntaxErrors()
+
+            if expect_success:
+                assert errors == 0, f"Parse failed with {errors} errors"
+
+            return tree, errors, None
+
+        except Exception as e:
+            if expect_success:
+                assert False, f"Exception during parsing: {e}"
+            return None, -1, str(e)
+
+    def test_non_intrinsic_basic(self):
+        """Test basic NON_INTRINSIC USE statement (ISO/IEC 1539-1:2004 R1110)."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue444_non_intrinsic_module_nature",
+            "non_intrinsic_basic.f90",
+        )
+        self.parse_fortran_code(code)
+
+    def test_non_intrinsic_with_only(self):
+        """Test NON_INTRINSIC with ONLY clause (ISO/IEC 1539-1:2004 R1109)."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue444_non_intrinsic_module_nature",
+            "non_intrinsic_with_only.f90",
+        )
+        self.parse_fortran_code(code)
+
+    def test_mixed_module_natures(self):
+        """Test mixing INTRINSIC and NON_INTRINSIC in same program."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue444_non_intrinsic_module_nature",
+            "mixed_module_natures.f90",
+        )
+        self.parse_fortran_code(code)
+
+    def test_non_intrinsic_direct_code(self):
+        """Test NON_INTRINSIC with inline Fortran code."""
+        code = """program test
+    use, non_intrinsic :: my_mod
+    implicit none
+    print *, "Hello"
+end program test
+        """
+        self.parse_fortran_code(code)
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])

--- a/tests/fixtures/Fortran2003/test_issue444_non_intrinsic_module_nature/mixed_module_natures.f90
+++ b/tests/fixtures/Fortran2003/test_issue444_non_intrinsic_module_nature/mixed_module_natures.f90
@@ -1,0 +1,17 @@
+! Test mixing INTRINSIC and NON_INTRINSIC modules (ISO/IEC 1539-1:2004 R1110)
+! Same program uses both intrinsic and user-defined modules with explicit module nature
+
+module user_module
+    implicit none
+    integer, parameter :: MY_CONSTANT = 42
+end module user_module
+
+program test_mixed_natures
+    use, intrinsic :: iso_c_binding, only: c_int, c_ptr
+    use, non_intrinsic :: user_module, only: MY_CONSTANT
+    implicit none
+
+    integer(c_int) :: c_value
+    c_value = MY_CONSTANT
+    print *, "C interop value: ", c_value
+end program test_mixed_natures

--- a/tests/fixtures/Fortran2003/test_issue444_non_intrinsic_module_nature/non_intrinsic_basic.f90
+++ b/tests/fixtures/Fortran2003/test_issue444_non_intrinsic_module_nature/non_intrinsic_basic.f90
@@ -1,0 +1,17 @@
+! Test Fortran 2003 NON_INTRINSIC module nature (ISO/IEC 1539-1:2004 R1110)
+! Basic NON_INTRINSIC usage with a user-defined module
+
+module my_utilities
+    implicit none
+    integer, parameter :: pi_approx = 314
+contains
+    subroutine print_pi()
+        print *, "Pi approximation: ", pi_approx / 100.0
+    end subroutine print_pi
+end module my_utilities
+
+program test_non_intrinsic_basic
+    use, non_intrinsic :: my_utilities
+    implicit none
+    call print_pi()
+end program test_non_intrinsic_basic

--- a/tests/fixtures/Fortran2003/test_issue444_non_intrinsic_module_nature/non_intrinsic_with_only.f90
+++ b/tests/fixtures/Fortran2003/test_issue444_non_intrinsic_module_nature/non_intrinsic_with_only.f90
@@ -1,0 +1,23 @@
+! Test Fortran 2003 NON_INTRINSIC with ONLY clause (ISO/IEC 1539-1:2004 R1109)
+! NON_INTRINSIC restricts import to specific entities
+
+module math_lib
+    implicit none
+    real, parameter :: euler = 2.71828
+    real, parameter :: sqrt2 = 1.41421
+contains
+    function square(x) result(y)
+        real, intent(in) :: x
+        real :: y
+        y = x * x
+    end function square
+end module math_lib
+
+program test_non_intrinsic_only
+    use, non_intrinsic :: math_lib, only: euler, square
+    implicit none
+    real :: result
+    result = square(3.0)
+    print *, "e = ", euler
+    print *, "square(3) = ", result
+end program test_non_intrinsic_only


### PR DESCRIPTION
## Summary

Implements R1110 (module-nature) specification from ISO/IEC 1539-1:2004 Section 11.2.1.

The F2003 grammar now supports explicit NON_INTRINSIC module nature in USE statements, allowing programs to distinguish between intrinsic (IEEE) and user-defined modules.

## Implementation Details

**Lexer Changes:**
- Added NON_INTRINSIC token to Fortran2003Lexer.g4 (line 190)
- Token inherits from F77 chain but is specific to F2003+ module nature syntax

**Parser Changes:**
- Extended use_stmt rule to accept two new alternatives:
  - `USE, NON_INTRINSIC :: module-name`
  - `USE, NON_INTRINSIC :: module-name, ONLY: only-list`
- Complements existing INTRINSIC support for IEEE modules

**Test Coverage:**
- `test_non_intrinsic_basic`: Basic NON_INTRINSIC with user module
- `test_non_intrinsic_with_only`: NON_INTRINSIC with ONLY clause
- `test_mixed_module_natures`: Same program using both INTRINSIC and NON_INTRINSIC
- `test_non_intrinsic_direct_code`: Inline code parsing

## Verification

All tests pass:
- 4 new NON_INTRINSIC-specific tests: ✅
- Full test suite: 1169 passed, 1 skipped ✅
- Code compliance (88-column limit): ✅

## ISO Standard Compliance

**ISO/IEC 1539-1:2004 Section 11.2.1**
- R1109: use-stmt → USE [[, module-nature] ::] module-name [, rename-list]
- R1110: module-nature → INTRINSIC | NON_INTRINSIC

This implementation correctly handles:
- Module nature specification with :: token
- Both INTRINSIC and NON_INTRINSIC keywords
- Combination with ONLY clause for selective imports