### PR TITLE
fix: Remove unused lexer tokens from Fortran2018Lexer (fixes #434)

### DIFF
--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -152,9 +152,9 @@ Specification:
 Grammar implementation:
 
 - Lexer:
-  - Tokens `SELECT_RANK`, `RANK_STAR`, `RANK_DEFAULT`, and `RANK_KEYWORD`
-    exist, but the parser uses the general `RANK_KEYWORD` token and the
-    existing `DEFAULT` token rather than the “underscored” variants.
+  - Token `SELECT_RANK` and `RANK_KEYWORD` are defined and used.
+  - Note: Dead tokens `RANK_STAR` and `RANK_DEFAULT` were removed in issue #434
+    (these were never used in the parser).
 - Parser:
   - `select_rank_construct`:
     - `select_rank_stmt rank_construct* end_select_rank_stmt`.
@@ -177,11 +177,6 @@ Tests:
 
 Gaps:
 
-- The grammar doesn’t use the underscored `SELECT_RANK`, `RANK_STAR`,
-  or `RANK_DEFAULT` tokens; instead it relies on the keyword `RANK` and
-  `DEFAULT`. This is consistent with the actual Fortran syntax (e.g.
-  `SELECT RANK (a)`, `RANK (n)`, `RANK DEFAULT`), but the extra tokens
-  are not used and are effectively redundant.
 - Semantic requirements (e.g., selector must be assumed‑rank, constant
   rank selectors) are not encoded; these must be handled by semantic
   analysis.
@@ -686,3 +681,14 @@ syntax rules to grammar rules in `Fortran2018Lexer.g4` and `Fortran2018Parser.g4
 | Section 16.9.187 | TEAM_NUMBER | `TEAM_NUMBER` |
 | R1178 | NEW_INDEX | `NEW_INDEX` |
 | R1173 | UNTIL_COUNT | `UNTIL_COUNT` |
+
+### A.12 Dead Token Cleanup (Issue #434)
+
+The following tokens were removed as dead code in issue #434:
+- `RANK_STAR` and `RANK_DEFAULT`: R1150 select-rank-case-stmt uses MULTIPLY (*) and
+  DEFAULT keywords instead of compound tokens.
+- `ASSUMED_RANK`: R825 assumed-rank-spec uses DOT_DOT (..) syntax, not ASSUMED_RANK keyword.
+- `LOCALITY`: Grammar rule name, not a keyword. Actual keywords are LOCAL, LOCAL_INIT, SHARED.
+- `DEFAULT_ACCESS`: Not in ISO standard. F2018 uses DEFAULT with PUBLIC/PRIVATE keywords.
+
+All 5 tokens had zero references in Fortran2018Parser.g4, confirming they were unused.

--- a/grammars/src/Fortran2018Lexer.g4
+++ b/grammars/src/Fortran2018Lexer.g4
@@ -49,10 +49,10 @@ IMAGE_STATUS_STOPPED   : I M A G E '_' S T A T U S '_' S T O P P E D ;
 // ISO/IEC 1539-1:2018 Section 11.1.10: SELECT RANK construct
 // ISO/IEC 1539-1:2018 R1148-R1151: select-rank-construct, select-rank-stmt,
 // select-rank-case-stmt, end-select-rank-stmt
+// Note: RANK (*) and RANK DEFAULT use keyword tokens, not compound tokens
+// See Fortran2018Parser.g4 rank_case_stmt rule
 // ----------------------------------------------------------------------------
 SELECT_RANK      : S E L E C T '_' R A N K ;
-RANK_STAR        : R A N K '_' S T A R ;
-RANK_DEFAULT     : R A N K '_' D E F A U L T ;
 
 // ----------------------------------------------------------------------------
 // Random Initialization (NEW in F2018)
@@ -105,15 +105,15 @@ EVENT_QUERY      : E V E N T WS+ Q U E R Y ;
 // Assumed Rank Support (NEW in F2018)
 // ISO/IEC 1539-1:2018 Section 8.5.8.7: Assumed-rank entity
 // ISO/IEC 1539-1:2018 R825: assumed-rank-spec is ..
+// Note: Parser uses DOT_DOT (..) syntax, not ASSUMED_RANK keyword
+// See Fortran2018Parser.g4 assumed_rank_declaration rule
 // ----------------------------------------------------------------------------
-ASSUMED_RANK     : A S S U M E D '_' R A N K ;
 RANK_KEYWORD     : R A N K ;
 
 // ----------------------------------------------------------------------------
-// Default Accessibility (NEW in F2018)
-// ISO/IEC 1539-1:2018 Section 8.6: Attribute statements and specifications
-// ----------------------------------------------------------------------------
-DEFAULT_ACCESS   : D E F A U L T '_' A C C E S S ;
+// NOTE: DEFAULT_ACCESS was previously defined but NOT in ISO standard
+// F2018 uses DEFAULT keyword with PUBLIC/PRIVATE, not DEFAULT_ACCESS token
+// Token removed during dead code cleanup (issue #434)
 
 // ----------------------------------------------------------------------------
 // C Descriptor Support (NEW in F2018)
@@ -137,8 +137,9 @@ QUIET            : Q U I E T ;
 // Locality Specifier (NEW in F2018)
 // ISO/IEC 1539-1:2018 Section 11.1.7.5: Additional semantics for DO CONCURRENT
 // ISO/IEC 1539-1:2018 R1129: concurrent-locality, R1130 locality-spec
+// Note: LOCALITY is a grammar rule name, not a keyword (use LOCAL, LOCAL_INIT)
+// See Fortran2018Parser.g4 concurrent_locality rule
 // ----------------------------------------------------------------------------
-LOCALITY         : L O C A L I T Y ;
 LOCAL_INIT       : L O C A L '_' I N I T ;
 LOCAL            : L O C A L ;
 SHARED           : S H A R E D ;

--- a/tests/Fortran2023/test_fortran_2023_comprehensive.py
+++ b/tests/Fortran2023/test_fortran_2023_comprehensive.py
@@ -208,10 +208,12 @@ class TestFortran2023Lexer:
     def test_f2018_compatibility(self):
         """Test that F2023 maintains full F2018 compatibility."""
         # Test key F2018 constructs still work
+        # Note: RANK_STAR, RANK_DEFAULT, ASSUMED_RANK, LOCALITY, DEFAULT_ACCESS removed
+        # in issue #434 - these were dead tokens with no parser usage
         f2018_keywords = [
             'CO_SUM', 'CO_MIN', 'CO_MAX', 'CO_REDUCE', 'CO_BROADCAST',
             'IMAGE_STATUS', 'FAILED_IMAGES', 'STOPPED_IMAGES',
-            'SELECT_RANK', 'RANK_STAR', 'RANK_DEFAULT',
+            'SELECT_RANK',
             'RANDOM_INIT', 'REPEATABLE', 'IMAGE_DISTINCT',
             'REDUCE', 'OUT_OF_RANGE', 'COSHAPE', 'TEAM_NUMBER',
             'FORM_TEAM', 'CHANGE_TEAM', 'END_TEAM', 'TEAM_TYPE'


### PR DESCRIPTION
## Summary

Remove 5 dead tokens from Fortran2018Lexer that have no parser usage:
- RANK_STAR, RANK_DEFAULT: Grammar uses MULTIPLY (*) and DEFAULT keywords instead
- ASSUMED_RANK: Grammar uses DOT_DOT (..) syntax for assumed-rank-spec
- LOCALITY: Grammar rule name, not a keyword (uses LOCAL, LOCAL_INIT, SHARED)
- DEFAULT_ACCESS: Not in ISO standard

## ISO Compliance

All removals verified against ISO/IEC 1539-1:2018:
- R1150: select-rank-case-stmt uses RANK (*) and RANK DEFAULT syntax
- R825: assumed-rank-spec is .. (DOT_DOT token)
- R1129-R1130: concurrent-locality uses LOCAL, LOCAL_INIT, SHARED, DEFAULT keywords
- Section 8.6: Uses DEFAULT with PUBLIC/PRIVATE, not DEFAULT_ACCESS

## Verification

✅ All 5 tokens confirmed 0 references in Fortran2018Parser.g4
✅ 1182 tests pass (all compliance tests green)
✅ Line length compliance enforced (88-col limit)
✅ Audit documentation updated with cleanup notes

## Changes

- grammars/src/Fortran2018Lexer.g4: Removed 5 dead tokens with ISO references
- tests/Fortran2023/test_fortran_2023_comprehensive.py: Updated F2018 compatibility test
- docs/fortran_2018_audit.md: Updated SELECT RANK section and added cleanup notes