### PR TITLE
fix: FORTRAN 77 missing COMPLEX*16 type support (fixes #583)

### DIFF
--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -83,6 +83,19 @@ Section 4.4.2):
   - `test_complex_literals_in_data_statement_fortran77` exercises complex
     constants in DATA statements.
 
+### COMPLEX kind selectors (issue #583)
+
+- Common FORTRAN 77 compilers accepted `COMPLEX*8`/`COMPLEX*16` even before
+  the kind parameter became official in ISO/IEC 1539:1991 Section 8.1.2.
+  The parser now acknowledges this extension: `non_character_type_spec`
+  accepts `COMPLEX complex_kind?`, and `complex_kind : MULTIPLY INTEGER_LITERAL`
+  allows `COMPLEX*8 W` and `COMPLEX*16 Z` to parse alongside the standard
+  `COMPLEX` declaration. Issue #583 documents this gap.
+- New tests cover the extension:
+  `test_complex_type_kind_spec_extension` parses `COMPLEX*8`/`COMPLEX*16`
+  declarations via `type_declaration`, exercising the optional kind selector
+  and ensuring the extension is not orphaned.
+
 - `character_length` supports:
   - `CHARACTER*10`
   - `CHARACTER*(* )`

--- a/grammars/src/FORTRAN77Parser.g4
+++ b/grammars/src/FORTRAN77Parser.g4
@@ -127,7 +127,14 @@ non_character_type_spec
     | REAL                       // ISO 1539:1980 Section 4.3
     | LOGICAL                    // ISO 1539:1980 Section 4.6
     | DOUBLE PRECISION           // ISO 1539:1980 Section 4.4
-    | COMPLEX                    // ISO 1539:1980 Section 4.5
+    | COMPLEX complex_kind?      // ISO 1539:1980 Section 4.5 + common extension
+    ;
+
+// Compiler-extension support for COMPLEX*8/COMPLEX*16 type statements.
+// type_spec still includes CHARACTER declarations per ISO 1539:1980 Section 8.4.
+// Extension tracked via issue #583.
+complex_kind
+    : MULTIPLY INTEGER_LITERAL
     ;
 
 // Type specification - ISO 1539:1980 Section 8.4

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -59,6 +59,20 @@ class TestFORTRAN77Parser(StatementFunctionTestMixin, unittest.TestCase):
             with self.subTest(character_type=text):
                 tree = self.parse(text, 'type_declaration')
                 self.assertIsNotNone(tree)
+
+    def test_complex_type_kind_spec_extension(self):
+        """Test FORTRAN 77 extension that accepts COMPLEX*8/COMPLEX*16 (issue #583)."""
+        test_cases = [
+            "COMPLEX*8 W",
+            "COMPLEX*16 Z",
+            "COMPLEX*8 W1, W2",
+            "COMPLEX*16 Z1, Z2"
+        ]
+
+        for text in test_cases:
+            with self.subTest(complex_decl=text):
+                tree = self.parse(text, 'type_declaration')
+                self.assertIsNotNone(tree)
     
     def test_if_then_else_construct(self):
         """Test IF-THEN-ELSE construct (NEW in FORTRAN 77)"""


### PR DESCRIPTION
## Summary
- allow a COMPLEX kind selector on FORTRAN 77 non-character type specs so CONMPLEX*8/COMPLEX*16 declarations parse (issue #583)
- add a regression test that exercises COMPLEX*8/COMPLEX*16 type declarations via `type_declaration`
- document the extension in the FORTRAN 77 audit notes so the tracked gap and tests are visible

## Verification
- `make test 2>&1 | tee /tmp/make-test-final.log` (1474 tests, log: `/tmp/make-test-final.log`)
- `make lint 2>&1 | tee /tmp/make-lint.log` (log: `/tmp/make-lint.log`)
