### PR TITLE
fix: SELECT RANK construct with optional END SELECT RANK keyword (fixes #406)

### DIFF
--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -250,8 +250,9 @@ rank_value
     ;
 
 // ISO/IEC 1539-1:2018 R1151: end-select-rank-stmt
+// Extended to support optional RANK keyword for modern compiler extensions
 end_select_rank_stmt
-    : END_SELECT (IDENTIFIER)? NEWLINE
+    : END_SELECT (RANK_KEYWORD)? (IDENTIFIER)? NEWLINE
     ;
 
 // ============================================================================

--- a/tests/Fortran2018/test_issue61_teams_and_collectives.py
+++ b/tests/Fortran2018/test_issue61_teams_and_collectives.py
@@ -82,6 +82,28 @@ class TestF2018TeamsAndCollectivesStatus:
         # Once SELECT RANK is fully wired up, this should parse with zero errors.
         assert errors == 0
 
+    def test_select_rank_with_explicit_end_select_rank(self):
+        """SELECT RANK with END SELECT RANK (modern compiler extension) parses cleanly."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "select_rank_with_end_select_rank.f90",
+        )
+        tree, errors, _ = parse_f2018(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_select_rank_named_with_explicit_end_select_rank(self):
+        """Named SELECT RANK with END SELECT RANK and construct name parses cleanly."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "select_rank_named_with_end_select_rank.f90",
+        )
+        tree, errors, _ = parse_f2018(code)
+        assert tree is not None
+        assert errors == 0
+
     def test_team_event_and_collective_semantics_program(self):
         """Teams, events and collectives program parses without syntax errors."""
         code = load_fixture(

--- a/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_named_with_end_select_rank.f90
+++ b/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_named_with_end_select_rank.f90
@@ -1,0 +1,13 @@
+program select_rank_named_explicit
+  implicit none
+  integer :: rank_value
+
+  my_rank_select: select rank (rank_value)
+  rank (0)
+     rank_value = 0
+  rank (*)
+     rank_value = -1
+  rank default
+     rank_value = -2
+  end select rank my_rank_select
+end program select_rank_named_explicit

--- a/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_with_end_select_rank.f90
+++ b/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_with_end_select_rank.f90
@@ -1,0 +1,13 @@
+program select_rank_explicit_form
+  implicit none
+  integer :: rank_value
+
+  select rank (rank_value)
+  rank (0)
+     rank_value = 0
+  rank (*)
+     rank_value = -1
+  rank default
+     rank_value = -2
+  end select rank
+end program select_rank_explicit_form


### PR DESCRIPTION
## Summary

Implements support for the optional RANK keyword in the `END SELECT RANK` statement, allowing modern Fortran compiler extensions while maintaining backward compatibility with the standard form.

- Extended `end_select_rank_stmt` rule to accept optional RANK keyword
- Allows both `END SELECT` and `END SELECT RANK [construct-name]` forms
- Full test coverage with named and unnamed SELECT RANK constructs

## Verification

- All 1324 tests passing (including 2 new tests for END SELECT RANK form)
- Grammar builds without errors
- Test fixtures:
  - `tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_with_end_select_rank.f90`
  - `tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/select_rank_named_with_end_select_rank.f90`

**Test results:**
```
tests/Fortran2018/test_issue61_teams_and_collectives.py::TestF2018TeamsAndCollectivesStatus::test_select_rank_with_explicit_end_select_rank PASSED
tests/Fortran2018/test_issue61_teams_and_collectives.py::TestF2018TeamsAndCollectivesStatus::test_select_rank_named_with_explicit_end_select_rank PASSED
======================= 1324 passed, 1 skipped in 24.98s =======================
```