### PR TITLE
fix: implement BIND(C) attribute for variable declarations (fixes #412)

### DIFF
--- a/grammars/src/Fortran2003Parser.g4
+++ b/grammars/src/Fortran2003Parser.g4
@@ -1608,12 +1608,13 @@ attr_spec_list
 // Attribute specification (ISO/IEC 1539-1:2004 R503)
 // R503: attr-spec -> ALLOCATABLE | ASYNCHRONOUS | BIND(C) | ...
 // F2003 adds VALUE (Section 15.3.5), VOLATILE (Section 5.1.2.16),
-// PROTECTED (Section 5.1.2.10)
+// PROTECTED (Section 5.1.2.10), and BIND(C) for variables (Section 15.3.4)
 attr_spec
     : PUBLIC
     | PRIVATE
     | ALLOCATABLE
     | ASYNCHRONOUS      // F2003 (Section 5.1.2.1)
+    | binding_spec      // F2003 BIND(C) for variables (Section 15.3.4)
     | POINTER
     | INTENT LPAREN intent_spec RPAREN
     | OPTIONAL

--- a/tests/fixtures/Fortran2003/test_issue412_bind_c_variables/bind_c_multiple_attributes.f90
+++ b/tests/fixtures/Fortran2003/test_issue412_bind_c_variables/bind_c_multiple_attributes.f90
@@ -1,0 +1,15 @@
+! ISO/IEC 1539-1:2004 Section 15.3.4
+! BIND(C) combined with other attributes
+program test_bind_c_with_attributes
+    use, intrinsic :: iso_c_binding
+    implicit none
+
+    ! BIND(C) with other attributes
+    real(c_double), target, bind(c, name="target_var") :: target_value
+    integer(c_int), volatile, bind(c, name="volatile_flag") :: flag
+    integer(c_int), bind(c, name="array_values") :: values(10)
+
+    target_value = 3.14d0
+    flag = 1
+    values(1) = 42
+end program test_bind_c_with_attributes

--- a/tests/fixtures/Fortran2003/test_issue412_bind_c_variables/bind_c_simple_variable.f90
+++ b/tests/fixtures/Fortran2003/test_issue412_bind_c_variables/bind_c_simple_variable.f90
@@ -1,0 +1,13 @@
+! ISO/IEC 1539-1:2004 Section 15.3.4
+! BIND(C) attribute for variables
+program test_bind_c_simple
+    use, intrinsic :: iso_c_binding
+    implicit none
+
+    ! Simple BIND(C) on module variable (not in module, but same syntax applies)
+    integer(c_int), bind(c) :: counter
+    real(c_double), bind(c) :: value
+
+    counter = 42
+    value = 3.14d0
+end program test_bind_c_simple

--- a/tests/fixtures/Fortran2003/test_issue412_bind_c_variables/bind_c_with_name.f90
+++ b/tests/fixtures/Fortran2003/test_issue412_bind_c_variables/bind_c_with_name.f90
@@ -1,0 +1,15 @@
+! ISO/IEC 1539-1:2004 Section 15.3.4
+! BIND(C) with NAME specifier for C interop
+program test_bind_c_with_name
+    use, intrinsic :: iso_c_binding
+    implicit none
+
+    ! Variables with C binding and explicit C names
+    integer(c_int), bind(c, name="my_counter") :: counter
+    real(c_double), bind(c, name="global_value") :: value
+    integer(c_int), bind(c, name="array_data") :: data_array(10)
+
+    counter = 42
+    value = 3.14d0
+    data_array(1) = 1
+end program test_bind_c_with_name


### PR DESCRIPTION
## Summary

Implements BIND(C) attribute support for variable type declarations in Fortran 2003, as specified in ISO/IEC 1539-1:2004 Section 15.3.4.

## Changes

- Modified `Fortran2003Parser.g4` `attr_spec` rule to include `binding_spec` alternative
- Variables can now be declared with `BIND(C)` or `BIND(C, NAME="...")` attributes
- Combined with other attributes (TARGET, VOLATILE, etc.) as per standard

## Verification

All 1341 tests pass with no regressions:
```
================= 1341 passed, 1 skipped in 106.81s (0:01:46) ==================
```

Test fixtures added:
- `bind_c_simple_variable.f90` - basic BIND(C) usage
- `bind_c_with_name.f90` - BIND(C, NAME="...") specifier
- `bind_c_multiple_attributes.f90` - BIND(C) with other attributes

## ISO Compliance

**Standard-Compliant**: ISO/IEC 1539-1:2004 Section 15.3.4 - BIND attribute for variables

Resolves #412