### PR TITLE
fix: add ASYNCHRONOUS attribute to attr_spec (fixes #413)

### DIFF
--- a/docs/fortran_2003_audit.md
+++ b/docs/fortran_2003_audit.md
@@ -446,6 +446,13 @@ Gap issues (resolved):
   is modeled structurally. Tests in
   `tests/Fortran2003/test_issue185_dt_edit_descriptors.py` verify that
   FORMAT strings containing DT descriptors are accepted correctly.
+- Issue #413: **ASYNCHRONOUS attribute missing from attr_spec** (RESOLVED)
+  - The ASYNCHRONOUS attribute (ISO/IEC 1539-1:2004 Section 5.1.2.1, R503)
+    was previously documented in grammar comments but not implemented in the
+    `attr_spec` rule. Now correctly added to `Fortran2003Parser.g4` line 1554.
+  - Allows valid declarations like `integer, asynchronous :: buffer`.
+  - Tests in `tests/Fortran2003/test_issue413_asynchronous_attribute.py` verify
+    ASYNCHRONOUS can be used alone and combined with other attributes.
 
 ---
 

--- a/grammars/src/Fortran2003Parser.g4
+++ b/grammars/src/Fortran2003Parser.g4
@@ -1551,6 +1551,7 @@ attr_spec
     : PUBLIC
     | PRIVATE
     | ALLOCATABLE
+    | ASYNCHRONOUS      // F2003 (Section 5.1.2.1)
     | POINTER
     | INTENT LPAREN intent_spec RPAREN
     | OPTIONAL

--- a/tests/Fortran2003/test_issue413_asynchronous_attribute.py
+++ b/tests/Fortran2003/test_issue413_asynchronous_attribute.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Test for Fortran 2003 ASYNCHRONOUS attribute (Issue #413).
+Verifies that ASYNCHRONOUS is correctly parsed as an attr_spec (ISO/IEC 1539-1:2004 R503).
+"""
+
+import sys
+import pytest
+from pathlib import Path
+
+# Add tests root (for fixture_utils) and grammars directory to path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT.parent / "grammars/generated/modern"))
+
+from fixture_utils import load_fixture
+
+from antlr4 import *
+
+
+class TestAsynchronousAttribute:
+    """Test Fortran 2003 ASYNCHRONOUS attribute parsing."""
+
+    def parse_fortran_code(self, code, expect_success=True):
+        """Helper to parse Fortran 2003 code."""
+        try:
+            from Fortran2003Lexer import Fortran2003Lexer
+            from Fortran2003Parser import Fortran2003Parser
+
+            input_stream = InputStream(code)
+            lexer = Fortran2003Lexer(input_stream)
+            parser = Fortran2003Parser(CommonTokenStream(lexer))
+
+            # Parse starting with F2003 program unit
+            tree = parser.program_unit_f2003()
+            errors = parser.getNumberOfSyntaxErrors()
+
+            if expect_success:
+                assert errors == 0, f"Parse failed with {errors} errors"
+                assert tree is not None, "Parse tree is None"
+
+            return tree, errors, None
+
+        except Exception as e:
+            if expect_success:
+                assert False, f"Exception during parsing: {e}"
+            return None, -1, str(e)
+
+    def test_asynchronous_simple(self):
+        """Test simple ASYNCHRONOUS attribute on variable (ISO/IEC 1539-1:2004 Section 5.1.2.1)."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue413_asynchronous_attribute",
+            "asynchronous_simple.f90",
+        )
+        tree, errors, exception = self.parse_fortran_code(code)
+        assert errors == 0, f"Failed to parse asynchronous_simple.f90: {errors} errors"
+        assert tree is not None, "Parse tree is None"
+
+    def test_asynchronous_with_io(self):
+        """Test ASYNCHRONOUS attribute with asynchronous I/O operations."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue413_asynchronous_attribute",
+            "asynchronous_with_io.f90",
+        )
+        tree, errors, exception = self.parse_fortran_code(code)
+        assert errors == 0, f"Failed to parse asynchronous_with_io.f90: {errors} errors"
+        assert tree is not None, "Parse tree is None"
+
+    def test_asynchronous_subroutine(self):
+        """Test ASYNCHRONOUS attribute in subroutine arguments."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_issue413_asynchronous_attribute",
+            "asynchronous_subroutine.f90",
+        )
+        tree, errors, exception = self.parse_fortran_code(code)
+        assert errors == 0, f"Failed to parse asynchronous_subroutine.f90: {errors} errors"
+        assert tree is not None, "Parse tree is None"
+
+    def test_asynchronous_with_other_attributes(self):
+        """Test ASYNCHRONOUS combined with other attributes."""
+        code = """program test_async_combined
+    implicit none
+    integer, asynchronous, allocatable :: data_buffer
+    integer, asynchronous, intent(inout) :: status_var
+    real, asynchronous, target :: shared_data
+end program test_async_combined
+"""
+        tree, errors, exception = self.parse_fortran_code(code)
+        assert errors == 0, f"Failed to parse combined attributes code: {errors} errors"
+        assert tree is not None, "Parse tree is None"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/fixtures/Fortran2003/test_issue413_asynchronous_attribute/asynchronous_simple.f90
+++ b/tests/fixtures/Fortran2003/test_issue413_asynchronous_attribute/asynchronous_simple.f90
@@ -1,0 +1,8 @@
+! Test Fortran 2003 ASYNCHRONOUS attribute (ISO/IEC 1539-1:2004 Section 5.1.2.1, R503)
+program test_asynchronous_simple
+    implicit none
+    integer, asynchronous :: buffer(100)
+    integer :: stat
+
+    buffer = 0
+end program test_asynchronous_simple

--- a/tests/fixtures/Fortran2003/test_issue413_asynchronous_attribute/asynchronous_subroutine.f90
+++ b/tests/fixtures/Fortran2003/test_issue413_asynchronous_attribute/asynchronous_subroutine.f90
@@ -1,0 +1,18 @@
+! Test Fortran 2003 ASYNCHRONOUS attribute in subroutine (ISO/IEC 1539-1:2004 Section 5.1.2.1)
+subroutine process_async_data(buffer, unit)
+    integer, asynchronous, intent(inout) :: buffer
+    integer, intent(in) :: unit
+end subroutine process_async_data
+
+program test_async_subroutine
+    implicit none
+    integer, asynchronous, allocatable :: data_buffer
+    integer :: unit_id
+
+    allocate(data_buffer)
+
+    open(newunit=unit_id, file='async_test.dat')
+
+    close(unit_id)
+    deallocate(data_buffer)
+end program test_async_subroutine

--- a/tests/fixtures/Fortran2003/test_issue413_asynchronous_attribute/asynchronous_with_io.f90
+++ b/tests/fixtures/Fortran2003/test_issue413_asynchronous_attribute/asynchronous_with_io.f90
@@ -1,0 +1,14 @@
+! Test Fortran 2003 ASYNCHRONOUS attribute with I/O (ISO/IEC 1539-1:2004 Section 5.1.2.1)
+program test_asynchronous_io
+    implicit none
+    integer, asynchronous, allocatable :: async_buffer
+    integer :: ios, unit_id
+
+    allocate(async_buffer)
+
+    open(newunit=unit_id, file='test.dat')
+
+    close(unit_id)
+
+    deallocate(async_buffer)
+end program test_asynchronous_io


### PR DESCRIPTION
## Summary

Implement the ASYNCHRONOUS attribute (ISO/IEC 1539-1:2004 Section 5.1.2.1, R503) in the Fortran 2003 grammar. The attribute token was already defined in the lexer and documented in grammar comments, but was missing from the `attr_spec` parser rule, making it impossible to parse valid code like `integer, asynchronous :: buffer`.

## Changes

- **grammars/src/Fortran2003Parser.g4**: Added `ASYNCHRONOUS` alternative to `attr_spec` rule at line 1554 with ISO section reference
- **test_issue413_asynchronous_attribute.py**: Created comprehensive test suite with 4 test cases
- **Test fixtures**: Created 3 fixture files demonstrating ASYNCHRONOUS usage (simple declaration, with I/O, in subroutine)
- **docs/fortran_2003_audit.md**: Added resolution note documenting the fix

## Verification

```bash
make test
# Result: 1297 passed, 1 skipped
```

All tests pass including:
- New ASYNCHRONOUS attribute tests (4/4 passed)
- Existing Fortran 2003 fixture parsing tests
- Full test suite (all standards FORTRAN 1957 through Fortran 2023)

## Standard Compliance

- **ISO/IEC 1539-1:2004 Section 5.1.2.1**: ASYNCHRONOUS attribute for variables
- **R503**: attr-spec → ALLOCATABLE | ASYNCHRONOUS | BIND(C) | ...
- **Status**: STANDARD-COMPLIANT

The implementation is minimal and focused - it adds the missing attribute to enable parsing of valid Fortran 2003 code.