### PR TITLE
docs: fix issue #407 and implement issue #394

### DIFF
--- a/docs/fortran_66_audit.md
+++ b/docs/fortran_66_audit.md
@@ -379,17 +379,28 @@ Mapping these families to the current grammar:
 `docs/fixed_form_support.md` describes the Fortran 66 fixed-form
 handling as:
 
-- Layout‑lenient:
+- Layout‑lenient grammar:
   - Statements are parsed according to token sequence, not strict
     column positions.
   - No enforcement of exact 80‑column semantics or sequence numbers.
+  - This makes the grammar suitable for analyzing typical FORTRAN 66 code
+    without reproducing exact card-image behavior.
+- Strict fixed-form validation (optional):
+  - The `tools/strict_fixed_form.py` preprocessor provides optional
+    strict ANSI X3.9-1966 Section 3.3 fixed-form validation and conversion
+    per issue #394.
+  - Supports card-image validation: columns 1-5 (labels), column 6
+    (continuation), columns 7-72 (statement), columns 73-80 (sequence).
+  - Dialect "66" validates labels (1-99999), comment markers (C/*),
+    and continuation rules.
+  - Provides conversion from strict to layout-lenient form for parsing.
+  - Test coverage: `tests/FORTRAN66/test_strict_fixed_form_66.py`
+    includes 22 test cases for card parsing, validation, and conversion.
 - Comments:
-  - Classic column‑1 `C`/`*` forms and sequence fields are treated as
-    historical context but are not modeled with strict semantics in
-    this grammar.
-
-This makes the grammar suitable for analyzing typical FORTRAN 66 code
-without reproducing exact card-image behavior.
+  - Classic column‑1 `C`/`*` forms are recognized as comment cards
+    (per X3.9-1966 Section 3.3).
+  - Sequence fields (columns 73-80) are recognized but not validated
+    (historical context only).
 
 ## 6. Tests and XPASS fixtures
 

--- a/docs/fortran_95_audit.md
+++ b/docs/fortran_95_audit.md
@@ -763,8 +763,9 @@ The following F95 features are **not yet implemented** or have limitations
 and are therefore **NON-COMPLIANT** with the corresponding ISO sections
 until they are addressed:
 
-1. **Automatic deallocation** (Section 6.3.3): Semantic behavior, not syntax –
-   **NON-COMPLIANT** (semantic deallocation rules not modeled).
+1. **Automatic deallocation** (Section 6.3.3): Runtime semantic behavior –
+   **STANDARD-COMPLIANT** (grammar correctly parses ALLOCATABLE syntax; automatic
+   deallocation is a runtime feature outside grammar scope; see #407).
 2. **NULL() intrinsic** (Section 13.10.79): Implemented NULL_INTRINSIC token and
    added to identifier_or_keyword_f95 rule (fixes #376) –
    **STANDARD-COMPLIANT** (intrinsic function with optional MOLD argument).

--- a/tests/FORTRAN66/test_strict_fixed_form_66.py
+++ b/tests/FORTRAN66/test_strict_fixed_form_66.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+Test suite for strict fixed-form card layout semantics for FORTRAN 66.
+
+Tests the StrictFixedFormProcessor against authentic fixed-form source files
+per ANSI X3.9-1966 Section 3.3 (Source Program Format).
+
+Reference: ANSI X3.9-1966 "USA Standard FORTRAN"
+           (American National Standards Institute, March 7, 1966)
+           Section 3.3: Source Program Format
+"""
+
+import sys
+import os
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT.parent / "tools"))
+sys.path.insert(0, str(ROOT))
+
+try:
+    from strict_fixed_form import (
+        StrictFixedFormProcessor,
+        validate_strict_fixed_form_66,
+        convert_to_lenient_66,
+        CardType,
+    )
+    PROCESSOR_AVAILABLE = True
+except ImportError as e:
+    print(f"Import error: {e}")
+    PROCESSOR_AVAILABLE = False
+
+
+class TestFORTRAN66CardParsing(unittest.TestCase):
+    """Test individual card parsing per X3.9-1966 Section 3.3."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+        self.processor = StrictFixedFormProcessor(dialect="66")
+
+    def test_blank_card(self):
+        """Test blank card recognition."""
+        card = self.processor.parse_card("", 1)
+        self.assertEqual(card.card_type, CardType.BLANK)
+        self.assertIsNone(card.label)
+        self.assertFalse(card.continuation)
+
+    def test_comment_card_c(self):
+        """Test C-comment card (column 1 = C)."""
+        card = self.processor.parse_card(
+            "C     THIS IS A COMMENT CARD                                   ", 1
+        )
+        self.assertEqual(card.card_type, CardType.COMMENT)
+
+    def test_comment_card_star(self):
+        """Test *-comment card (column 1 = *)."""
+        card = self.processor.parse_card(
+            "*     ANOTHER COMMENT STYLE                                     ", 1
+        )
+        self.assertEqual(card.card_type, CardType.COMMENT)
+
+    def test_statement_card_with_label(self):
+        """Test statement card with label in columns 1-5."""
+        card = self.processor.parse_card(
+            "  100 CONTINUE                                                  ", 1
+        )
+        self.assertEqual(card.card_type, CardType.STATEMENT)
+        self.assertEqual(card.label, "100")
+        self.assertFalse(card.continuation)
+        self.assertIn("CONTINUE", card.statement_text)
+
+    def test_continuation_card(self):
+        """Test continuation card (column 6 non-blank)."""
+        card = self.processor.parse_card(
+            "     1    LOGICAL X, Y                                           ", 1
+        )
+        self.assertEqual(card.card_type, CardType.CONTINUATION)
+        self.assertTrue(card.continuation)
+        self.assertIsNone(card.label)
+
+    def test_sequence_field_extraction(self):
+        """Test extraction of sequence field (columns 73-80)."""
+        line = "      X = 1.0                                                           00000010"
+        card = self.processor.parse_card(line, 1)
+        self.assertEqual(card.sequence_field, "00000010")
+
+
+class TestFORTRAN66Validation(unittest.TestCase):
+    """Test validation of card sequences per X3.9-1966 Section 3.3."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+
+    def test_valid_simple_program(self):
+        """Test validation of valid simple FORTRAN 66 program."""
+        source = """\
+C     SIMPLE FORTRAN 66 PROGRAM
+      PROGRAM COMPUTE
+      REAL X, Y, Z
+      X = 3.14
+      Y = 2.71
+      Z = X + Y
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+        self.assertEqual(len(result.errors), 0)
+
+    def test_valid_with_labels(self):
+        """Test validation of program with statement labels."""
+        source = """\
+      PROGRAM TEST
+  100 X = 1.0
+  200 Y = 2.0
+      GOTO 300
+  300 CONTINUE
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_valid_fortran66_types(self):
+        """Test FORTRAN 66 type declarations validate."""
+        source = """\
+      PROGRAM TYPES
+      INTEGER I
+      REAL R
+      LOGICAL L
+      DOUBLE PRECISION D
+      COMPLEX C
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_invalid_label_alphabetic(self):
+        """Test detection of alphabetic characters in label field."""
+        source = """\
+ABCDE X = 1.0
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertFalse(result.valid)
+        self.assertTrue(any("label" in e.message.lower() for e in result.errors))
+
+    def test_valid_max_label(self):
+        """Test that maximum label 99999 is accepted."""
+        # Maximum valid is 99999 (right-justified in columns 1-5)
+        source_valid = """\
+99999 CONTINUE
+      END
+"""
+        result_valid = validate_strict_fixed_form_66(source_valid)
+        self.assertTrue(result_valid.valid, f"Label 99999 should be valid. Errors: {result_valid.errors}")
+
+    def test_invalid_continuation_with_label(self):
+        """Test detection of label on continuation card."""
+        source = """\
+      LOGICAL X, Y,
+   101          Z
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertFalse(result.valid)
+
+    def test_valid_continuation_sequence(self):
+        """Test valid continuation card sequence."""
+        source = """\
+      REAL A, B, C, D,
+     1     E, F, G, H
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+
+class TestFORTRAN66LenientConversion(unittest.TestCase):
+    """Test conversion from strict to lenient format."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+
+    def test_comment_conversion(self):
+        """Test C-comments converted to !-comments."""
+        source = """\
+C     THIS IS A COMMENT
+      END
+"""
+        lenient, result = convert_to_lenient_66(source)
+        self.assertTrue(result.valid)
+        self.assertIn("!", lenient)
+
+    def test_label_preservation(self):
+        """Test statement labels preserved in lenient form."""
+        source = """\
+  100 CONTINUE
+      END
+"""
+        lenient, result = convert_to_lenient_66(source)
+        self.assertTrue(result.valid)
+        self.assertIn("100", lenient)
+        self.assertIn("CONTINUE", lenient)
+
+    def test_continuation_joining(self):
+        """Test continuation cards joined into single statements."""
+        source = """\
+      X = A + B +
+     1    C + D
+      END
+"""
+        lenient, result = convert_to_lenient_66(source)
+        self.assertTrue(result.valid)
+        lines = [l for l in lenient.split("\n") if l.strip() and not l.startswith("!")]
+        stmt_line = lines[0]
+        self.assertIn("A + B +", stmt_line)
+        self.assertIn("C + D", stmt_line)
+
+    def test_sequence_field_stripped(self):
+        """Test sequence numbers (cols 73-80) stripped."""
+        source = """\
+      X = 1.0                                                           00000010
+      END                                                               00000020
+"""
+        lenient, result = convert_to_lenient_66(source)
+        self.assertTrue(result.valid)
+        self.assertNotIn("00000010", lenient)
+        self.assertNotIn("00000020", lenient)
+
+
+class TestFORTRAN66DialectConfig(unittest.TestCase):
+    """Test FORTRAN 66 dialect configuration."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+        self.processor = StrictFixedFormProcessor(dialect="66")
+
+    def test_dialect_config_labels(self):
+        """Test FORTRAN 66 allows labels up to 99999."""
+        # Valid: 99999
+        source = """\
+99999 CONTINUE
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid)
+
+    def test_dialect_config_comment_markers(self):
+        """Test FORTRAN 66 allows both C and * comment markers."""
+        c_comment = "C     COMMENT\n      END\n"
+        star_comment = "*     COMMENT\n      END\n"
+
+        result_c = validate_strict_fixed_form_66(c_comment)
+        result_star = validate_strict_fixed_form_66(star_comment)
+
+        self.assertTrue(result_c.valid)
+        self.assertTrue(result_star.valid)
+
+
+class TestFORTRAN66RealWorld(unittest.TestCase):
+    """Test real-world FORTRAN 66 code patterns."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+
+    def test_formatted_io_program(self):
+        """Test typical FORTRAN 66 formatted I/O program."""
+        source = """\
+C     FORMATTED I/O EXAMPLE
+      PROGRAM IOTEST
+      INTEGER N
+      REAL X, Y
+      READ (5, 100) N, X, Y
+  100 FORMAT (I5, 2F10.2)
+      Z = X + Y
+      WRITE (6, 200) Z
+  200 FORMAT (F15.4)
+      STOP
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+        lenient, _ = convert_to_lenient_66(source, strip_comments=True)
+        self.assertIn("PROGRAM", lenient)
+        self.assertIn("FORMAT", lenient)
+
+    def test_subroutine_example(self):
+        """Test FORTRAN 66 subroutine with multiple continuation lines."""
+        source = """\
+C     SUBROUTINE EXAMPLE
+      SUBROUTINE PROCESS(A, B, C,
+     1                   D, E, F)
+      REAL A, B, C, D, E, F
+      A = B + C
+      D = E * F
+      RETURN
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_common_block_example(self):
+        """Test FORTRAN 66 program with COMMON blocks."""
+        source = """\
+      PROGRAM COMMONTEST
+      COMMON /DATA/ X, Y, Z
+      REAL X, Y, Z
+      X = 1.0
+      Y = 2.0
+      Z = 3.0
+      END
+"""
+        result = validate_strict_fixed_form_66(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/strict_fixed_form.py
+++ b/tools/strict_fixed_form.py
@@ -31,7 +31,7 @@ from enum import Enum
 from typing import List, Literal, Optional, Tuple
 
 
-FortranDialect = Literal["1957", "II"]
+FortranDialect = Literal["1957", "II", "66", "77"]
 
 
 class CardType(Enum):
@@ -54,6 +54,18 @@ DIALECT_CONFIG = {
         "label_max": 99999,
         "reference": "C28-6000-2",
         "parser": "FORTRANIIParser",
+    },
+    "66": {
+        "comment_markers": ("C", "*"),
+        "label_max": 99999,
+        "reference": "X3.9-1966",
+        "parser": "FORTRAN66Parser",
+    },
+    "77": {
+        "comment_markers": ("C", "*"),
+        "label_max": 99999,
+        "reference": "X3.9-1978",
+        "parser": "FORTRAN77Parser",
     },
 }
 
@@ -474,6 +486,106 @@ def convert_to_lenient_1957(source: str,
     """
     return convert_to_lenient(source, strict_width, allow_tabs,
                               strip_comments, dialect="1957")
+
+
+def validate_strict_fixed_form_66(source: str,
+                                  strict_width: bool = True,
+                                  allow_tabs: bool = False) -> ValidationResult:
+    """
+    Validate source code as strict fixed-form FORTRAN 66.
+
+    Convenience wrapper for validate_strict_fixed_form with dialect="66".
+
+    Per ANSI X3.9-1966 Section 3.3 (Source Program Format):
+    - Labels must be 1-99999
+    - C or * in column 1 marks a comment card
+    - Column 6 continuation mark
+    - Columns 7-72 contain statement text
+    - Columns 73-80 contain sequence field
+
+    Args:
+        source: Source code text
+        strict_width: Enforce 80-column cards
+        allow_tabs: Allow tab characters
+
+    Returns:
+        ValidationResult with validation status, errors, and parsed cards
+    """
+    return validate_strict_fixed_form(source, strict_width, allow_tabs,
+                                      dialect="66")
+
+
+def convert_to_lenient_66(source: str,
+                          strict_width: bool = True,
+                          allow_tabs: bool = False,
+                          strip_comments: bool = False
+                          ) -> Tuple[str, ValidationResult]:
+    """
+    Validate and convert FORTRAN 66 strict fixed-form to lenient form.
+
+    Convenience wrapper for convert_to_lenient with dialect="66".
+
+    Args:
+        source: Source code text
+        strict_width: Enforce 80-column cards
+        allow_tabs: Allow tab characters
+        strip_comments: If True, omit comment lines from output
+
+    Returns:
+        Tuple of (lenient_source, validation_result)
+    """
+    return convert_to_lenient(source, strict_width, allow_tabs,
+                              strip_comments, dialect="66")
+
+
+def validate_strict_fixed_form_77(source: str,
+                                  strict_width: bool = True,
+                                  allow_tabs: bool = False) -> ValidationResult:
+    """
+    Validate source code as strict fixed-form FORTRAN 77.
+
+    Convenience wrapper for validate_strict_fixed_form with dialect="77".
+
+    Per ANSI X3.9-1978 Section 3.3 (Source Program Format):
+    - Labels must be 1-99999
+    - C or * in column 1 marks a comment card
+    - Column 6 continuation mark
+    - Columns 7-72 contain statement text
+    - Columns 73-80 contain sequence field
+
+    Args:
+        source: Source code text
+        strict_width: Enforce 80-column cards
+        allow_tabs: Allow tab characters
+
+    Returns:
+        ValidationResult with validation status, errors, and parsed cards
+    """
+    return validate_strict_fixed_form(source, strict_width, allow_tabs,
+                                      dialect="77")
+
+
+def convert_to_lenient_77(source: str,
+                          strict_width: bool = True,
+                          allow_tabs: bool = False,
+                          strip_comments: bool = False
+                          ) -> Tuple[str, ValidationResult]:
+    """
+    Validate and convert FORTRAN 77 strict fixed-form to lenient form.
+
+    Convenience wrapper for convert_to_lenient with dialect="77".
+
+    Args:
+        source: Source code text
+        strict_width: Enforce 80-column cards
+        allow_tabs: Allow tab characters
+        strip_comments: If True, omit comment lines from output
+
+    Returns:
+        Tuple of (lenient_source, validation_result)
+    """
+    return convert_to_lenient(source, strict_width, allow_tabs,
+                              strip_comments, dialect="77")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR addresses two documentation and feature implementation issues:

1. **Issue #407**: Clarify FORTRAN 95 automatic deallocation semantics
2. **Issue #394**: Implement FORTRAN 66 strict fixed-form column layout validation

## Changes

### Issue #407 Fix
- Updated `docs/fortran_95_audit.md` Section 11 to clarify automatic deallocation
- Marked automatic deallocation as **STANDARD-COMPLIANT** (grammar correctly parses ALLOCATABLE syntax)
- Documented that automatic deallocation is a **runtime feature**, not a syntactic grammar constraint
- Added reference to issue #407 for tracking

### Issue #394 Implementation
- Extended `tools/strict_fixed_form.py` to support FORTRAN 66 and FORTRAN 77 dialects
- Added `validate_strict_fixed_form_66()` and `convert_to_lenient_66()` convenience functions
- Added `validate_strict_fixed_form_77()` and `convert_to_lenient_77()` convenience functions
- FORTRAN 66 dialect validates per ANSI X3.9-1966 Section 3.3:
  - Columns 1-5: Labels (1-99999)
  - Column 6: Continuation mark (non-blank indicates continuation)
  - Columns 7-72: Statement text
  - Columns 73-80: Sequence field (recognized but not validated)
- Updated `docs/fortran_66_audit.md` Section 5 with fixed-form validation documentation
- Added comprehensive test suite: `tests/FORTRAN66/test_strict_fixed_form_66.py`
  - 22 test cases covering card parsing, validation, and conversion
  - Tests for valid FORTRAN 66 programs, type declarations, continuations
  - Tests for invalid card layouts with proper error detection
  - Real-world test cases (formatted I/O, subroutines, COMMON blocks)

## Verification

All tests pass (1419 passed, 1 skipped):
- Existing 1397 tests continue to pass without regression
- 22 new FORTRAN 66 fixed-form test cases all pass
- Full test suite executed: `make test`

## Test Plan

- [x] Run `make test` - all 1419 tests pass
- [x] Verify FORTRAN 66 fixed-form tests: `pytest tests/FORTRAN66/test_strict_fixed_form_66.py -v`
- [x] Verify audit documentation updates are correct
- [x] Verify no regression in existing functionality