### PR TITLE
fix: implement optional double-colon in VOLATILE/PROTECTED (fixes #604)

### DIFF
--- a/grammars/src/Fortran2003Parser.g4
+++ b/grammars/src/Fortran2003Parser.g4
@@ -1327,12 +1327,13 @@ move_alloc_args
 // VOLATILE statement (ISO/IEC 1539-1:2004 R548)
 // R548: volatile-stmt -> VOLATILE [::] object-name-list
 volatile_stmt
-    : VOLATILE DOUBLE_COLON object_name_list NEWLINE
+    : VOLATILE (DOUBLE_COLON)? object_name_list NEWLINE
     ;
 
 // PROTECTED statement (ISO/IEC 1539-1:2004 Section 5.1.2.10)
+// R540: protected-stmt -> PROTECTED [::] entity-name-list
 protected_stmt
-    : PROTECTED DOUBLE_COLON object_name_list NEWLINE
+    : PROTECTED (DOUBLE_COLON)? object_name_list NEWLINE
     ;
 
 object_name_list

--- a/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/combined_volatile_protected.f90
+++ b/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/combined_volatile_protected.f90
@@ -1,0 +1,7 @@
+module test_combined_volatile_protected
+    implicit none
+    integer :: async_var, read_only_var, regular_var
+    volatile async_var
+    protected :: read_only_var
+    ! regular_var has no attributes
+end module test_combined_volatile_protected

--- a/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/protected_with_colon.f90
+++ b/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/protected_with_colon.f90
@@ -1,0 +1,5 @@
+module test_protected_with_colon
+    implicit none
+    integer :: read_only_var
+    protected :: read_only_var
+end module test_protected_with_colon

--- a/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/protected_without_colon.f90
+++ b/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/protected_without_colon.f90
@@ -1,0 +1,5 @@
+module test_protected_without_colon
+    implicit none
+    integer :: read_only_var
+    protected read_only_var
+end module test_protected_without_colon

--- a/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/volatile_with_colon.f90
+++ b/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/volatile_with_colon.f90
@@ -1,0 +1,5 @@
+module test_volatile_with_colon
+    implicit none
+    integer :: async_var
+    volatile :: async_var
+end module test_volatile_with_colon

--- a/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/volatile_without_colon.f90
+++ b/tests/fixtures/Fortran2003/test_issue604_volatile_protected_optional_colon/volatile_without_colon.f90
@@ -1,0 +1,5 @@
+module test_volatile_without_colon
+    implicit none
+    integer :: async_var
+    volatile async_var
+end module test_volatile_without_colon


### PR DESCRIPTION
## Summary

Fixes ISO/IEC 1539-1:2004 compliance issue #604 by making the double-colon (::) optional in VOLATILE and PROTECTED statements, per the standard specification.

## Changes

- **Grammar**: Updated `volatile_stmt` and `protected_stmt` in Fortran2003Parser.g4 to make `DOUBLE_COLON` optional using `(DOUBLE_COLON)?`
- **Compliance**: Aligns with ISO/IEC 1539-1:2004 R548 and R540, which specify `[::] ` (optional double-colon)
- **Tests**: Added comprehensive test fixtures covering both forms:
  - `VOLATILE :: var` (existing form)
  - `VOLATILE var` (new form per standard)
  - `PROTECTED :: var` (existing form)
  - `PROTECTED var` (new form per standard)

## Verification

All 1460 tests pass locally:

\`\`\`
make test
# ... [build warnings] ...
============================ 1460 passed in 27.71s =============================
\`\`\`

### Test Fixtures Added
- `test_issue604_volatile_protected_optional_colon/volatile_with_colon.f90`
- `test_issue604_volatile_protected_optional_colon/volatile_without_colon.f90`
- `test_issue604_volatile_protected_optional_colon/protected_with_colon.f90`
- `test_issue604_volatile_protected_optional_colon/protected_without_colon.f90`
- `test_issue604_volatile_protected_optional_colon/combined_volatile_protected.f90`

All fixtures parse correctly with the updated grammar.