### PR TITLE
fix: Remove unused ELSEIF token in FORTRAN77Lexer (fixes #445)

### DIFF
--- a/grammars/src/FORTRAN77Lexer.g4
+++ b/grammars/src/FORTRAN77Lexer.g4
@@ -77,7 +77,6 @@ CHARACTER       : C H A R A C T E R ;
 // - END IF statement (Section 11.9): END IF
 THEN            : T H E N ;
 ELSE            : E L S E ;
-ELSEIF          : E L S E I F ;
 ENDIF           : E N D I F ;
 
 // --------------------------------------------------------------------
@@ -167,7 +166,7 @@ STRING_LITERAL  : '\'' (~'\'' | '\'\'')* '\'' ;
 //   - Section 9.1: DATA statement -> DATA token
 //
 // Section 11 (Control Statements):
-//   - Section 11.6-11.9: Block IF -> THEN, ELSE, ELSEIF, ENDIF tokens
+//   - Section 11.6-11.9: Block IF -> THEN, ELSE, ENDIF tokens (ELSE IF is two tokens)
 //
 // Section 12 (I/O Statements):
 //   - Section 12.10.1: OPEN statement -> OPEN token

--- a/tests/fixtures/FORTRAN77/test_fortran77_parser/block_if_construct.f
+++ b/tests/fixtures/FORTRAN77/test_fortran77_parser/block_if_construct.f
@@ -1,0 +1,54 @@
+      PROGRAM TESTBLKIF
+      INTEGER X, Y
+      REAL R
+
+      X = 5
+      Y = 0
+      R = 0.0
+
+      IF (X .GT. 0) THEN
+          Y = 1
+      END IF
+
+      IF (X .GT. 10) THEN
+          Y = 2
+      ELSE
+          Y = 3
+      END IF
+
+      IF (X .LT. 0) THEN
+          PRINT *, 'NEGATIVE'
+      ELSE IF (X .EQ. 0) THEN
+          PRINT *, 'ZERO'
+      ELSE IF (X .GT. 10) THEN
+          PRINT *, 'LARGE'
+      ELSE
+          PRINT *, 'SMALL POSITIVE'
+      END IF
+
+      IF (X .GT. 0) THEN
+          IF (X .GT. 10) THEN
+              Y = 100
+          ELSE
+              Y = 50
+          END IF
+      END IF
+
+      IF (X .LT. 0) THEN
+          IF (R .LT. 0.0) THEN
+              PRINT *, 'BOTH NEGATIVE'
+          ELSE
+              PRINT *, 'X NEG, R POS'
+          END IF
+      ELSE IF (X .EQ. 0) THEN
+          PRINT *, 'X IS ZERO'
+      ELSE
+          IF (R .GT. 0.0) THEN
+              PRINT *, 'BOTH POSITIVE'
+          ELSE
+              PRINT *, 'X POS, R NOT POSITIVE'
+          END IF
+      END IF
+
+      STOP
+      END


### PR DESCRIPTION
## Summary

Removes the unused ELSEIF token from the FORTRAN77 lexer to achieve ISO/IEC 1539:1980 compliance. Per Section 11.7, ELSE IF is defined as two separate keywords, not one.

## Changes

- **Removed unused ELSEIF token** from FORTRAN77Lexer.g4 (line 80)
- **Updated lexer documentation** to clarify that ELSE IF consists of two tokens
- **Added comprehensive test fixture** (block_if_construct.f) covering:
  - Simple IF-THEN-END IF
  - IF-THEN-ELSE-END IF
  - IF-THEN with multiple ELSE IF and ELSE clauses
  - Nested IF constructs
  - Complex nested structures with ELSE IF

## Verification

All 1176 tests pass locally:
- FORTRAN77 parser tests: 36 passed
- FORTRAN77 fixture tests: 6 passed
- Full test suite: 1176 passed, 1 skipped

**Commands executed:**
```bash
make FORTRAN77       # Build grammar
pytest tests/FORTRAN77/ -v  # Run FORTRAN77 tests (36 passed)
make test            # Full test suite (1176 passed)
```

## ISO Standard Compliance

**Standard:** ISO/IEC 1539:1980 Section 11.7
**Issue:** Lexer-parser mismatch where lexer tokenizes as single ELSEIF but parser expects two tokens (ELSE IF)
**Resolution:** Remove single-word ELSEIF token, ensuring parser uses standard-compliant two-token form
**Status:** STANDARD-COMPLIANT after fix

## Related Issue

Fixes #445: "FORTRAN 77: Unused ELSEIF token in lexer while parser uses ELSE IF"