### PR TITLE
fix: FORTRAN 77: Missing READ statement form with positional unit (fixes #578)

### DIFF
--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -404,9 +404,11 @@ Mapping that classification to the current grammar:
   - Implemented:
     - READ and PRINT are inherited from FORTRAN 66 (`read_stmt`,
       `print_stmt`).
+    - READ now supports the positional `unit, fmt [, iolist]` form per
+      ANSI X3.9-1978 Section 12.6; issue #578 tracked this gap.
     - Enhanced WRITE is implemented as `write_stmt` with:
       - A `control_info_list` including unit, format identifier, and
-        list‑directed `*`.
+        list-directed `*`.
       - `output_item_list` supporting implied DO constructs.
 
 - **REWIND, BACKSPACE, ENDFILE, OPEN, CLOSE, INQUIRE**
@@ -526,6 +528,9 @@ cover:
   `test_data_type_revolution_features` and others).
 - A structured program example fixture:
   - `FORTRAN77/test_fortran77_parser/structured_program_example.f`.
+- READ positional unit form coverage:
+  - `FORTRAN77/test_fortran77_parser/read_positional_unit_form.f` ensures the
+    positional `READ unit, fmt [, iolist]` form parses (tracked as issue #578).
 
 In the generic fixture harness (`tests/test_fixture_parsing.py`):
 

--- a/grammars/src/FORTRAN77Parser.g4
+++ b/grammars/src/FORTRAN77Parser.g4
@@ -340,10 +340,11 @@ executable_construct
 // - Section 12.10: File connection statements (OPEN, CLOSE, INQUIRE)
 
 // READ statement - ISO 1539:1980 Sections 12.4 and 12.6
-// Forms: READ fmt, iolist  OR  READ (cilist) iolist
+// Forms: READ fmt, iolist  OR  READ (cilist) iolist  OR  READ unit, fmt [, iolist]
 read_stmt
-    : READ format_identifier (COMMA input_item_list_f77)?
-    | READ LPAREN read_control_info_list RPAREN input_item_list_f77?
+    : READ LPAREN read_control_info_list RPAREN input_item_list_f77?
+    | READ integer_expr COMMA format_identifier (COMMA input_item_list_f77)?
+    | READ format_identifier (COMMA input_item_list_f77)?
     ;
 
 // Input item list - ISO 1539:1980 Section 12.6.1

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -176,6 +176,19 @@ END IF"""
                 tree = self.parse(text, 'save_stmt')
                 self.assertIsNotNone(tree)
 
+    def test_read_positional_unit_format(self):
+        """Verify READ statements with the positional unit/format form."""
+        test_cases = [
+            "READ 5, 100",
+            "READ 5, 100, A, B",
+            "READ 7, 200, (A(I), I=1, 5)"
+        ]
+
+        for text in test_cases:
+            with self.subTest(read_stmt=text):
+                tree = self.parse(text, 'read_stmt')
+                self.assertIsNotNone(tree)
+
     def test_call_statement_with_hollerith_argument(self):
         """Verify CALL statements accept Hollerith constants as arguments."""
         test_cases = [

--- a/tests/fixtures/FORTRAN77/test_fortran77_parser/read_positional_unit_form.f
+++ b/tests/fixtures/FORTRAN77/test_fortran77_parser/read_positional_unit_form.f
@@ -1,0 +1,9 @@
+      PROGRAM READ_POSITIONAL_UNIT
+      INTEGER A(5), B, C
+      READ 5, 100, A
+      READ 6, 200, B, C
+      READ 7, 300, (A(I), I=1,5)
+  100  FORMAT(5I5)
+  200  FORMAT(2I4)
+  300  FORMAT(5I5)
+      END


### PR DESCRIPTION
## Summary
- extend the FORTRAN 77 `read_stmt` to cover the positional `unit, fmt [, iolist]` form mandated by ANSI X3.9-1978 Section 12.6
- add a parser test plus fixture that exercises the new form and log it in the generic fixture suite
- note the resolved gap in `docs/fortran_77_audit.md`, including the new fixture coverage

## Verification
- `make test` (pass; see `/tmp/make-test.log`, ends with \"All tests completed!\")
- `make lint` (pass; see `/tmp/make-lint.log`, ends with \"✅ Lint completed successfully\")
- Artifact: `tests/fixtures/FORTRAN77/test_fortran77_parser/read_positional_unit_form.f`