### PR TITLE
fix: wire file-control statements into FORTRAN II grammar (fixes #384)

### DIFF
--- a/docs/fortran_ii_audit.md
+++ b/docs/fortran_ii_audit.md
@@ -11,8 +11,9 @@ repository currently supports, based on:
 
 This is a descriptive audit of the current implementation. Full
 conformance to the IBM 704 FORTRAN II manual (C28-6000-2, 1958) requires
-resolving the gaps documented in section 8 below. Tape/drum I/O and
-file-control statements are tracked by issue #153 (reopened).
+resolving the gaps documented in section 8 below. Tape/drum I/O
+statements are tracked by issue #153 (reopened). File-control statements
+(END FILE, REWIND, BACKSPACE) are implemented per issue #384.
 
 ## 1. Program structure and subprograms
 
@@ -401,9 +402,9 @@ or are out of scope for the current grammar:
 | WRITE OUTPUT TAPE i, n, list         | Not implemented                | Gap: see #153   |
 | WRITE TAPE i, list                   | Not implemented                | Gap: see #153   |
 | WRITE DRUM i, j, list                | Not implemented                | Gap: see #153   |
-| END FILE i                           | Not implemented                | Gap: see #153   |
-| REWIND i                             | Not implemented                | Gap: see #153   |
-| BACKSPACE i                          | Not implemented                | Gap: see #153   |
+| END FILE i                           | `end_file_stmt`                | Implemented     |
+| REWIND i                             | `rewind_stmt`                  | Implemented     |
+| BACKSPACE i                          | `backspace_stmt`               | Implemented     |
 
 ### 8.4 Implementation Status
 
@@ -420,6 +421,10 @@ been addressed:
   (issue #395, closed). Includes IF (SENSE SWITCH i), IF (SENSE LIGHT i),
   IF ACCUMULATOR OVERFLOW, IF QUOTIENT OVERFLOW, IF DIVIDE CHECK, and
   SENSE LIGHT statements per C28-6003 Appendix B rows 4–8, 11.
+- **File-control statements**: END FILE, REWIND, and BACKSPACE are
+  implemented in FORTRAN I parser and wired into FORTRAN II `statement_body`
+  and `statement_body_strict` (issue #384, closed). These statements
+  control magnetic tape operations per C28-6003 Chapter III.F.
 - **Strict fixed-form card layout**: Implemented via `tools/strict_fixed_form.py`
   preprocessor (issue #143, closed). Validates IBM 704 card layout per
   C28-6000-2 and converts to lenient form for parsing.
@@ -427,8 +432,7 @@ been addressed:
 The following features remain as gaps to be resolved:
 
 - Tape/drum I/O forms (READ INPUT TAPE, WRITE OUTPUT TAPE, READ/WRITE
-  TAPE/DRUM) and auxiliary file control (END FILE, REWIND, BACKSPACE)
-  are not implemented. These are tracked by issue #153 (reopened).
+  TAPE/DRUM) are not implemented. These are tracked by issue #153 (reopened).
 
 ## 9. Summary
 

--- a/grammars/src/FORTRANIIParser.g4
+++ b/grammars/src/FORTRANIIParser.g4
@@ -193,6 +193,9 @@ statement_body
     | write_stmt_basic   // C28-6003 Chap III: WRITE output_list (from FORTRAN I)
     | print_stmt         // Appendix A: PRINT n, list
     | punch_stmt         // Appendix A: PUNCH n, list
+    | end_file_stmt      // C28-6003 Chapter III.F: END FILE i
+    | rewind_stmt        // C28-6003 Chapter III.F: REWIND i
+    | backspace_stmt     // C28-6003 Chapter III.F: BACKSPACE i
     | format_stmt        // Appendix A: FORMAT (specification)
     | dimension_stmt     // Appendix A: DIMENSION v, v, ...
     | equivalence_stmt   // Appendix A: EQUIVALENCE (a,b,...), ...
@@ -226,6 +229,9 @@ statement_body_strict
     | write_stmt_basic   // C28-6003 Chap III: WRITE output_list (from FORTRAN I)
     | print_stmt         // Appendix A: PRINT n, list
     | punch_stmt         // Appendix A: PUNCH n, list
+    | end_file_stmt      // C28-6003 Chapter III.F: END FILE i
+    | rewind_stmt        // C28-6003 Chapter III.F: REWIND i
+    | backspace_stmt     // C28-6003 Chapter III.F: BACKSPACE i
     | format_stmt        // Appendix A: FORMAT (specification)
     | dimension_stmt     // Appendix A: DIMENSION v, v, ...
     | equivalence_stmt   // Appendix A: EQUIVALENCE (a,b,...), ...

--- a/tests/FORTRANII/test_fortran_ii_parser.py
+++ b/tests/FORTRANII/test_fortran_ii_parser.py
@@ -857,6 +857,108 @@ class TestFORTRANIIParser(unittest.TestCase):
                 self.assertIn('(', tree.getText())
                 self.assertIn(')', tree.getText())
 
+    def test_end_file_statement(self):
+        """Test END FILE statement (inherited from FORTRAN I, per C28-6000-2 Appendix A)
+
+        The FORTRAN II manual (C28-6000-2) documents that FORTRAN II includes
+        all FORTRAN I statements including file-control statements.
+
+        END FILE writes an end-of-file mark on a tape unit:
+            END FILE i
+        where i is a tape unit number (integer expression).
+        Reference: IBM Form C28-6003 Chapter III.F
+        Issue #384: File-control statements not wired into FORTRAN II statement_body
+        """
+        test_cases = [
+            ("END FILE 1", 1),
+            ("END FILE 10", 10),
+            ("END FILE ITAPE", None),
+        ]
+
+        for text, unit_num in test_cases:
+            with self.subTest(end_file_stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree, f"Failed to parse: {text}")
+                # Verify END FILE keywords present
+                tree_text = tree.getText()
+                self.assertIn('END', tree_text)
+                self.assertIn('FILE', tree_text)
+
+    def test_rewind_statement(self):
+        """Test REWIND statement (inherited from FORTRAN I, per C28-6000-2 Appendix A)
+
+        The FORTRAN II manual (C28-6000-2) documents that FORTRAN II includes
+        all FORTRAN I statements including file-control statements.
+
+        REWIND rewinds tape unit to the beginning:
+            REWIND i
+        where i is a tape unit number (integer expression).
+        Reference: IBM Form C28-6003 Chapter III.F
+        Issue #384: File-control statements not wired into FORTRAN II statement_body
+        """
+        test_cases = [
+            ("REWIND 1", 1),
+            ("REWIND 5", 5),
+            ("REWIND ITAPE", None),
+        ]
+
+        for text, unit_num in test_cases:
+            with self.subTest(rewind_stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree, f"Failed to parse: {text}")
+                # Verify REWIND keyword present
+                tree_text = tree.getText()
+                self.assertIn('REWIND', tree_text)
+
+    def test_backspace_statement(self):
+        """Test BACKSPACE statement (inherited from FORTRAN I, per C28-6000-2 Appendix A)
+
+        The FORTRAN II manual (C28-6000-2) documents that FORTRAN II includes
+        all FORTRAN I statements including file-control statements.
+
+        BACKSPACE repositions tape unit back one logical record:
+            BACKSPACE i
+        where i is a tape unit number (integer expression).
+        Reference: IBM Form C28-6003 Chapter III.F
+        Issue #384: File-control statements not wired into FORTRAN II statement_body
+        """
+        test_cases = [
+            ("BACKSPACE 1", 1),
+            ("BACKSPACE 7", 7),
+            ("BACKSPACE ITAPE", None),
+        ]
+
+        for text, unit_num in test_cases:
+            with self.subTest(backspace_stmt=text):
+                tree = self.parse(text, 'statement_body')
+                self.assertIsNotNone(tree, f"Failed to parse: {text}")
+                # Verify BACKSPACE keyword present
+                tree_text = tree.getText()
+                self.assertIn('BACKSPACE', tree_text)
+
+    def test_file_control_statements_in_program(self):
+        """Test file-control statements in a complete FORTRAN II program
+
+        Verify END FILE, REWIND, and BACKSPACE parse correctly within
+        a full FORTRAN II program structure (issue #384).
+        """
+        program_text = """
+        DIMENSION DATA(100)
+        REWIND 1
+        BACKSPACE 1
+        END FILE 1
+        STOP
+        END
+        """
+        tree = self.parse(program_text, 'main_program')
+        self.assertIsNotNone(tree)
+        text = tree.getText()
+        # Verify all file-control statements are present
+        self.assertIn('REWIND', text)
+        self.assertIn('BACKSPACE', text)
+        self.assertIn('END', text)
+        self.assertIn('FILE', text)
+
 
 class TestStrictCommon(unittest.TestCase):
     """Test strict 1958 COMMON mode (blank COMMON only, per issue #156)"""


### PR DESCRIPTION
## Summary

Wire file-control statements (END FILE, REWIND, BACKSPACE) into the FORTRAN II grammar's `statement_body` and `statement_body_strict` rules. These statements were already implemented in FORTRAN I but were missing from FORTRAN II despite being part of the inherited FORTRAN I statement set per C28-6000-2.

## Changes

### Grammar (grammars/src/FORTRANIIParser.g4)
- Added `end_file_stmt` to both `statement_body` and `statement_body_strict` (line 196, 232)
- Added `rewind_stmt` to both `statement_body` and `statement_body_strict` (line 197, 233)
- Added `backspace_stmt` to both `statement_body` and `statement_body_strict` (line 198, 234)
- Included C28-6003 Chapter III.F references in comments

### Tests (tests/FORTRANII/test_fortran_ii_parser.py)
- Added `test_end_file_statement` - tests END FILE i syntax
- Added `test_rewind_statement` - tests REWIND i syntax  
- Added `test_backspace_statement` - tests BACKSPACE i syntax
- Added `test_file_control_statements_in_program` - integration test in complete program

### Documentation (docs/fortran_ii_audit.md)
- Updated intro to mention file-control statements are implemented per issue #384
- Updated section 8.3 crosswalk table to mark file-control statements as Implemented
- Updated section 8.4 implementation notes with file-control statements
- Removed file-control statements from gaps list (tape/drum I/O remains)

## Verification

- All 1290 tests pass, including 4 new file-control statement tests
- File-control statements now parse in FORTRAN II main programs
- Both relaxed and strict modes support file-control statements

## Standards Compliance

- END FILE i: IBM Form C28-6003 Chapter III.F (magnetic tape end-of-file mark)
- REWIND i: IBM Form C28-6003 Chapter III.F (rewind magnetic tape)
- BACKSPACE i: IBM Form C28-6003 Chapter III.F (backspace one record on tape)
- FORTRAN II inheritance: IBM Form C28-6000-2, Part I, Chapter 1 (states all FORTRAN I statements remain available)