### PR TITLE
fix: Implement ASSOCIATED intrinsic in Fortran 90 grammar (fixes #438)

### DIFF
--- a/grammars/src/F90ExprsParser.g4
+++ b/grammars/src/F90ExprsParser.g4
@@ -63,6 +63,7 @@ intrinsic_function_f90
     | LBOUND LPAREN actual_arg_spec_list RPAREN       // LBOUND array intrinsic
     | UBOUND LPAREN actual_arg_spec_list RPAREN       // UBOUND array intrinsic
     | ALLOCATED LPAREN variable_f90 RPAREN            // ALLOCATED status
+    | ASSOCIATED LPAREN actual_arg_spec_list RPAREN   // ASSOCIATED pointer status
     | PRESENT LPAREN IDENTIFIER RPAREN                // PRESENT argument check
     | SELECTED_REAL_KIND LPAREN actual_arg_spec_list RPAREN
     | SELECTED_INT_KIND LPAREN actual_arg_spec_list RPAREN

--- a/tests/Fortran90/test_fortran_90_comprehensive.py
+++ b/tests/Fortran90/test_fortran_90_comprehensive.py
@@ -602,6 +602,29 @@ end program
         except Exception as e:
             pytest.fail(f"F90 IMPLICIT spec-list parsing failed: {e}")
 
+    def test_associated_intrinsic_parsing(self):
+        """Test ASSOCIATED intrinsic function parsing per ISO/IEC 1539:1991 Section 13.8.6.
+
+        ISO/IEC 1539:1991 Section 13.8.6 defines ASSOCIATED intrinsic:
+        - ASSOCIATED(POINTER) - returns .TRUE. if pointer is associated
+        - ASSOCIATED(POINTER, TARGET) - returns .TRUE. if pointer is associated with target
+
+        This tests both 1-argument and 2-argument forms of ASSOCIATED.
+        """
+        code = load_fixture(
+            "Fortran90",
+            "test_fortran_90_comprehensive",
+            "associated_intrinsic.f90",
+        )
+
+        parser = self.create_parser(code)
+
+        try:
+            tree = parser.program_unit_f90()
+            assert tree is not None
+        except Exception as e:
+            pytest.fail(f"F90 ASSOCIATED intrinsic parsing failed: {e}")
+
 
 class TestFortran90Foundation:
     """Test F90 as foundation for modern Fortran standards chain."""

--- a/tests/fixtures/Fortran90/test_fortran_90_comprehensive/associated_intrinsic.f90
+++ b/tests/fixtures/Fortran90/test_fortran_90_comprehensive/associated_intrinsic.f90
@@ -1,0 +1,35 @@
+program test_associated
+    ! Test ASSOCIATED intrinsic function per ISO/IEC 1539:1991 Section 13.8.6
+    ! ASSOCIATED(POINTER [, TARGET]) - Pointer association status inquiry
+
+    integer, pointer :: ptr1
+    integer, pointer :: ptr2
+    integer, target :: target_var
+    logical :: is_associated
+
+    ! Initialize pointers to null
+    nullify(ptr1)
+    nullify(ptr2)
+
+    ! Test 1: ASSOCIATED with 1 argument - checks if pointer is associated
+    is_associated = associated(ptr1)
+
+    ! Test 2: ASSOCIATED with 2 arguments - checks if pointer is associated with target
+    target_var = 42
+    ptr2 => target_var
+    is_associated = associated(ptr2, target_var)
+
+    ! Test 3: ASSOCIATED in IF statement - common usage pattern
+    if (associated(ptr2)) then
+        print *, "Pointer is associated"
+    end if
+
+    ! Test 4: ASSOCIATED in expression
+    if (.not. associated(ptr1) .and. associated(ptr2)) then
+        print *, "ptr1 is null but ptr2 is associated"
+    end if
+
+    ! Test 5: Multiple ASSOCIATED calls in same statement
+    is_associated = associated(ptr1) .or. associated(ptr2, target_var)
+
+end program test_associated


### PR DESCRIPTION
## Summary

Implements the ASSOCIATED intrinsic function in Fortran 90 grammar per ISO/IEC 1539:1991 Section 13.8.6. The ASSOCIATED token was defined in the lexer but never wired into the parser, preventing pointer association status queries.

## Problem

Fortran 90 pointer code using ASSOCIATED fails to parse:
- `IF (ASSOCIATED(ptr)) THEN` - pointer is associated check fails
- `IF (ASSOCIATED(ptr, target)) THEN` - pointer targets specific variable fails

## Solution

- Add ASSOCIATED to `intrinsic_function_f90` rule in F90ExprsParser.g4
- Support both 1-argument and 2-argument forms (per ISO standard)
- Integrate pointer status inquiry with existing intrinsic function infrastructure

## Verification

### Commands Run
```bash
make test
```

### Test Results
✅ All 1178 tests pass, 1 skipped
- New test: `test_associated_intrinsic_parsing` covers both ASSOCIATED forms
- Fixture: `associated_intrinsic.f90` tests multiple usage patterns
- No regressions in existing tests

### Compliance
- **ISO/IEC 1539:1991 Section 13.8.6**: STANDARD-COMPLIANT
  - Implements full ASSOCIATED intrinsic specification
  - Supports 1-arg form: pointer association status
  - Supports 2-arg form: pointer-target association
- Code formatting: 88-column compliant per CLAUDE.md

### Test Coverage
New fixture exercises:
1. 1-argument form: `associated(ptr1)`
2. 2-argument form: `associated(ptr2, target_var)`
3. IF statement pattern: `if (associated(ptr2)) then`
4. Logical expressions: `.not. associated(ptr1) .and. associated(ptr2)`
5. Multiple calls: `associated(ptr1) .or. associated(ptr2, target_var)`

## Files Changed
- `grammars/src/F90ExprsParser.g4`: Added ASSOCIATED to intrinsic_function_f90 rule
- `tests/Fortran90/test_fortran_90_comprehensive.py`: Added test_associated_intrinsic_parsing
- `tests/fixtures/Fortran90/test_fortran_90_comprehensive/associated_intrinsic.f90`: New test fixture