### PR TITLE
fix: FORTRAN 77: Missing alternate return specifiers in CALL statemen (fixes #576)

### DIFF
--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -426,8 +426,17 @@ Mapping that classification to the current grammar:
 
 - **CALL, RETURN, END**
   - Implemented:
-    - `call_stmt`, `return_stmt`, and `end_stmt` are inherited and
-      wired into `statement_body`.
+    - `call_stmt` is overridden to consume `actual_arg_spec_list`, which now
+      accepts `expr` or `*label` alternate return specifiers per ISO 1539:1980
+      Sections 15.8.1 and 15.8.3. Issue #576 tracked the previous gap where
+      `*s` forms were rejected.
+    - `return_stmt` now accepts an optional `integer_expr` (Section 15.8.2) so a
+      subroutine can `RETURN 1`/`RETURN 2` to select among the alternate
+      return specifiers supplied by the caller.
+    - Tests: `test_call_statement_with_alternate_return_specifiers`,
+      `test_return_statement_with_alternate_return_selection`, and the new
+      fixture `tests/fixtures/FORTRAN77/test_fortran77_parser_extra/alternate_return_specifiers.f`
+      exercise the complete alternate-return cycle.
 
 - **PROGRAM, FUNCTION, SUBROUTINE, ENTRY, BLOCK DATA**
   - Implemented:

--- a/grammars/src/FORTRAN77Parser.g4
+++ b/grammars/src/FORTRAN77Parser.g4
@@ -105,6 +105,18 @@ entry_dummy_arg
     | MULTIPLY                // Alternate return specifier (*)
     ;
 
+// CALL and RETURN statements - ISO 1539:1980 Section 15.8
+// CALL includes alternate return specifiers via actual_arg_spec_list (Section 15.8.1)
+call_stmt
+    : CALL IDENTIFIER (LPAREN actual_arg_spec_list? RPAREN)?
+    ;
+
+// RETURN optionally selects an alternate return via an integer expression
+// (Section 15.8.2)
+return_stmt
+    : RETURN integer_expr?
+    ;
+
 // ====================================================================
 // TYPE SYSTEM - ISO 1539:1980 Section 4 and Section 8.4
 // ====================================================================
@@ -843,6 +855,7 @@ actual_arg_spec_list
 // Actual argument specification - ISO 1539:1980 Section 15.8.1
 actual_arg_spec
     : expr
+    | MULTIPLY label           // Alternate return specifier (*label) per Section 15.8.3
     ;
 
 // Integer variable - ISO 1539:1980 Section 4.2

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -201,6 +201,42 @@ END IF"""
                 tree = self.parse(text, 'call_stmt')
                 self.assertIsNotNone(tree)
 
+    def test_call_statement_with_alternate_return_specifiers(self):
+        """Ensure CALL statements handle alternate return arguments (*label)."""
+        test_cases = [
+            "CALL SOLVE(X, Y, *100, *200, Z)",
+            "CALL ROUTE(*50)",
+        ]
+
+        for text in test_cases:
+            with self.subTest(call_stmt=text):
+                tree = self.parse(text, 'call_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_return_statement_with_alternate_return_selection(self):
+        """Verify RETURN accepts an integer expression for alternate returns."""
+        return_cases = [
+            "RETURN",
+            "RETURN 1",
+            "RETURN 2",
+        ]
+
+        for text in return_cases:
+            with self.subTest(return_stmt=text):
+                tree = self.parse(text, 'return_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_alternate_return_specifiers_fixture(self):
+        """Parse a FORTRAN 77 program that uses alternate return specifiers."""
+        fixture_text = load_fixture(
+            "FORTRAN77",
+            "test_fortran77_parser_extra",
+            "alternate_return_specifiers.f",
+        )
+
+        tree = self.parse(fixture_text, 'fortran66_program')
+        self.assertIsNotNone(tree)
+
     def test_format_edit_descriptors(self):
         """Parse the FORMAT edit descriptors introduced in ISO 1539:1980 Section 13."""
         format_variants = [

--- a/tests/fixtures/FORTRAN77/test_fortran77_parser_extra/alternate_return_specifiers.f
+++ b/tests/fixtures/FORTRAN77/test_fortran77_parser_extra/alternate_return_specifiers.f
@@ -1,0 +1,14 @@
+      PROGRAM ALTRET
+      REAL X, Y
+      CALL SOLVE(X, Y, *100, *200)
+      STOP
+ 100  WRITE(*,*) 'ALT RETURN 100'
+      STOP
+ 200  WRITE(*,*) 'ALT RETURN 200'
+      STOP
+
+      SUBROUTINE SOLVE(A, B)
+      REAL A, B
+      IF (A .GT. B) RETURN 2
+      RETURN 1
+      END


### PR DESCRIPTION
## Summary
- override the FORTRAN 77 call/return statements so CALL accepts starred labels and RETURN can select alternate exits per ISO 1539:1980 Section 15.8
- add targeted tests plus the new `alternate_return_specifiers.f` fixture under `tests/fixtures/FORTRAN77/test_fortran77_parser_extra`
- document the new coverage in `docs/fortran_77_audit.md`

## Verification
- `make test 2>&1 | tee /tmp/test.log`
- `make lint 2>&1 | tee /tmp/lint.log`
