### PR TITLE
fix: implement Fortran 2008 advanced bit manipulation intrinsics (fixes #382)

### DIFF
--- a/grammars/src/Fortran2008Lexer.g4
+++ b/grammars/src/Fortran2008Lexer.g4
@@ -251,6 +251,22 @@ BGT              : B G T ;
 BLE              : B L E ;
 BLT              : B L T ;
 
+// Advanced bit manipulation intrinsics (Section 13.7.50-51, 103, 112, 133-134, 168)
+// - DSHIFTL(I,J,SHIFT): Combined left shift (Section 13.7.50)
+// - DSHIFTR(I,J,SHIFT): Combined right shift (Section 13.7.51)
+// - LEADZ(I): Number of leading zero bits (Section 13.7.103)
+// - MERGE_BITS(I,J,MASK): Merge bits under mask (Section 13.7.112)
+// - POPCNT(I): Population count (Section 13.7.133)
+// - POPPAR(I): Population parity (Section 13.7.134)
+// - TRAILZ(I): Number of trailing zero bits (Section 13.7.168)
+DSHIFTL          : D S H I F T L ;
+DSHIFTR          : D S H I F T R ;
+LEADZ            : L E A D Z ;
+MERGE_BITS       : M E R G E '_' B I T S ;
+POPCNT           : P O P C N T ;
+POPPAR           : P O P P A R ;
+TRAILZ           : T R A I L Z ;
+
 // ============================================================================
 // ATOMIC INTRINSICS (ISO/IEC 1539-1:2010 Section 13.7.19-13.7.21)
 // ============================================================================

--- a/grammars/src/Fortran2008Parser.g4
+++ b/grammars/src/Fortran2008Parser.g4
@@ -808,6 +808,7 @@ intrinsic_function_call_f2008
     | bit_mask_function_call          // Bit mask intrinsics (Section 13.7.110-111)
     | bit_reduction_function_call     // Bit reduction (Section 13.7.79-80, 94)
     | bitwise_comparison_function_call // Bitwise comparison (Section 13.7.28-31)
+    | advanced_bit_function_call      // Advanced bit manipulation (Section 13.7)
     ;
 
 // Bessel function calls (ISO/IEC 1539-1:2010 Section 13.7.22-27)
@@ -893,6 +894,18 @@ bitwise_comparison_function_call
     | BGT LPAREN actual_arg_list RPAREN         // Section 13.7.29
     | BLE LPAREN actual_arg_list RPAREN         // Section 13.7.30
     | BLT LPAREN actual_arg_list RPAREN         // Section 13.7.31
+    ;
+
+// Advanced bit manipulation function calls (ISO/IEC 1539-1:2010 Section 13.7)
+// Double shifts, bit counting, and merge operations
+advanced_bit_function_call
+    : DSHIFTL LPAREN actual_arg_list RPAREN     // Section 13.7.50
+    | DSHIFTR LPAREN actual_arg_list RPAREN     // Section 13.7.51
+    | LEADZ LPAREN actual_arg_list RPAREN       // Section 13.7.103
+    | MERGE_BITS LPAREN actual_arg_list RPAREN  // Section 13.7.112
+    | POPCNT LPAREN actual_arg_list RPAREN      // Section 13.7.133
+    | POPPAR LPAREN actual_arg_list RPAREN      // Section 13.7.134
+    | TRAILZ LPAREN actual_arg_list RPAREN      // Section 13.7.168
     ;
 
 // ============================================================================
@@ -1109,6 +1122,14 @@ identifier_or_keyword
     | BGT          // BGT can be used as variable name
     | BLE          // BLE can be used as variable name
     | BLT          // BLT can be used as variable name
+    // F2008 advanced bit manipulation intrinsics (Section 13.7)
+    | DSHIFTL      // DSHIFTL can be used as variable name
+    | DSHIFTR      // DSHIFTR can be used as variable name
+    | LEADZ        // LEADZ can be used as variable name
+    | MERGE_BITS   // MERGE_BITS can be used as variable name
+    | POPCNT       // POPCNT can be used as variable name
+    | POPPAR       // POPPAR can be used as variable name
+    | TRAILZ       // TRAILZ can be used as variable name
     // F2008 atomic intrinsics (Section 13.7.19-20)
     | ATOMIC_DEFINE  // ATOMIC_DEFINE can be used as variable name
     | ATOMIC_REF     // ATOMIC_REF can be used as variable name

--- a/tests/Fortran2008/test_basic_f2008_features.py
+++ b/tests/Fortran2008/test_basic_f2008_features.py
@@ -257,6 +257,17 @@ class TestBasicF2008Features:
         assert tree is not None, "Bitwise comparison intrinsics failed to produce parse tree"
         assert errors == 0, f"Expected 0 errors for bitwise comparison intrinsics, got {errors}"
 
+    def test_advanced_bit_intrinsics(self):
+        """Test advanced bit manipulation intrinsics DSHIFTL, DSHIFTR, LEADZ, MERGE_BITS, POPCNT, POPPAR, TRAILZ (ISO 13.7.50-51, 103, 112, 133-134, 168)"""
+        code = load_fixture(
+            "Fortran2008",
+            "test_basic_f2008_features",
+            "advanced_bit_intrinsics.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "Advanced bit intrinsics failed to produce parse tree"
+        assert errors == 0, f"Expected 0 errors for advanced bit intrinsics, got {errors}"
+
     def test_atomic_intrinsics(self):
         """Test ATOMIC_DEFINE and ATOMIC_REF intrinsics (ISO 13.7.19-20)"""
         code = load_fixture(

--- a/tests/fixtures/Fortran2008/test_basic_f2008_features/advanced_bit_intrinsics.f90
+++ b/tests/fixtures/Fortran2008/test_basic_f2008_features/advanced_bit_intrinsics.f90
@@ -1,0 +1,87 @@
+! Test Fortran 2008 advanced bit manipulation intrinsics (ISO/IEC 1539-1:2010 Section 13.7)
+! - DSHIFTL(I,J,SHIFT): Combined left shift (Section 13.7.50)
+! - DSHIFTR(I,J,SHIFT): Combined right shift (Section 13.7.51)
+! - LEADZ(I): Leading zero count (Section 13.7.103)
+! - MERGE_BITS(I,J,MASK): Merge bits under mask (Section 13.7.112)
+! - POPCNT(I): Population count (Section 13.7.133)
+! - POPPAR(I): Population parity (Section 13.7.134)
+! - TRAILZ(I): Trailing zero count (Section 13.7.168)
+
+module test_advanced_bit_intrinsics
+    implicit none
+contains
+    subroutine test_double_shift_functions()
+        ! Test DSHIFTL and DSHIFTR (Section 13.7.50-51)
+        integer :: a, b, shift, result_val
+
+        a = 15
+        b = 240
+        shift = 4
+
+        ! Section 13.7.50: DSHIFTL - Combined left shift
+        result_val = dshiftl(a, b, shift)
+
+        ! Section 13.7.51: DSHIFTR - Combined right shift
+        result_val = dshiftr(a, b, shift)
+    end subroutine test_double_shift_functions
+
+    subroutine test_bit_counting_functions()
+        ! Test LEADZ, POPCNT, POPPAR, TRAILZ (Section 13.7.103, 133-134, 168)
+        integer :: a, count_val
+
+        a = 15
+
+        ! Section 13.7.103: LEADZ - Leading zero count
+        count_val = leadz(a)
+        count_val = leadz(0)
+
+        ! Section 13.7.133: POPCNT - Population count
+        count_val = popcnt(a)
+        count_val = popcnt(-1)
+
+        ! Section 13.7.134: POPPAR - Population parity
+        count_val = poppar(a)
+        count_val = poppar(7)
+
+        ! Section 13.7.168: TRAILZ - Trailing zero count
+        count_val = trailz(a)
+        count_val = trailz(16)
+    end subroutine test_bit_counting_functions
+
+    subroutine test_merge_bits_function()
+        ! Test MERGE_BITS (Section 13.7.112)
+        integer :: a, b, mask, result_val
+
+        a = 15
+        b = 240
+        mask = 255
+
+        ! Section 13.7.112: MERGE_BITS - Merge under mask
+        ! Result = IOR(IAND(I, MASK), IAND(J, NOT(MASK)))
+        result_val = merge_bits(a, b, mask)
+        result_val = merge_bits(a, b, 0)
+        result_val = merge_bits(a, b, -1)
+    end subroutine test_merge_bits_function
+
+    subroutine test_array_operations()
+        ! Test elemental behavior with arrays
+        integer :: arr_a(4), arr_b(4), arr_result(4)
+        integer :: arr_counts(4)
+        integer :: shift
+
+        arr_a = [1, 3, 7, 15]
+        arr_b = [16, 32, 64, 128]
+        shift = 2
+
+        ! Double shift with arrays
+        arr_result = dshiftl(arr_a, arr_b, shift)
+        arr_result = dshiftr(arr_a, arr_b, shift)
+
+        ! Bit counting with arrays
+        arr_counts = popcnt(arr_a)
+        arr_counts = leadz(arr_a)
+        arr_counts = trailz(arr_b)
+        arr_counts = poppar(arr_a)
+    end subroutine test_array_operations
+
+end module test_advanced_bit_intrinsics


### PR DESCRIPTION
## Summary

Implement seven advanced bit manipulation intrinsics from ISO/IEC 1539-1:2010 Section 13.7 that are required for comprehensive F2008 intrinsic coverage.

## Changes

### Lexer (`Fortran2008Lexer.g4`)
- Added tokens for: DSHIFTL, DSHIFTR, LEADZ, MERGE_BITS, POPCNT, POPPAR, TRAILZ

### Parser (`Fortran2008Parser.g4`)
- Added `advanced_bit_function_call` rule with all seven intrinsics
- Updated `intrinsic_function_call_f2008` to include advanced bit functions
- Updated `identifier_or_keyword` to allow these tokens as variable names

### Test Coverage
- Added `advanced_bit_intrinsics.f90` fixture with:
  - Double shift operations (DSHIFTL, DSHIFTR)
  - Bit counting functions (LEADZ, POPCNT, POPPAR, TRAILZ)
  - Merge bits operation (MERGE_BITS)
  - Array operations (elemental behavior)
- Added test case `test_advanced_bit_intrinsics` to `test_basic_f2008_features.py`

## Verification

- All 25 F2008 basic feature tests pass
- All code compliance checks pass (88-column limit)
- All existing tests continue to pass (1312 total tests pass)

## ISO Standard References

- ISO/IEC 1539-1:2010 Section 13.7.50-51: Double shift functions
- ISO/IEC 1539-1:2010 Section 13.7.103: LEADZ (leading zero count)
- ISO/IEC 1539-1:2010 Section 13.7.112: MERGE_BITS (merge under mask)
- ISO/IEC 1539-1:2010 Section 13.7.133: POPCNT (population count)
- ISO/IEC 1539-1:2010 Section 13.7.134: POPPAR (population parity)
- ISO/IEC 1539-1:2010 Section 13.7.168: TRAILZ (trailing zero count)