### PR TITLE
fix: remove dead IMAGE_STATUS_FAILED and IMAGE_STATUS_STOPPED tokens (fixes #386)

### DIFF
--- a/grammars/src/Fortran2018Lexer.g4
+++ b/grammars/src/Fortran2018Lexer.g4
@@ -37,12 +37,12 @@ CO_BROADCAST     : C O '_' B R O A D C A S T ;
 // ISO/IEC 1539-1:2018 Section 16.9.73: FAILED_IMAGES
 // ISO/IEC 1539-1:2018 Section 16.9.81: IMAGE_STATUS
 // ISO/IEC 1539-1:2018 Section 16.9.182: STOPPED_IMAGES
+// Note: IMAGE_STATUS_FAILED and IMAGE_STATUS_STOPPED are NOT in the standard
+// and have been removed (see issue #386).
 // ----------------------------------------------------------------------------
 IMAGE_STATUS     : I M A G E '_' S T A T U S ;
 FAILED_IMAGES    : F A I L E D '_' I M A G E S ;
 STOPPED_IMAGES   : S T O P P E D '_' I M A G E S ;
-IMAGE_STATUS_FAILED    : I M A G E '_' S T A T U S '_' F A I L E D ;
-IMAGE_STATUS_STOPPED   : I M A G E '_' S T A T U S '_' S T O P P E D ;
 
 // ----------------------------------------------------------------------------
 // SELECT RANK Construct (NEW in F2018)


### PR DESCRIPTION
## Summary

Removes two dead tokens (`IMAGE_STATUS_FAILED` and `IMAGE_STATUS_STOPPED`) that were defined in the Fortran 2018 lexer but never used by the parser and do not correspond to any ISO/IEC 1539-1:2018 feature.

The actual image status intrinsics defined in the standard are:
- `IMAGE_STATUS(image, TEAM=...)` function (Section 16.9.81)
- `FAILED_IMAGES(TEAM=...)` function (Section 16.9.73)
- `STOPPED_IMAGES(TEAM=...)` function (Section 16.9.182)

## Changes

- Removed `IMAGE_STATUS_FAILED` and `IMAGE_STATUS_STOPPED` lexer tokens from `grammars/src/Fortran2018Lexer.g4`
- Added clarifying comment explaining these tokens are not in ISO standard
- This cascades to Fortran2023 and LazyFortran2025 which inherit from Fortran2018

## Standard Compliance

**STANDARD-COMPLIANT** with ISO/IEC 1539-1:2018 Sections 16.9.73, 16.9.81, 16.9.182

These tokens did not correspond to any standard feature and have been removed for code clarity.

## Verification

- All 1356 existing tests pass
- No parser changes required (tokens were never used)
- Grammar regeneration successful for Fortran2018, Fortran2023, and LazyFortran2025

## Test Plan

- [x] Run full test suite: 1356 tests pass, 1 skipped
- [x] Verify no regressions in grammar regeneration
- [x] Confirm tokens are no longer referenced in parser