### PR TITLE
fix: remove unused GENERIC token from Fortran 90 lexer (fixes #439)

### DIFF
--- a/grammars/src/Fortran90Lexer.g4
+++ b/grammars/src/Fortran90Lexer.g4
@@ -148,9 +148,6 @@ INTERFACE       : ('i'|'I') ('n'|'N') ('t'|'T') ('e'|'E') ('r'|'R')
 // END INTERFACE - ISO/IEC 1539:1991 Section 12.3, R1201
 END_INTERFACE   : ('e'|'E') ('n'|'N') ('d'|'D') WS+ ('i'|'I') ('n'|'N') ('t'|'T')
                   ('e'|'E') ('r'|'R') ('f'|'F') ('a'|'A') ('c'|'C') ('e'|'E') ;
-// GENERIC keyword - ISO/IEC 1539:1991 Section 12.3.2.1
-GENERIC         : ('g'|'G') ('e'|'E') ('n'|'N') ('e'|'E')
-                  ('r'|'R') ('i'|'I') ('c'|'C') ;
 // OPERATOR keyword - ISO/IEC 1539:1991 Section 12.3, R1203
 OPERATOR        : ('o'|'O') ('p'|'P') ('e'|'E') ('r'|'R')
                   ('a'|'A') ('t'|'T') ('o'|'O') ('r'|'R') ;
@@ -691,7 +688,7 @@ fragment DIGIT : [0-9] ;
 // Section 9 (I/O)             -> NAMELIST, ADVANCE, SIZE, STAT, EOR, IOSTAT,
 //                                UNIT, FMT, REC, ERR
 // Section 11 (Program units)  -> MODULE, END_MODULE, USE, ONLY, CONTAINS
-// Section 12 (Procedures)     -> INTERFACE, END_INTERFACE, GENERIC, OPERATOR,
+// Section 12 (Procedures)     -> INTERFACE, END_INTERFACE, OPERATOR,
 //                                ASSIGNMENT, RECURSIVE, RESULT, PROCEDURE
 // Section 13 (Intrinsics)     -> *_INTRINSIC tokens, SELECTED_*_KIND,
 //                                ASSOCIATED, ALLOCATED, PRESENT

--- a/tests/Fortran90/test_fortran_90_comprehensive.py
+++ b/tests/Fortran90/test_fortran_90_comprehensive.py
@@ -106,8 +106,7 @@ class TestFortran90Lexer:
         """Test F90 interface block keywords (explicit interfaces)."""
         interface_keywords = {
             'INTERFACE': Fortran90Lexer.INTERFACE,
-            'END INTERFACE': Fortran90Lexer.END_INTERFACE, 
-            'GENERIC': Fortran90Lexer.GENERIC,
+            'END INTERFACE': Fortran90Lexer.END_INTERFACE,
             'OPERATOR': Fortran90Lexer.OPERATOR,
             'ASSIGNMENT': Fortran90Lexer.ASSIGNMENT
         }
@@ -647,8 +646,8 @@ class TestFortran90Foundation:
         required_f90_features = [
             # Module system
             'MODULE', 'END_MODULE', 'USE', 'ONLY', 'PUBLIC', 'PRIVATE',
-            # Interface blocks  
-            'INTERFACE', 'END_INTERFACE', 'GENERIC', 'OPERATOR',
+            # Interface blocks
+            'INTERFACE', 'END_INTERFACE', 'OPERATOR',
             # Derived types
             'TYPE', 'END_TYPE', 'PERCENT',
             # Dynamic arrays


### PR DESCRIPTION
## Summary
Removed the unused GENERIC token from the Fortran 90 lexer. The token was defined but never used in the parser, and ISO/IEC 1539:1991 R1203 does not include GENERIC as a keyword in the generic-spec rule.

## Verification
- All 1252 tests pass
- Grammar still correctly parses interface blocks without the GENERIC keyword
- GENERIC keyword was never referenced in the Fortran 90 parser rules

## Changes
- Removed GENERIC token definition from `grammars/src/Fortran90Lexer.g4`
- Removed GENERIC reference from Section 12 comment
- Updated test references in `tests/Fortran90/test_fortran_90_comprehensive.py`

## Test Results
```
======================= 1252 passed, 1 skipped in 23.29s =======================
✅ All tests completed!
```