### PR TITLE
fix: FORTRAN 77 DO terminal statements coverage (fixes #586)

### DIFF
--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -243,6 +243,17 @@ Tests:
 - `test_enhanced_do_loops` parses examples such as:
   - `DO 100 X = 1.0, 10.0, 0.5`.
   - `DO 200 I = 1, N`.
+  - `test_do_loop_terminal_statement_forms` parses a complete main program
+    with assignment, `CALL`, `READ`, `WRITE`, and arithmetic `IF` terminal
+    statements per ANSI X3.9-1978 Section 11.10.4, proving the parser accepts
+    any labeled executable statement while leaving restricted forms to later
+    analysis (issue #586).
+
+Interpretation:
+
+- `do_stmt` only ensures the terminal label exists; blockage of GO TO, RETURN,
+  STOP, PAUSE, DO, block IF, ELSE IF, ELSE, or END IF terminals remains a
+  semantic restriction that is intentionally deferred per issue #586.
 
 ## 5. Declarations: SAVE, INTRINSIC, EXTERNAL, DATA
 

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -120,6 +120,34 @@ END IF"""
             with self.subTest(do_stmt=text):
                 tree = self.parse(text, 'do_stmt')
                 self.assertIsNotNone(tree)
+
+    def test_do_loop_terminal_statement_forms(self):
+        """DO loops may end on any labeled executable statement except restricted ones."""
+        terminal_loops = """      PROGRAM DO_LOOP_TERMINALS
+      REAL A(5), B(5), C(5), TEMP
+      DO 10 I = 1, 5
+      A(I) = B(I) + C(I)
+10   A(I) = A(I) * 2.0
+      DO 20 J = 1, 3
+      B(J) = J
+20   CALL HANDLE(B(J))
+      DO 30 K = 1, 2
+      C(K) = K * 2
+30   READ(5,*) C(K)
+      DO 31 L = 1, 2
+      C(L) = L - 1
+31   WRITE(6,*) C(L)
+      DO 40 M = 1, 4
+      TEMP = M - 2
+ 40   IF (TEMP .GT. 0) 50, 60, 70
+ 50   CONTINUE
+ 60   CONTINUE
+ 70   CONTINUE
+      END
+"""
+
+        tree = self.parse(terminal_loops, 'main_program')
+        self.assertIsNotNone(tree)
     
     def test_save_statement(self):
         """Test SAVE statement (NEW in FORTRAN 77)"""


### PR DESCRIPTION
## Summary\n- add a DO loop fixture that exercises assignment, CALL, READ, WRITE, and arithmetic IF terminal statements so the parser covers ANSI X3.9-1978 Section 11.10.4\n- document the terminal-statement flexibility and reference issue #586 while noting the semantic restriction on prohibited labels\n\n## Verification\n- `make test 2>&1 | tee /tmp/make_test.log` (1473 tests passed; see /tmp/make_test.log)\n- `make lint 2>&1 | tee /tmp/make_lint.log` (lint completed successfully; see /tmp/make_lint.log)