### PR TITLE
fix: implement Fortran 2008 NEWUNIT I/O specifier (fixes #416)

### DIFF
--- a/grammars/src/Fortran2008Lexer.g4
+++ b/grammars/src/Fortran2008Lexer.g4
@@ -343,6 +343,16 @@ REAL64           : R E A L '6' '4' ;
 REAL128          : R E A L '1' '2' '8' ;
 
 // ============================================================================
+// ENHANCED I/O SPECIFIERS (ISO/IEC 1539-1:2010 Section 9.5.6.10)
+// ============================================================================
+// Fortran 2008 adds the NEWUNIT specifier for automatic unit number allocation
+// in OPEN statements, eliminating manual unit management and avoiding conflicts.
+// - R905: connect-spec -> ... | NEWUNIT= scalar-int-variable
+// - NEWUNIT returns a unique, negative unit number for the opened file
+// - Mutually exclusive with UNIT= specifier (constraint C924)
+NEWUNIT          : N E W U N I T ;
+
+// ============================================================================
 // CASE-INSENSITIVE FRAGMENTS (inherited from F2003)
 // ============================================================================
 // All letter fragments inherited from Fortran2003Lexer for case-insensitive

--- a/grammars/src/Fortran2008Parser.g4
+++ b/grammars/src/Fortran2008Parser.g4
@@ -312,6 +312,10 @@ executable_construct_f2008
     | sync_construct                  // SYNC (Section 8.5) - NEW in F2008
     | wait_stmt                       // WAIT (Section 9.7.1)
     | flush_stmt                      // FLUSH (Section 9.7.2)
+    | open_stmt                       // OPEN (Section 9.5.6) - Enhanced with NEWUNIT
+    | close_stmt                      // CLOSE (Section 9.5.7)
+    | write_stmt                      // WRITE (Section 9.4)
+    | read_stmt                       // READ (Section 9.4)
     | if_construct                    // IF (Section 8.1.7)
     | do_construct_f2008              // DO (Section 8.1.6) - Enhanced in F2008
     | select_case_construct           // SELECT CASE (Section 8.1.8)
@@ -1058,6 +1062,43 @@ elsewhere_stmt
     ;
 
 // ============================================================================
+// ENHANCED I/O SPECIFIER OVERRIDE (ISO/IEC 1539-1:2010 Section 9.5.6.10)
+// ============================================================================
+// F2008 extends the I/O specifier list with NEWUNIT for OPEN statements.
+// This rule overrides f2003_io_spec to add the NEWUNIT specifier.
+// R905: connect-spec -> ... | NEWUNIT= scalar-int-variable
+f2003_io_spec
+    : IDENTIFIER EQUALS primary
+        // Regular identifier = value (file='test.dat')
+    | UNIT EQUALS primary                        // unit=10, unit=*
+    | FILE EQUALS primary                        // file='filename'
+    | ACCESS EQUALS primary                      // access='stream' (F2003)
+    | FORM EQUALS primary                        // form='unformatted'
+    | STATUS EQUALS primary                      // status='new'
+    | BLANK EQUALS primary                       // blank='null'
+    | POSITION EQUALS primary                    // position='rewind'
+    | ACTION EQUALS primary                      // action='read'
+    | DELIM EQUALS primary                       // delim='apostrophe'
+    | PAD EQUALS primary                         // pad='yes'
+    | RECL EQUALS primary                        // recl=100
+    | IOSTAT EQUALS primary                      // iostat=ios
+    | IOMSG EQUALS primary                       // iomsg=msg (F2003)
+    | ERR EQUALS primary                         // err=100
+    | END EQUALS primary                         // end=200
+    | EOR EQUALS primary                         // eor=300
+    | ADVANCE EQUALS primary                     // advance='yes'
+    | SIZE EQUALS primary                        // size=isize
+    | REC EQUALS primary                         // rec=irec
+    | ASYNCHRONOUS EQUALS primary                // asynchronous='yes' (F2003)
+    | STREAM EQUALS primary                      // stream='yes' (F2003 R905)
+    | PENDING EQUALS primary                     // pending=var (F2003 R923)
+    | ID EQUALS primary                          // id=id_var (F2003)
+    | FMT EQUALS primary                         // fmt=*, fmt=100, fmt='(DT)'
+    | NEWUNIT EQUALS primary                     // newunit=unit_var (F2008 S9.5.6.10)
+    | primary                                    // Positional: *, 10, '(DT)', etc.
+    ;
+
+// ============================================================================
 // IDENTIFIER OR KEYWORD OVERRIDE (F2008 Extension)
 // ============================================================================
 // F2008 adds several new keywords that can also be used as identifiers.
@@ -1093,6 +1134,7 @@ identifier_or_keyword
     | RECL         // RECL can be used as variable name in I/O
     | IOMSG        // IOMSG can be used as variable name in I/O
     | ASYNCHRONOUS // ASYNCHRONOUS can be used as variable name in I/O
+    | NEWUNIT      // NEWUNIT can be used as variable name in I/O (F2008 S9.5.6.10)
     // F2008-specific tokens that can be used as identifiers
     | IMAGES       // IMAGES can be used as variable name (SYNC IMAGES keyword)
     | ALL          // ALL can be used as variable name (SYNC ALL keyword)

--- a/tests/Fortran2008/test_basic_f2008_features.py
+++ b/tests/Fortran2008/test_basic_f2008_features.py
@@ -329,6 +329,19 @@ class TestBasicF2008Features:
             f"Expected 0 errors for NON_RECURSIVE procedures test, got {errors}"
         )
 
+    def test_newunit_io_specifier(self):
+        """Test NEWUNIT I/O specifier for OPEN statements (ISO/IEC 1539-1:2010 Section 9.5.6.10)"""
+        code = load_fixture(
+            "Fortran2008",
+            "test_basic_f2008_features",
+            "newunit_io.f90",
+        )
+        tree, errors = self.parse_code(code)
+        assert tree is not None, "NEWUNIT I/O specifier failed to produce parse tree"
+        assert errors == 0, (
+            f"Expected 0 errors for NEWUNIT I/O specifier test, got {errors}"
+        )
+
     def test_execute_command_line_intrinsic(self):
         """Test EXECUTE_COMMAND_LINE intrinsic subroutine (ISO/IEC 1539-1:2010 Section 13.7.55)"""
         code = load_fixture(

--- a/tests/fixtures/Fortran2008/test_basic_f2008_features/newunit_io.f90
+++ b/tests/fixtures/Fortran2008/test_basic_f2008_features/newunit_io.f90
@@ -1,0 +1,59 @@
+! Test Fortran 2008 NEWUNIT I/O specifier (ISO/IEC 1539-1:2010 Section 9.5.6.10)
+! NEWUNIT provides automatic assignment of unique unit numbers for OPEN statements,
+! eliminating manual unit number management and avoiding conflicts.
+
+program test_newunit_io
+    implicit none
+
+    ! Automatic unit number assignment via NEWUNIT
+    integer :: unit1, unit2, unit3
+
+    ! Test 1: Basic NEWUNIT with file
+    open(newunit=unit1, file='test1.txt', status='replace', action='write')
+    write(unit1, *) 'Test file 1'
+    close(unit1)
+
+    ! Test 2: NEWUNIT with status and action
+    open(newunit=unit2, file='test2.txt', status='new', action='write')
+    write(unit2, *) 'Test file 2'
+    close(unit2)
+
+    ! Test 3: NEWUNIT with form specifier
+    open(newunit=unit3, file='test3.dat', status='replace', &
+         action='write', form='formatted')
+    write(unit3, '(A)') 'Formatted output'
+    close(unit3)
+
+    ! Test 4: NEWUNIT with access specifier
+    open(newunit=unit1, file='test4.txt', status='replace', &
+         action='write', access='sequential')
+    write(unit1, *) 'Sequential access'
+    close(unit1)
+
+    ! Test 5: NEWUNIT with blank specifier
+    open(newunit=unit2, file='test5.txt', status='replace', &
+         action='write', form='formatted', blank='zero')
+    write(unit2, *) 'Blank handling'
+    close(unit2)
+
+    ! Test 6: NEWUNIT with position specifier
+    open(newunit=unit3, file='test6.txt', status='replace', &
+         action='write', position='rewind')
+    write(unit3, *) 'Position test'
+    close(unit3)
+
+    ! Test 7: NEWUNIT with RECL specifier
+    open(newunit=unit1, file='test7.txt', status='replace', &
+         action='write', recl=100)
+    write(unit1, '(A)') 'Record length test'
+    close(unit1)
+
+    ! Test 8: NEWUNIT with multiple specifiers
+    open(newunit=unit2, file='test8.txt', status='replace', &
+         action='write', form='formatted', access='sequential')
+    write(unit2, *) 'Multiple specifiers'
+    close(unit2)
+
+    print *, 'All NEWUNIT tests completed successfully'
+
+end program test_newunit_io


### PR DESCRIPTION
## Summary

Implements support for the NEWUNIT specifier in OPEN statements as specified in ISO/IEC 1539-1:2010 Section 9.5.6.10. NEWUNIT provides automatic assignment of unique unit numbers, eliminating manual unit management and avoiding conflicts in modular code.

## Changes

- Added NEWUNIT token to Fortran2008Lexer.g4 with comprehensive comments referencing ISO Section 9.5.6.10
- Added NEWUNIT to f2003_io_spec rule in Fortran2008Parser.g4 for syntactic support
- Added NEWUNIT to identifier_or_keyword rule to allow use as variable name
- **Fixed critical bug**: executable_construct_f2008 was missing I/O statements (OPEN, CLOSE, READ, WRITE). These are now explicitly included in the F2008 execution context, enabling I/O operations in F2008 programs
- Created comprehensive test fixture (newunit_io.f90) with 8 distinct test cases covering NEWUNIT with various specifiers (file, status, action, form, access, blank, position, recl)
- Added test case to Fortran2008 test suite

## Verification

All tests pass:
- test_newunit_io_specifier: PASSED
- Full test suite: 1320 passed, 1 skipped
- Grammar compilation: successful with no errors

## Standards Compliance

- ISO/IEC 1539-1:2010 Section 9.5.6.10: NEWUNIT= specifier in OPEN statement
- R905: connect-spec syntax rule
- STANDARD-COMPLIANT: All syntax validated against standard

## Related Issue

Fixes #416