### PR TITLE
fix: implement C interoperability intrinsic procedures (fixes #410)

### DIFF
--- a/grammars/src/Fortran2003Lexer.g4
+++ b/grammars/src/Fortran2003Lexer.g4
@@ -257,6 +257,14 @@ C_FUNPTR         : [cC] '_' F U N P T R ;
 C_NULL_PTR       : [cC] '_' N U L L '_' P T R ;
 C_NULL_FUNPTR    : [cC] '_' N U L L '_' F U N P T R ;
 
+// C interoperability intrinsic procedures (Section 15.2.5)
+// These are intrinsic functions for C interoperability
+C_LOC            : [cC] '_' L O C ;
+C_FUNLOC         : [cC] '_' F U N L O C ;
+C_ASSOCIATED     : [cC] '_' A S S O C I A T E D ;
+C_F_POINTER      : [cC] '_' F '_' P O I N T E R ;
+C_F_PROCPOINTER  : [cC] '_' F '_' P R O C P O I N T E R ;
+
 // ====================================================================
 // ADDITIONAL F2003 TOKENS
 // ====================================================================

--- a/grammars/src/Fortran2003Parser.g4
+++ b/grammars/src/Fortran2003Parser.g4
@@ -86,7 +86,7 @@ identifier_or_keyword
     | SHAPE_INTRINSIC  // SHAPE can be used as a type name
     | STAT         // STAT can be used as variable name in ALLOCATE
     | ERRMSG       // ERRMSG can be used as variable name in ALLOCATE
-    | SOURCE       // SOURCE can be used as variable name 
+    | SOURCE       // SOURCE can be used as variable name
     | MOLD         // MOLD can be used as variable name
     | UNIT         // UNIT can be used as variable name in I/O
     | IOSTAT       // IOSTAT can be used as variable name
@@ -102,6 +102,11 @@ identifier_or_keyword
     | RECL         // RECL can be used as variable name in I/O
     | IOMSG        // IOMSG can be used as variable name in I/O
     | ASYNCHRONOUS // ASYNCHRONOUS can be used as variable name in I/O
+    | C_LOC        // C_LOC intrinsic (Section 15.2.5)
+    | C_FUNLOC     // C_FUNLOC intrinsic (Section 15.2.5)
+    | C_ASSOCIATED // C_ASSOCIATED intrinsic (Section 15.2.5)
+    | C_F_POINTER  // C_F_POINTER intrinsic (Section 15.2.5)
+    | C_F_PROCPOINTER // C_F_PROCPOINTER intrinsic (Section 15.2.5)
     ;
 
 // ====================================================================

--- a/tests/Fortran2003/test_issue410_c_interop_intrinsics.py
+++ b/tests/Fortran2003/test_issue410_c_interop_intrinsics.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Issue #410 – Fortran 2003 C interoperability intrinsic procedures
+
+This module tests C interoperability intrinsic procedures as defined in
+ISO/IEC 1539-1:2004 Section 15.2.5:
+- C_LOC(X) – Returns C address of argument
+- C_FUNLOC(X) – Returns C address of procedure argument
+- C_ASSOCIATED(C_PTR_1 [, C_PTR_2]) – Check C pointer association status
+- C_F_POINTER(CPTR, FPTR [, SHAPE]) – Convert C pointer to Fortran pointer
+- C_F_PROCPOINTER(CPTR, FPTR) – Convert C function pointer to Fortran procedure pointer
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from antlr4 import InputStream, CommonTokenStream
+
+sys.path.append(str(Path(__file__).parent.parent))
+sys.path.append(str(Path(__file__).parent.parent.parent / "grammars/generated/modern"))
+
+from Fortran2003Lexer import Fortran2003Lexer
+from Fortran2003Parser import Fortran2003Parser
+
+
+def parse_f2003(code: str):
+    """Parse Fortran 2003 code and return (tree, errors, parser)."""
+    input_stream = InputStream(code)
+    lexer = Fortran2003Lexer(input_stream)
+    parser = Fortran2003Parser(CommonTokenStream(lexer))
+    tree = parser.program_unit_f2003()
+    return tree, parser.getNumberOfSyntaxErrors(), parser
+
+
+class TestF2003CInteropIntrinsics:
+    """Test C interoperability intrinsic procedures."""
+
+    def test_c_loc_basic(self):
+        """C_LOC(X) returns C address of argument."""
+        code = """
+program test_c_loc
+  use, intrinsic :: iso_c_binding
+  implicit none
+  integer(c_int), target :: i
+  type(c_ptr) :: ptr
+
+  ptr = c_loc(i)
+end program test_c_loc
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_funloc_basic(self):
+        """C_FUNLOC(X) returns C address of procedure."""
+        code = """
+program test_c_funloc
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+  interface
+    subroutine c_sub() bind(c)
+    end subroutine
+  end interface
+
+  type(c_funptr) :: fptr
+  fptr = c_funloc(c_sub)
+end program test_c_funloc
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_associated_single_pointer(self):
+        """C_ASSOCIATED(C_PTR) checks if pointer is associated."""
+        code = """
+program test_c_associated
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr) :: ptr
+  logical :: is_assoc
+
+  is_assoc = c_associated(ptr)
+end program test_c_associated
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_associated_two_pointers(self):
+        """C_ASSOCIATED(C_PTR_1, C_PTR_2) compares two pointers."""
+        code = """
+program test_c_associated_compare
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr) :: ptr1, ptr2
+  logical :: same
+
+  same = c_associated(ptr1, ptr2)
+end program test_c_associated_compare
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_f_pointer_basic(self):
+        """C_F_POINTER(CPTR, FPTR) converts C pointer to Fortran pointer."""
+        code = """
+program test_c_f_pointer
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr) :: cptr
+  integer(c_int), pointer :: fptr
+
+  call c_f_pointer(cptr, fptr)
+end program test_c_f_pointer
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_f_pointer_with_shape(self):
+        """C_F_POINTER with SHAPE specifies array dimensions."""
+        code = """
+program test_c_f_pointer_array
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr) :: cptr
+  integer(c_int), pointer :: arr(:,:)
+  integer(c_int) :: shape(2)
+
+  shape = [10, 20]
+  call c_f_pointer(cptr, arr, shape)
+end program test_c_f_pointer_array
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_f_procpointer_basic(self):
+        """C_F_PROCPOINTER(CPTR, FPTR) converts C function pointer to Fortran."""
+        code = """
+program test_c_f_procpointer
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_funptr) :: cfptr
+
+  abstract interface
+    subroutine sub()
+    end subroutine
+  end interface
+
+  procedure(sub), pointer :: fsub
+  call c_f_procpointer(cfptr, fsub)
+end program test_c_f_procpointer
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_all_c_interop_intrinsics_in_module(self):
+        """Integration test: all C interop intrinsics in a module."""
+        code = """
+module c_interop_utils
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+contains
+
+  function get_c_address(x) result(ptr)
+    integer(c_int), target :: x
+    type(c_ptr) :: ptr
+    ptr = c_loc(x)
+  end function get_c_address
+
+  function check_pointer(ptr) result(is_assoc)
+    type(c_ptr) :: ptr
+    logical :: is_assoc
+    is_assoc = c_associated(ptr)
+  end function check_pointer
+
+  subroutine convert_pointer(cptr, fptr)
+    type(c_ptr) :: cptr
+    integer(c_int), pointer :: fptr
+    call c_f_pointer(cptr, fptr)
+  end subroutine convert_pointer
+
+  subroutine convert_procpointer(cfptr, fsub)
+    type(c_funptr) :: cfptr
+    abstract interface
+      subroutine sub()
+      end subroutine
+    end interface
+    procedure(sub), pointer :: fsub
+    call c_f_procpointer(cfptr, fsub)
+  end subroutine convert_procpointer
+
+end module c_interop_utils
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_interop_intrinsics_in_expressions(self):
+        """Test C interop intrinsics used in expressions and assignments."""
+        code = """
+program test_c_interop_expressions
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+  integer(c_int), target :: x, y
+  type(c_ptr) :: ptr_x, ptr_y
+  logical :: ptrs_equal
+
+  ptr_x = c_loc(x)
+  ptr_y = c_loc(y)
+  ptrs_equal = c_associated(ptr_x, ptr_y)
+
+  if (c_associated(ptr_x)) then
+    print *, 'Pointer is associated'
+  end if
+
+end program test_c_interop_expressions
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0
+
+    def test_c_interop_in_interface_block(self):
+        """Test C interop intrinsics in interface blocks."""
+        code = """
+program test_interface
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+  interface
+    subroutine c_procedure(ptr) bind(c)
+      use, intrinsic :: iso_c_binding
+      type(c_ptr), value :: ptr
+    end subroutine
+  end interface
+
+  integer(c_int), target :: x
+  type(c_ptr) :: ptr
+
+  ptr = c_loc(x)
+  call c_procedure(ptr)
+
+end program test_interface
+"""
+        tree, errors, _ = parse_f2003(code)
+        assert tree is not None
+        assert errors == 0


### PR DESCRIPTION
## Summary

Implements ISO/IEC 1539-1:2004 Section 15.2.5 C interoperability intrinsic procedures for Fortran 2003:

- **C_LOC(X)** – Returns C address of argument
- **C_FUNLOC(X)** – Returns C address of procedure argument  
- **C_ASSOCIATED(C_PTR_1 [, C_PTR_2])** – Check C pointer association status
- **C_F_POINTER(CPTR, FPTR [, SHAPE])** – Convert C pointer to Fortran pointer
- **C_F_PROCPOINTER(CPTR, FPTR)** – Convert C function pointer to Fortran procedure pointer

## Implementation Details

### Lexer Changes (Fortran2003Lexer.g4)
Added 5 new tokens after C pointer type declarations:
```antlr
C_LOC            : [cC] '_' L O C ;
C_FUNLOC         : [cC] '_' F U N L O C ;
C_ASSOCIATED     : [cC] '_' A S S O C I A T E D ;
C_F_POINTER      : [cC] '_' F '_' P O I N T E R ;
C_F_PROCPOINTER  : [cC] '_' F '_' P R O C P O I N T E R ;
```

### Parser Changes (Fortran2003Parser.g4)
Wired intrinsic function tokens into `identifier_or_keyword` rule so they can be used as procedure names in function calls. This allows the C interop intrinsics to be called like any other intrinsic function.

### Test Coverage
Added comprehensive test suite with 10 test cases covering:
- Single-pointer C_LOC calls
- Function pointer C_FUNLOC calls
- Single and dual pointer C_ASSOCIATED calls
- C_F_POINTER with and without SHAPE specification
- C_F_PROCPOINTER calls
- Integration test with all intrinsics in a module
- Expression usage and interface blocks

## Verification

- **Build**: Grammar compiles without errors
- **Tests**: All 1351 tests pass (100% pass rate)
- **Compliance**: ISO/IEC 1539-1:2004 Section 15.2.5 fully implemented
- **Formatting**: Code follows 88-column line limit and project standards

### Test Execution
```
make test
======================= 1351 passed, 1 skipped in 25.82s =======================
✅ All tests completed!
```

### Example Usage (now parses correctly)
```fortran
program test_c_interop
  use, intrinsic :: iso_c_binding
  implicit none
  integer(c_int), target :: i
  type(c_ptr) :: ptr

  ptr = c_loc(i)
  if (c_associated(ptr)) then
    print *, 'Pointer is associated'
  end if
end program test_c_interop
```

## Related Issues
Fixes #410 - Fortran 2003: C interoperability intrinsic procedures not implemented