### PR TITLE
feat: implement statement functions for FORTRAN 1957 (fixes #422)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -139,6 +139,22 @@ Mapping that Appendix‑B list to the current grammar:
     (`frequency_stmt.f`, `frequency_test_1957.f`) that assert
     `getNumberOfSyntaxErrors() == 0`.
 
+- **Statement Functions**
+  - Status: **implemented and tested.**
+  - Evidence: `statement_function_stmt` rule and `identifier_list` rule in
+    `FORTRANParser.g4` implementing `f(a1, a2, ..., an) = expr` per C28-6003
+    Chapter II.E and Appendix B row 17. Test fixtures
+    `statement_function_basic.f`, `statement_function_nested.f`, and
+    `statement_function_program.f` in the `test_fortran_historical_stub`
+    directory parse with zero syntax errors. Dedicated tests in
+    `tests/FORTRAN/test_fortran_historical_stub.py` validate statement
+    functions with explicit `getNumberOfSyntaxErrors() == 0` assertions.
+  - **NON-COMPLIANT with ISO/IEC 1539-1:1991 (Fortran 90 and later):**
+    - Statement functions are made OBSOLESCENT in Fortran 90
+      (ISO/IEC 1539:1991 Annex B.2.2).
+    - Historically accurate for IBM 704 FORTRAN (1957) and retained in
+      this grammar for educational and archival purposes only.
+
 ## 3. Statements and control flow (implemented subset)
 
 Implemented and tested in `tests/FORTRAN/test_fortran_historical_stub.py`
@@ -391,8 +407,8 @@ Today the FORTRAN (1957) grammar is:
     - Tape I/O: READ TAPE, WRITE TAPE (unformatted/binary)
     - Drum I/O: READ DRUM, WRITE DRUM (binary)
     - File-control: END FILE, REWIND, BACKSPACE
-- Remaining gap:
-  - Statement functions (f(a,b,...) = e) per Appendix B row 17
+    - Statement functions (f(a,b,...) = e) per Appendix B row 17
+- No remaining gaps in Appendix B coverage.
 
 Further work on this standard should reference this audit together with
 the open issues for expanding 1957 coverage.

--- a/grammars/src/FORTRANParser.g4
+++ b/grammars/src/FORTRANParser.g4
@@ -70,6 +70,7 @@ statement_body
     | do_stmt_basic                 // Appendix B row 18: DO n i = m1,m2,m3
     | frequency_stmt                // Appendix B row 13: FREQUENCY n(i,j,...)
     | format_stmt                   // Appendix B row 16: FORMAT (specification)
+    | statement_function_stmt       // Appendix B row 17: f(a,b,...) = expr
     | read_tape_drum_stmt            // Appendix B rows 21-24: READ tape/drum forms
     | read_stmt_basic               // Appendix B row 20, 24: READ n, list / READ n
     | write_tape_drum_stmt          // Appendix B rows 25-27: WRITE tape/drum forms
@@ -129,6 +130,33 @@ equivalence_stmt
 // C28-6003: At least two variables per set
 equivalence_set
     : LPAREN variable (COMMA variable)+ RPAREN
+    ;
+
+// STATEMENT FUNCTION - Appendix B row 17
+// C28-6003 Chapter II.E (Function Statements) and Appendix B row 17
+// Statement functions are compile-time-substitutable functions defined as:
+//   f(a1, a2, ..., an) = expr
+// where:
+// - f is the function name (typically 4-7 chars, often ending in F)
+// - a1, a2, ..., an are formal parameters (identifiers)
+// - expr is an arithmetic expression using the parameters
+// Must appear before any executable statements in the program.
+//
+// Examples:
+//   POLYF(X) = C0 + X*(C1 + X*C2)      ! Floating-point polynomial
+//   MULTF(I,J) = I*J                   ! Integer multiplication
+//   XMULTF(X,Y) = X*Y                  ! Fixed-point multiplication
+//
+// Note: STATEMENT FUNCTIONS are made OBSOLESCENT in Fortran 90
+// (ISO/IEC 1539:1991 Annex B.2.2). Retained here for historical accuracy
+// in the 1957 FORTRAN grammar.
+statement_function_stmt
+    : IDENTIFIER LPAREN identifier_list RPAREN EQUALS expr
+    ;
+
+// Identifier list for statement function arguments
+identifier_list
+    : IDENTIFIER (COMMA IDENTIFIER)*
     ;
 
 // ============================================================================

--- a/tests/FORTRAN/test_fortran_historical_stub.py
+++ b/tests/FORTRAN/test_fortran_historical_stub.py
@@ -238,6 +238,77 @@ class TestFORTRANHistoricalStub:
         except Exception as e:
             pytest.fail(f"ASSIGN/assigned GOTO combined parsing failed: {e}")
 
+    def test_statement_function_basic(self):
+        """Test parsing of statement functions (1957 compile-time substitutable functions).
+
+        Per IBM 704 manual (C28-6003) Chapter II.E and Appendix B row 17,
+        statement functions provide compile-time substitution of arithmetic
+        expressions. Format: f(a1, a2, ..., an) = expr
+        Example: POLYF(X) = C0 + X*(C1 + X*C2)
+
+        Note: Statement functions are made OBSOLESCENT in Fortran 90
+        (ISO/IEC 1539:1991 Annex B.2.2). Retained here for historical accuracy.
+        """
+        test_input = load_fixture(
+            "FORTRAN",
+            "test_fortran_historical_stub",
+            "statement_function_basic.f",
+        )
+
+        parser = self.create_parser(test_input)
+
+        try:
+            tree = parser.program_unit_core()
+            assert tree is not None
+            assert parser.getNumberOfSyntaxErrors() == 0
+        except Exception as e:
+            pytest.fail(f"Statement function basic parsing failed: {e}")
+
+    def test_statement_function_nested(self):
+        """Test parsing of multiple statement functions with nested references.
+
+        This tests a program with several statement functions that reference
+        each other, demonstrating typical 1957 usage patterns.
+        """
+        test_input = load_fixture(
+            "FORTRAN",
+            "test_fortran_historical_stub",
+            "statement_function_nested.f",
+        )
+
+        parser = self.create_parser(test_input)
+
+        try:
+            tree = parser.program_unit_core()
+            assert tree is not None
+            assert parser.getNumberOfSyntaxErrors() == 0
+        except Exception as e:
+            pytest.fail(f"Statement function nested parsing failed: {e}")
+
+    def test_statement_function_program(self):
+        """Test complete program using statement functions.
+
+        This tests a realistic 1957 program that:
+        1. Defines statement functions at the beginning
+        2. Initializes variables
+        3. Calls the statement functions
+        4. Outputs results via PRINT statement
+        """
+        test_input = load_fixture(
+            "FORTRAN",
+            "test_fortran_historical_stub",
+            "statement_function_program.f",
+        )
+
+        parser = self.create_parser(test_input)
+
+        try:
+            tree = parser.program_unit_core()
+            assert tree is not None
+            assert parser.getNumberOfSyntaxErrors() == 0
+        except Exception as e:
+            pytest.fail(f"Statement function program parsing failed: {e}")
+
     def test_do_loop_with_label(self):
         """Test parsing of DO loops with mandatory labels (1957 style)."""
         # DO loops REQUIRED labels in 1957 (no END DO statement)

--- a/tests/fixtures/FORTRAN/test_fortran_historical_stub/statement_function_basic.f
+++ b/tests/fixtures/FORTRAN/test_fortran_historical_stub/statement_function_basic.f
@@ -1,0 +1,3 @@
+      POLYF(X) = 2.0 + X*(3.0 + X*4.0)
+      MULTF(I,J) = I*J
+      END

--- a/tests/fixtures/FORTRAN/test_fortran_historical_stub/statement_function_nested.f
+++ b/tests/fixtures/FORTRAN/test_fortran_historical_stub/statement_function_nested.f
@@ -1,0 +1,4 @@
+      ABSF(X) = -X
+      SQRF(X) = X*X
+      HYPOTF(A,B) = SQRF(A) + SQRF(B)
+      END

--- a/tests/fixtures/FORTRAN/test_fortran_historical_stub/statement_function_program.f
+++ b/tests/fixtures/FORTRAN/test_fortran_historical_stub/statement_function_program.f
@@ -1,0 +1,10 @@
+      POLYF(X) = C0 + X*(C1 + X*C2)
+      MULTF(I,J) = I*J
+      C0 = 1.0
+      C1 = 2.0
+      C2 = 3.0
+      Y = POLYF(2.0)
+      Z = MULTF(3,4)
+      PRINT 10, Y, Z
+10    FORMAT(2F10.2)
+      END


### PR DESCRIPTION
## Summary

Implements complete support for FORTRAN 1957 statement functions (Appendix B row 17) per C28-6003 Chapter II.E specifications. Statement functions are compile-time-substitutable functions in the form `f(a1, a2, ..., an) = expr`.

## Changes

### Grammar Implementation
- Added `statement_function_stmt` rule to `FORTRANParser.g4` (lines 134-154):
  - Syntax: `IDENTIFIER LPAREN identifier_list RPAREN EQUALS expr`
  - Supports arbitrary-arity function parameter lists
  - Wired into `statement_body` alternatives (line 73)

- Added `identifier_list` rule (lines 157-159) for function parameter lists

### Test Coverage
Created 3 comprehensive test fixtures in `tests/fixtures/FORTRAN/test_fortran_historical_stub/`:
1. `statement_function_basic.f` - Basic single and multi-parameter statement functions
2. `statement_function_nested.f` - Multiple statement functions with nested references
3. `statement_function_program.f` - Complete program using statement functions

Added 3 dedicated test cases in `tests/FORTRAN/test_fortran_historical_stub.py`:
- `test_statement_function_basic()` - Validates basic parsing
- `test_statement_function_nested()` - Tests nested function references
- `test_statement_function_program()` - End-to-end program validation

All tests use explicit `getNumberOfSyntaxErrors() == 0` assertions per project standards.

### Documentation
Updated `docs/fortran_1957_audit.md`:
- Added Statement Functions section (lines 142-156) documenting implementation and compliance
- Updated "Implemented Statements" list to include statement functions
- Updated "Remaining gaps" section: removed statement functions from gap list (line 410-411)
- Added ISO/IEC 1539-1:1991 obsolescence note for historical context

## Verification

**Test Results**: All tests pass with 100% success rate
```
===== 1286 passed, 1 skipped in 22.22s =====
```

**Grammar validation**: Parser and lexer compile successfully with no errors

**Historical accuracy**: Implementation matches C28-6003 Appendix B row 17 and Chapter II.E specifications

## ISO Standard Compliance

**STANDARD-COMPLIANT for FORTRAN 1957 (C28-6003)**: Statement functions are part of the original IBM 704 FORTRAN specification

**NON-COMPLIANT with ISO/IEC 1539-1:1991 (Fortran 90 and later)**: Statement functions became OBSOLESCENT in Fortran 90 (ISO/IEC 1539:1991 Annex B.2.2) but are retained here for historical accuracy

## Related Issues

Closes #422