### PR TITLE
fix: implement ISO_FORTRAN_ENV intrinsic module support (fixes #420)

### DIFF
--- a/grammars/src/Fortran2003Parser.g4
+++ b/grammars/src/Fortran2003Parser.g4
@@ -1347,12 +1347,21 @@ object_name_list
 // and ISO_C_BINDING (Section 15.2).
 
 // USE statement (ISO/IEC 1539-1:2004 R1109)
+// Supports:
+// - user-defined modules: USE module_name
+// - intrinsic modules: USE, INTRINSIC :: module_name
+// - ISO_FORTRAN_ENV (Section 13.8.2): USE, INTRINSIC :: iso_fortran_env
+// - IEEE modules (Section 14): USE, INTRINSIC :: ieee_*
+// - non-intrinsic: USE, NON_INTRINSIC :: module_name
 use_stmt
     : USE IDENTIFIER NEWLINE
     | USE IDENTIFIER COMMA ONLY COLON only_list NEWLINE
     | USE COMMA INTRINSIC DOUBLE_COLON ieee_module_name NEWLINE
     | USE COMMA INTRINSIC DOUBLE_COLON ieee_module_name COMMA
       ONLY COLON ieee_only_list NEWLINE
+    | USE COMMA INTRINSIC DOUBLE_COLON IDENTIFIER NEWLINE
+    | USE COMMA INTRINSIC DOUBLE_COLON IDENTIFIER COMMA
+      ONLY COLON only_list NEWLINE
     | USE COMMA NON_INTRINSIC DOUBLE_COLON IDENTIFIER NEWLINE
     | USE COMMA NON_INTRINSIC DOUBLE_COLON IDENTIFIER COMMA
       ONLY COLON only_list NEWLINE

--- a/tests/Fortran2003/test_fortran_2003_comprehensive.py
+++ b/tests/Fortran2003/test_fortran_2003_comprehensive.py
@@ -142,7 +142,16 @@ class TestFortran2003Unified:
             "import_mod.f90",
         )
         self.parse_fortran_code(code)
-    
+
+    def test_iso_fortran_env(self):
+        """Test F2003 ISO_FORTRAN_ENV intrinsic module support (issue #420)."""
+        code = load_fixture(
+            "Fortran2003",
+            "test_fortran_2003_comprehensive",
+            "iso_fortran_env_mod.f90",
+        )
+        self.parse_fortran_code(code)
+
     def test_fixed_form_compatibility(self):
         """Test that F2003 features work with fixed-form format."""
         code = "\n" + load_fixture(

--- a/tests/fixtures/Fortran2003/test_fortran_2003_comprehensive/iso_fortran_env_mod.f90
+++ b/tests/fixtures/Fortran2003/test_fortran_2003_comprehensive/iso_fortran_env_mod.f90
@@ -1,0 +1,50 @@
+module iso_fortran_env_mod
+    ! Test ISO_FORTRAN_ENV intrinsic module support
+    ! ISO/IEC 1539-1:2004 Section 13.8.2
+    use, intrinsic :: iso_fortran_env
+    implicit none
+
+contains
+
+    subroutine write_to_output(msg)
+        implicit none
+        character(len=*), intent(in) :: msg
+
+        ! Use OUTPUT_UNIT named constant from ISO_FORTRAN_ENV
+        write(output_unit, '(A)') msg
+    end subroutine write_to_output
+
+    subroutine write_to_error(msg)
+        implicit none
+        character(len=*), intent(in) :: msg
+
+        ! Use ERROR_UNIT named constant from ISO_FORTRAN_ENV
+        write(error_unit, '(A)') msg
+    end subroutine write_to_error
+
+    subroutine check_eof(stat)
+        implicit none
+        integer, intent(in) :: stat
+        integer :: end_code, eor_code
+
+        ! Use IOSTAT_END and IOSTAT_EOR named constants for EOF/EOR detection
+        end_code = iostat_end
+        eor_code = iostat_eor
+
+        if (stat == end_code) then
+            write(output_unit, '(A)') 'End of file reached'
+        end if
+    end subroutine check_eof
+
+end module iso_fortran_env_mod
+
+program test_iso_fortran_env
+    ! Direct use of ISO_FORTRAN_ENV with ONLY list
+    use, intrinsic :: iso_fortran_env, only: output_unit, error_unit, &
+                                             input_unit
+    implicit none
+
+    write(output_unit, '(A)') 'Testing ISO_FORTRAN_ENV support'
+    write(error_unit, '(A)') 'Error unit message'
+
+end program test_iso_fortran_env


### PR DESCRIPTION
## Summary

Implement ISO_FORTRAN_ENV intrinsic module support in Fortran 2003 grammar per ISO/IEC 1539-1:2004 Section 13.8.2.

The grammar now accepts both:
- Bare import: `USE, INTRINSIC :: iso_fortran_env`
- With ONLY clause: `USE, INTRINSIC :: iso_fortran_env, ONLY: output_unit, error_unit, ...`

## Test Results

All 1338 tests pass (100% pass rate):
```
======================= 1338 passed, 1 skipped in 24.47s =======================
✅ All tests completed!
```

## Verification

Test fixture demonstrates:
- Module-level use of ISO_FORTRAN_ENV without ONLY clause
- Program-level use with ONLY clause selecting specific named constants
- References to named constants like `output_unit`, `error_unit`, `input_unit`, `iostat_end`, `iostat_eor`

Files changed:
- `grammars/src/Fortran2003Parser.g4`: Extended use_stmt to accept IDENTIFIER for intrinsic modules
- `tests/Fortran2003/test_fortran_2003_comprehensive.py`: Added test method for ISO_FORTRAN_ENV
- `tests/fixtures/Fortran2003/test_fortran_2003_comprehensive/iso_fortran_env_mod.f90`: Test fixture demonstrating feature

## ISO Standard Compliance

STANDARD-COMPLIANT per ISO/IEC 1539-1:2004 Section 13.8.2: ISO_FORTRAN_ENV provides named constants for standard input/output/error units and IOSTAT status codes.