### PR TITLE
docs: update project CLAUDE.md with current open issues and audit status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,9 @@ Each standard has an audit document in `docs/fortran_*_audit.md` that MUST conta
 
 | Issue | Standard | Description |
 |-------|----------|-------------|
-| #153 | FORTRAN 1957/II | Tape/drum I/O statements |
-| #309 | Fortran 2003 | Fixed-form C comment handling |
-| #310 | Fortran 2023 | F2023 grammar features (7 xfail) |
-| #311 | Fortran 90 | Module/control flow gaps (9 xfail) |
-| #313 | Fortran 2008 | CRITICAL, LOCK/UNLOCK, bitwise intrinsics |
+| #399 | FORTRAN 66 | DO loop terminal statement restrictions not enforced (X3.9-1966 Section 7.1.2.8) |
+| #415 | Fortran 95 | Interface-definition characteristics matching not enforced (ISO/IEC 1539-1:1997 Section 12.2) |
+| #427 | FORTRAN 1957 | IF statement forms from Appendix B rows 9-10 not implemented (C28-6003) |
 
 ### Validation Workflow
 

--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -10,8 +10,7 @@ repository actually supports today, based only on the contents of:
 
 This is a descriptive audit of the current implementation. Full
 conformance to the original IBM 704 FORTRAN compiler requires resolving
-the gaps documented in sections 2 and 8 below (tracked by issues #141
-and #153).
+the gaps documented in sections 2 and 8 below (tracked by issue #427).
 
 ## 1. Program structure
 
@@ -339,8 +338,8 @@ each Appendix B entry to the corresponding grammar rule(s) or notes gaps.
 | 6   | IF QUOTIENT OVERFLOW n1, n2   | `if_stmt_quotient_overflow`    | Implemented     |
 | 7   | IF DIVIDE CHECK n1, n2        | `if_stmt_divide_check`         | Implemented     |
 | 8   | IF (SENSE LIGHT i) n1, n2     | `if_stmt_sense_light`          | Implemented     |
-| 9   | IF (a) n1, n2 (where a is...) | Not implemented                | Gap: see #141   |
-| 10  | IF (a) n1, n2 (another form)  | Not implemented                | Gap: see #141   |
+| 9   | IF (a) n1, n2 (where a is...) | Not implemented                | Gap: see #427   |
+| 10  | IF (a) n1, n2 (another form)  | Not implemented                | Gap: see #427   |
 | 11  | SENSE LIGHT i                 | `sense_light_stmt`             | Implemented     |
 | 12  | ASSIGN i TO n                 | `assign_stmt`                  | Implemented     |
 | 13  | FREQUENCY n (i1, i2, ...)     | `frequency_stmt`               | Implemented     |

--- a/docs/fortran_ii_audit.md
+++ b/docs/fortran_ii_audit.md
@@ -10,10 +10,10 @@ repository currently supports, based on:
 - `tests/test_fixture_parsing.py` (XPASS fixtures)
 
 This is a descriptive audit of the current implementation. Full
-conformance to the IBM 704 FORTRAN II manual (C28-6000-2, 1958) requires
-resolving the gaps documented in section 8 below. Tape/drum I/O
-statements are tracked by issue #153 (reopened). File-control statements
-(END FILE, REWIND, BACKSPACE) are implemented per issue #384.
+conformance to the IBM 704 FORTRAN II manual (C28-6000-2, 1958) is
+substantially complete. Tape/drum I/O statements are implemented per
+issue #153 (closed). File-control statements (END FILE, REWIND, BACKSPACE)
+are implemented per issue #384.
 
 ## 1. Program structure and subprograms
 
@@ -396,12 +396,12 @@ or are out of scope for the current grammar:
 | IF QUOTIENT OVERFLOW n1, n2          | `if_stmt_quotient_overflow`    | Implemented     |
 | IF DIVIDE CHECK n1, n2               | `if_stmt_divide_check`         | Implemented     |
 | SENSE LIGHT i                        | `sense_light_stmt`             | Implemented     |
-| READ INPUT TAPE i, n, list           | Not implemented                | Gap: see #153   |
-| READ TAPE i, list                    | Not implemented                | Gap: see #153   |
-| READ DRUM i, j, list                 | Not implemented                | Gap: see #153   |
-| WRITE OUTPUT TAPE i, n, list         | Not implemented                | Gap: see #153   |
-| WRITE TAPE i, list                   | Not implemented                | Gap: see #153   |
-| WRITE DRUM i, j, list                | Not implemented                | Gap: see #153   |
+| READ INPUT TAPE i, n, list           | `read_tape_drum_stmt`          | Implemented     |
+| READ TAPE i, list                    | `read_tape_drum_stmt`          | Implemented     |
+| READ DRUM i, j, list                 | `read_tape_drum_stmt`          | Implemented     |
+| WRITE OUTPUT TAPE i, n, list         | `write_tape_drum_stmt`         | Implemented     |
+| WRITE TAPE i, list                   | `write_tape_drum_stmt`         | Implemented     |
+| WRITE DRUM i, j, list                | `write_tape_drum_stmt`         | Implemented     |
 | END FILE i                           | `end_file_stmt`                | Implemented     |
 | REWIND i                             | `rewind_stmt`                  | Implemented     |
 | BACKSPACE i                          | `backspace_stmt`               | Implemented     |
@@ -429,10 +429,9 @@ been addressed:
   preprocessor (issue #143, closed). Validates IBM 704 card layout per
   C28-6000-2 and converts to lenient form for parsing.
 
-The following features remain as gaps to be resolved:
-
-- Tape/drum I/O forms (READ INPUT TAPE, WRITE OUTPUT TAPE, READ/WRITE
-  TAPE/DRUM) are not implemented. These are tracked by issue #153 (reopened).
+Tape/drum I/O forms (READ INPUT TAPE, WRITE OUTPUT TAPE, READ/WRITE
+TAPE/DRUM) are now implemented (issue #153 closed). There are no
+remaining significant gaps for FORTRAN II coverage.
 
 ## 9. Summary
 


### PR DESCRIPTION
## Summary

Updated project documentation to reflect current state of the repository. This is a Boy Scout Principle fix for outdated documentation that no longer accurately reflected the actual open issues and implementation status.

## Changes

- **CLAUDE.md**: Updated "Current Open Issues (Grammar Gaps)" table to reflect actual open issues (#399, #415, #427) instead of stale references to closed issues (#153, #309, #310, #311, #313)
- **docs/fortran_1957_audit.md**: Updated issue references to point to #427 (the current tracking issue for Appendix B rows 9-10 IF statements)
- **docs/fortran_ii_audit.md**: Updated tape/drum I/O statement status from "Not implemented" to "Implemented" with correct grammar rule references (closed issue #153)

## Verification

All 1451 tests pass, 1 skipped. No functional changes, documentation-only.

```
======================= 1451 passed, 1 skipped in 27.05s =======================
✅ All tests completed!
```