### PR TITLE
docs: correct FORTRAN 1957 audit - statement functions are implemented (row 17)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -346,7 +346,7 @@ each Appendix B entry to the corresponding grammar rule(s) or notes gaps.
 | 14  | DIMENSION v, v, ...           | `dimension_stmt`               | Implemented     |
 | 15  | EQUIVALENCE (a,b,...), ...    | `equivalence_stmt`             | Implemented     |
 | 16  | FORMAT (specification)        | `format_stmt`                  | Implemented     |
-| 17  | f(a, b, ...) = e              | Not implemented                | Gap: stmt func  |
+| 17  | f(a, b, ...) = e              | `statement_function_stmt`      | Implemented     |
 | 18  | DO n i = m1, m2, m3           | `do_stmt_basic`                | Implemented     |
 | 19  | CONTINUE                      | `CONTINUE` token in body       | Implemented     |
 | 20  | READ n, list                  | `read_stmt_basic`              | Implemented     |


### PR DESCRIPTION
## Summary

Fixed inconsistency in the FORTRAN 1957 audit document. The grammar correctly implements statement functions (Appendix B row 17: `f(a, b, ...) = e`), but the Appendix B crosswalk table incorrectly marked them as "Not implemented".

## Changes

- Updated `docs/fortran_1957_audit.md` row 17 from "Not implemented" to "Implemented"
- Added correct grammar rule reference: `statement_function_stmt`
- Aligns crosswalk with implementation (rule exists in `grammars/src/FORTRANParser.g4` lines 73, 153-155)
- Aligns crosswalk with existing test coverage in `tests/FORTRAN/test_fortran_historical_stub.py` (lines 241-300)

## Verification

All 1451 tests pass with zero syntax errors.