### PR TITLE
fix: Restore missing technical content and fix intent semantics

### DIFF
--- a/docs/lazyfortran2025-design.md
+++ b/docs/lazyfortran2025-design.md
@@ -9,13 +9,25 @@
 
 Lazy Fortran 2025 extends Fortran 2023 with automatic type inference, intent deduction, and generic programming. The goal is reduced boilerplate while maintaining compatibility with standard Fortran compilers through a source-to-source standardizer.
 
-Key features:
-- **Type inference** - variables get their type from first assignment
-- **Intent inference** - argument intents derived from usage analysis
-- **Generics** - templates and traits for type-safe polymorphism
-- **Monomorphization** - automatic generation of specialized code
-
 All standard Fortran 2023 programs remain valid Lazy Fortran programs.
+
+### Feature Classification
+
+Features are classified by compilation complexity:
+
+**Single-pass (local analysis only):**
+- Type inference from first assignment
+- Default `intent(in)` for arguments
+- Expression type rules
+- Declaration placement
+- Explicit template/trait declarations
+
+**Semantic analysis (multi-pass or whole-program):**
+- Monomorphization (collect all call sites)
+- Function result type inference (with monomorphization)
+- Infer from `intent(out)` arguments (Open Issue 2)
+- Infer pointer/allocatable attributes (Open Issues 11, 12)
+- Auto-USE for derived types (Open Issue 14)
 
 ---
 
@@ -45,45 +57,89 @@ arr = [1, 2, 3]           ! rank-1 integer array, 3 elements
 allocate(matrix(n, m))    ! rank-2, runtime bounds
 ```
 
+### Expression Type Rules
+
+Expression types follow ISO/IEC 1539-1:2023 Clause 10.1.5 (Numeric intrinsic operations). Mixed numeric array constructors use type promotion: `[1, 2.0, 3]` promotes all elements to real.
+
 ### Interaction with implicit none
 
 When `implicit none` is present, undeclared names are errors and inference is disabled. This preserves compatibility with strict coding styles.
 
 ### Open Issues
 
+**Single-pass (local analysis):**
+
 | Issue | Question | Options |
 |-------|----------|---------|
 | 1 | Default numeric kinds? | A: ISO default (real(4)) B: Double precision (real(8)) C: Context-dependent |
+| 3 | Declaration placement? | A: Block beginning only B: Anywhere in scope |
 | 10 | Character length handling? | A: First assignment wins B: Maximum length seen C: Allocatable deferred-length |
 | 15 | Fallback when type unclear? | A: Compile error B: Default to real(8) C: ISO default kind |
+
+**Semantic analysis (multi-pass):**
+
+| Issue | Question | Options |
+|-------|----------|---------|
 | 2 | Infer from intent(out)? | A: No (assignment only) B: Yes (inspect callee signature) |
-| 3 | Declaration placement? | A: Block beginning only B: Anywhere in scope |
 | 11 | Infer pointer attribute? | A: No B: From pointer assignment C: Both pointer and target |
 | 12 | Infer allocatable? | A: No B: From allocate statements |
-| 13 | Function result types? | A: Body only B: Call site only C: Body first, call site fallback D: Must match |
 | 14 | Derived type scope? | A: Explicit USE required B: Auto-USE C: Explicit declaration required |
+
+### Function Result Types
+
+Function result types are inferred from the body expression given the input types. With monomorphization, each specialization gets its return type from evaluating the body:
+
+```fortran
+function add(a, b)
+    add = a + b       ! return type = type of (a + b)
+end function
+
+x = add(5, 3)         ! add__i32_i32 returns integer
+y = add(2.5d0, 1.5d0) ! add__r64_r64 returns real(8)
+```
+
+The call site provides argument types, which determines which specialization to generate. That specialization's return type comes from the body expression.
 
 ---
 
-## Intent Inference
+## Default Intent
 
-Procedure argument intents are derived from usage analysis:
+Lazy Fortran uses `intent(in)` as the default for all procedure arguments. This is stricter than standard Fortran, which has no default intent (arguments without explicit intent can be read and modified).
+
+To modify an argument, explicitly specify `intent(inout)` or `intent(out)`:
 
 ```fortran
 subroutine process(x, y, z)
-    ! x only read     -> intent(in)
-    ! y modified      -> intent(inout)
-    ! z only written  -> intent(out)
+    integer, intent(in) :: x       ! Explicit (same as default)
+    integer, intent(inout) :: y    ! Explicit override - can read and modify
+    integer, intent(out) :: z      ! Explicit override - output only
     y = x + 1
     z = y * 2
 end subroutine
 ```
 
-### Open Issue
+Without explicit intent, `y` and `z` would default to `intent(in)` and the assignments would be compile-time errors.
 
-| Issue | Question | Options |
-|-------|----------|---------|
-| 4 | Default intent when usage is inconclusive? | A: intent(in) B: intent(inout) C: Require explicit |
+### Rationale
+
+Standard Fortran allows unrestricted modification of arguments without explicit intent, which can lead to subtle bugs. The `intent(in)` default follows the principle of least privilege: arguments are read-only unless explicitly declared otherwise. This aligns with modern language design (e.g., Rust immutable-by-default).
+
+### Standardizer Behavior
+
+The standardizer generates explicit `intent(in)` declarations for all arguments that lack explicit intent:
+
+```fortran
+! Input: script.lf
+subroutine scale(x, factor)
+    x = x * factor   ! ERROR: x has intent(in) by default
+end subroutine
+
+! Must be written as:
+subroutine scale(x, factor)
+    real, intent(inout) :: x    ! Explicit override required
+    x = x * factor
+end subroutine
+```
 
 ---
 
@@ -137,6 +193,17 @@ abstract interface :: INumeric
 end interface INumeric
 ```
 
+Traits can specify required procedure signatures:
+
+```fortran
+abstract interface :: ISum
+    function sum{INumeric :: T}(x) result(s)
+        type(T), intent(in) :: x(:)
+        type(T) :: s
+    end function
+end interface ISum
+```
+
 Types declare trait conformance:
 
 ```fortran
@@ -149,6 +216,18 @@ end type
 implements IComparable :: integer
     procedure :: less_than => builtin_less_than
 end implements
+```
+
+### Trait Annotation Syntax
+
+An alternative `@` annotation syntax for trait declarations:
+
+```fortran
+@IComparable
+integer function compare(a, b)
+    integer, intent(in) :: a, b
+    compare = a - b
+end function
 ```
 
 ### Combining Approaches
@@ -218,17 +297,44 @@ Specialized procedures use kind suffixes:
 
 Kind suffix table (bits convention):
 
+| Type | Kind | Storage | Suffix |
+|------|------|---------|--------|
+| integer | 1 | 1 byte | i8 |
+| integer | 2 | 2 bytes | i16 |
+| integer | 4 | 4 bytes | i32 |
+| integer | 8 | 8 bytes | i64 |
+| integer | 16 | 16 bytes | i128 |
+| real | 4 | 4 bytes | r32 |
+| real | 8 | 8 bytes | r64 |
+| real | 16 | 16 bytes | r128 |
+| complex | 4 | 8 bytes | c64 |
+| complex | 8 | 16 bytes | c128 |
+| complex | 16 | 32 bytes | c256 |
+| logical | 1 | 1 byte | l8 |
+| logical | 4 | 4 bytes | l32 |
+| character | N | N bytes | chN |
+
+Alternative byte-based convention (matches Fortran kind parameters):
+
 | Type | Kind | Suffix |
 |------|------|--------|
-| integer | 4 | i32 |
-| integer | 8 | i64 |
-| real | 4 | r32 |
-| real | 8 | r64 |
-| complex | 8 | c128 |
-| logical | 4 | l32 |
-| character | N | chN |
+| integer | 1 | i1 |
+| integer | 2 | i2 |
+| integer | 4 | i4 |
+| integer | 8 | i8 |
+| real | 4 | r4 |
+| real | 8 | r8 |
+| complex | 4 | c4 |
+| complex | 8 | c8 |
+| logical | 1 | l1 |
+| logical | 4 | l4 |
 
 Array rank uses `rank<n>` suffix: `sum__r64rank1`
+
+Examples:
+- `add(integer, integer)` -> `add__i32_i32`
+- `add(real(8), real(8))` -> `add__r64_r64`
+- `sum(real(8), dimension(:))` -> `sum__r64rank1`
 
 Multiple specializations are wrapped in a generic interface within an auto-generated module:
 
@@ -254,13 +360,13 @@ The standardizer transforms Lazy Fortran (.lf) to standard Fortran (.f90).
 
 ### Transformations
 
-1. **Program wrapping** - Bare statements become `program main`
+1. **Program wrapping** - Bare statements become `program main`; files with only procedures become `module <filename>`
 2. **Declaration generation** - Inferred types become explicit declarations
 3. **implicit none injection** - Added to all program units
-4. **Intent generation** - Inferred intents become explicit
+4. **Intent generation** - Default `intent(in)` becomes explicit
 5. **Monomorphization** - Generic calls become specialized procedures
 
-### Example
+### Simple Example
 
 Input (script.lf):
 ```fortran
@@ -275,6 +381,47 @@ program main
     integer :: x
     x = 5
     print *, x
+end program main
+```
+
+### Monomorphization Example
+
+Input (script.lf):
+```fortran
+function add(a, b)
+    add = a + b
+end function
+
+x = add(5, 3)
+y = add(2.5, 1.5)
+```
+
+Output (script.f90):
+```fortran
+module auto_add
+    implicit none
+    interface add
+        module procedure add__i32_i32, add__r64_r64
+    end interface add
+contains
+    integer function add__i32_i32(a, b)
+        integer, intent(in) :: a, b
+        add__i32_i32 = a + b
+    end function
+
+    real(8) function add__r64_r64(a, b)
+        real(8), intent(in) :: a, b
+        add__r64_r64 = a + b
+    end function
+end module auto_add
+
+program main
+    use auto_add
+    implicit none
+    integer :: x
+    real(8) :: y
+    x = add(5, 3)
+    y = add(2.5d0, 1.5d0)
 end program main
 ```
 


### PR DESCRIPTION
## Summary

- Restore missing technical content from LazyFortran design doc (removed in PR #373)
- Fix intent semantics: strict `intent(in)` default, not inference

## Changes

### Restored Technical Content

| Content | Description |
|---------|-------------|
| Trait signatures | `ISum` interface example with function signature |
| Trait annotations | `@IComparable` syntax example |
| Full kind suffix tables | All integer (1,2,4,8,16), real (4,8,16), complex (4,8,16), logical (1,4) kinds |
| Byte-based convention | Alternative table matching Fortran kind parameters (i4, r8 vs i32, r64) |
| Mangling examples | `add__i32_i32`, `add__r64_r64`, `sum__r64rank1` |
| Monomorphization output | Full standardizer example showing auto-generated module with interface |

### Intent Semantics Fix

Changed from inference-based to strict default:

| Before (Wrong) | After (Correct) |
|---------------|-----------------|
| "Intent inference" | "Default intent" |
| Usage analysis infers intent | Fixed `intent(in)` default |
| Automatic based on code patterns | Explicit `intent(inout)`/`intent(out)` required |
| Open Issue 4 asking which default | Decision made - intent(in) |

## Test plan

- [x] Document renders correctly
- [x] All technical content restored
- [x] Intent section describes strict default behavior
- [x] No inference language in intent section
