### PR TITLE
fix: FORTRAN 1957 FORMAT slash record separation (fixes #596)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -223,6 +223,10 @@ Implemented (full IBM 704 I/O statement family):
   - Hollerith constants: nHtext (the only string literals in 1957 FORTRAN)
   - Group repetition `n(...)` (including nested parenthesized lists) per
     C28-6003 Chapter III is now modeled via `format_group` (issue #597).
+- Slash (`/` or `//`) record separators per C28-6003 Chapter III and
+  Appendix B row 16 now parse without commas between descriptors. Fixture
+  `tests/fixtures/FORTRAN/test_fortran_parser/format_slash_record_separators.f`
+  validates single/double slash usage (issue #596).
 - `END FILE i` (write end-of-file mark) via `end_file_stmt`.
 - `REWIND i` (rewind tape to beginning) via `rewind_stmt`.
 - `BACKSPACE i` (backspace one record) via `backspace_stmt`.

--- a/grammars/src/FORTRANParser.g4
+++ b/grammars/src/FORTRANParser.g4
@@ -437,9 +437,11 @@ format_stmt
     : FORMAT LPAREN format_specification RPAREN
     ;
 
-// Format specification items - C28-6003 Chapter III
+// Format specification items - C28-6003 Chapter III.
+// Commas are optional so slash descriptors can appear without
+// intervening delimiters (record separators per Appendix B row 16).
 format_specification
-    : format_item (COMMA format_item)*
+    : format_item (COMMA? format_item)*
     ;
 
 // Individual format items - C28-6003 Chapter III

--- a/tests/fixtures/FORTRAN/test_fortran_parser/format_slash_record_separators.f
+++ b/tests/fixtures/FORTRAN/test_fortran_parser/format_slash_record_separators.f
@@ -1,0 +1,6 @@
+! 2025 FORMAT slash separators for IBM 704 record control
+      100  FORMAT(I5/F10.2)
+      200  FORMAT(5HNAME:, A6/5HAGE:, I3)
+      300  FORMAT(I5//F10.2)
+      400  FORMAT(10HRESULTS://3F10.2)
+      END


### PR DESCRIPTION
## Summary
- allow FORMAT specifications to omit commas so slash record separators can appear directly between descriptors
- exercise the slash variants via a new FORTRAN fixture (`tests/fixtures/FORTRAN/test_fortran_parser/format_slash_record_separators.f`)
- document the coverage update and issue #596 resolution in `docs/fortran_1957_audit.md`

## Verification
- `make test 2>&1 | tee /tmp/make_test.log`
- `make lint 2>&1 | tee /tmp/make_lint.log`