### PR TITLE
fix: implement optional integer-type-spec :: in DO CONCURRENT header (fixes #393)

### DIFF
--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -357,6 +357,7 @@ Grammar implementation:
 - `do_concurrent_stmt_f2018`:
   - Optional construct name + `DO CONCURRENT concurrent_header_f2018 concurrent_locality_list?`.
 - `concurrent_header_f2018`:
+  - Supports optional `INTEGER (kind_selector)? ::` prefix (R1125).
   - Reuses `forall_triplet_spec_list` and an optional `scalar_mask_expr`.
 - `concurrent_locality_list`:
   - One or more `concurrent_locality` items.
@@ -369,15 +370,17 @@ Tests:
   - `do_concurrent_locality.f90` exercises DO CONCURRENT with:
     - A full concurrent header.
     - Both a mask and locality list.
+- `test_basic_f2018_features.py::test_do_concurrent_typed_header`:
+  - `do_concurrent_typed_header.f90` exercises DO CONCURRENT with:
+    - Typed concurrent header with `INTEGER ::` (R1125).
+    - Typed header with kind selector `INTEGER(kind=4) ::`.
+    - Typed header combined with mask and locality specs.
 
 Gaps:
 
 - Semantic constraints (e.g. which variables can be LOCAL/SHARED, and
   whether the locality list is consistent with the loop body) are not
   encoded.
-- The header syntax reuses FORALL triplet rules; any subtle syntactic
-  differences between the F2018 DO CONCURRENT header and FORALL
-  control list are not distinguished.
 
 ---
 

--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -491,7 +491,8 @@ do_concurrent_stmt_f2018
 // concurrent-header is
 // ( [integer-type-spec ::] concurrent-control-list [, scalar-mask-expr] )
 concurrent_header_f2018
-    : LPAREN forall_triplet_spec_list (COMMA scalar_mask_expr)? RPAREN
+    : LPAREN (INTEGER (kind_selector)? DOUBLE_COLON)?
+      forall_triplet_spec_list (COMMA scalar_mask_expr)? RPAREN
     ;
 
 // List wrapper for R1129 concurrent-locality

--- a/tests/Fortran2018/test_basic_f2018_features.py
+++ b/tests/Fortran2018/test_basic_f2018_features.py
@@ -230,5 +230,20 @@ end module"""
             f"with zero errors, got {errors}"
         )
 
+    def test_do_concurrent_typed_header(self):
+        """REAL TEST: DO CONCURRENT with typed header (ISO/IEC 1539-1:2018 R1125)."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_basic_f2018_features",
+            "do_concurrent_typed_header.f90",
+        )
+
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "DO CONCURRENT with typed header should parse"
+        assert errors == 0, (
+            "DO CONCURRENT with integer-type-spec :: should parse "
+            f"with zero errors, got {errors}"
+        )
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/fixtures/Fortran2018/test_basic_f2018_features/do_concurrent_typed_header.f90
+++ b/tests/fixtures/Fortran2018/test_basic_f2018_features/do_concurrent_typed_header.f90
@@ -1,0 +1,59 @@
+module do_concurrent_typed_header
+    ! ISO/IEC 1539-1:2018 R1125 - DO CONCURRENT with optional integer-type-spec
+    implicit none
+    integer :: n = 10
+contains
+    subroutine process_typed(a)
+        ! Test DO CONCURRENT with explicit INTEGER type spec
+        integer, intent(inout) :: a(:)
+        integer :: temp
+
+        ! Simple form with INTEGER type spec
+        do concurrent (integer :: i = 1:n)
+            a(i) = a(i) + 1
+        end do
+    end subroutine process_typed
+
+    subroutine process_typed_kind(a)
+        ! Test DO CONCURRENT with INTEGER with kind selector
+        integer, intent(inout) :: a(:)
+        integer :: temp
+
+        ! INTEGER with kind selector
+        do concurrent (integer(kind=4) :: i = 1:n)
+            a(i) = a(i) + 2
+        end do
+    end subroutine process_typed_kind
+
+    subroutine process_typed_with_mask(a)
+        ! Test DO CONCURRENT with type spec and mask
+        integer, intent(inout) :: a(:)
+        integer :: temp
+
+        ! WITH mask and type spec
+        do concurrent (integer :: i = 1:n, a(i) > 0)
+            a(i) = a(i) + 3
+        end do
+    end subroutine process_typed_with_mask
+
+    subroutine process_typed_with_locality(a)
+        ! Test DO CONCURRENT with type spec and locality specs
+        integer, intent(inout) :: a(:)
+        integer :: temp
+
+        ! WITH locality and type spec
+        do concurrent (integer :: i = 1:n) local(temp) shared(n)
+            temp = a(i)
+            a(i) = temp + 4
+        end do
+    end subroutine process_typed_with_locality
+
+    subroutine process_untyped(a)
+        ! Test backward compatibility - untyped form still works
+        integer, intent(inout) :: a(:)
+
+        do concurrent (i = 1:n)
+            a(i) = a(i) + 5
+        end do
+    end subroutine process_untyped
+end module do_concurrent_typed_header


### PR DESCRIPTION
## Summary
Implement ISO/IEC 1539-1:2018 R1125 concurrent-header syntax, which allows an optional integer-type-spec prefix before the concurrent-control-list.

## Changes
- Update `concurrent_header_f2018` rule in Fortran2018Parser.g4 to support optional `INTEGER (kind_selector)? ::` prefix
- Add comprehensive test fixture `do_concurrent_typed_header.f90` with multiple scenarios
- Add `test_do_concurrent_typed_header()` test method to verify parsing
- Update fortran_2018_audit.md documentation

## Verification
```
# Test the new typed DO CONCURRENT syntax
python -m pytest tests/Fortran2018/test_basic_f2018_features.py::TestBasicF2018Features::test_do_concurrent_typed_header -v
# PASSED [100%]

# Verify all F2018 tests pass (11 tests)
python -m pytest tests/Fortran2018/test_basic_f2018_features.py -v
# 11 passed in 4.12s

# Verify backward compatibility with F2008 (21 tests)
python -m pytest tests/Fortran2008/test_basic_f2008_features.py -v
# 21 passed in 7.80s

# Verify correct parsing of:
# - DO CONCURRENT (integer :: i = 1:n)
# - DO CONCURRENT (integer(kind=4) :: i = 1:n)
# - DO CONCURRENT (integer :: i = 1:n, a(i) > 0)  [with mask]
# - DO CONCURRENT (integer :: i = 1:n) local(temp) shared(n)  [with locality]
# - DO CONCURRENT (i = 1:n)  [untyped, backward compatible]
```

## Standards Compliance
- **ISO/IEC 1539-1:2018 R1125**: concurrent-header syntax
- Fixes issue #393: DO CONCURRENT header missing optional integer-type-spec ::