### PR TITLE
fix: FORTRAN 77 format edit descriptors (fixes #580)

### DIFF
--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -474,6 +474,10 @@ Mapping that classification to the current grammar:
       `FORTRAN77Parser.g4`, and included in `statement_body` (twice,
       harmlessly).
     - FORMAT: via the inherited FORMAT machinery from FORTRAN 66.
+    - Format edit descriptors from ANSI X3.9-1978 / ISO 1539:1980 Section 13.2-13.3
+      (T/TL/TR tab positioning, S/SP/SS sign control, BN/BZ blank control, and
+      the L and A data edit descriptors) are now exercised by `tests/FORTRAN77/test_fortran77_parser.py::test_format_edit_descriptors`
+      (issue #580).
 
 - **Statement functions**
   - Implemented:

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -187,6 +187,20 @@ END IF"""
             with self.subTest(call_stmt=text):
                 tree = self.parse(text, 'call_stmt')
                 self.assertIsNotNone(tree)
+
+    def test_format_edit_descriptors(self):
+        """Parse the FORMAT edit descriptors introduced in ISO 1539:1980 Section 13."""
+        format_variants = [
+            "FORMAT(T10, TL5, TR2)",
+            "FORMAT(S, SP, SS)",
+            "FORMAT(BN, BZ)",
+            "FORMAT(L5, A10)"
+        ]
+
+        for text in format_variants:
+            with self.subTest(format_stmt=text):
+                tree = self.parse(text, 'format_stmt')
+                self.assertIsNotNone(tree)
     
     def test_intrinsic_statement(self):
         """Test INTRINSIC statement (NEW in FORTRAN 77)"""


### PR DESCRIPTION
## Summary
- add regression coverage for T/TL/TR, S/SP/SS, BN/BZ, L, and A edit descriptors in FORMAT statements
- document the ISO 1539:1980 Section 13 coverage in the FORTRAN 77 audit (issue #580)

## Verification
- `make test` (logs: /tmp/make-test.log)
