### PR TITLE
fix: FORTRAN 77 Missing support for GO TO statement form (fixes #570)

### DIFF
--- a/grammars/src/F90ControlParser.g4
+++ b/grammars/src/F90ControlParser.g4
@@ -239,7 +239,13 @@ continue_stmt
 
 // GOTO statement - ISO/IEC 1539:1991 Section 8.2
 goto_stmt
-    : GOTO label
+    : go_to_keyword label
+    ;
+
+// GO TO keyword accepts both the historic two-word form and the modern alias
+go_to_keyword
+    : GOTO
+    | GO TO
     ;
 
 // STOP statement - ISO/IEC 1539:1991 Section 8.3, R841

--- a/grammars/src/FORTRAN66Parser.g4
+++ b/grammars/src/FORTRAN66Parser.g4
@@ -766,7 +766,7 @@ assign_stmt
 // ============================================================================
 
 assigned_goto_stmt
-    : GOTO variable COMMA LPAREN label_list RPAREN
+    : go_to_keyword variable COMMA LPAREN label_list RPAREN
     ;
 
 // ============================================================================

--- a/grammars/src/FORTRANIIParser.g4
+++ b/grammars/src/FORTRANIIParser.g4
@@ -305,13 +305,13 @@ assignment_stmt
 // Unconditional GO TO - Appendix A: GO TO n
 // Transfers control to the statement with label n
 goto_stmt
-    : GOTO label
+    : go_to_keyword label
     ;
 
 // Computed GO TO - Appendix A: GO TO (n1, n2, ..., nm), i
 // Transfers to n1 if i=1, n2 if i=2, etc.
 computed_goto_stmt
-    : GOTO LPAREN label_list RPAREN COMMA expr
+    : go_to_keyword LPAREN label_list RPAREN COMMA expr
     ;
 
 // Arithmetic IF - Appendix A: IF (e) n1, n2, n3

--- a/grammars/src/FORTRANLexer.g4
+++ b/grammars/src/FORTRANLexer.g4
@@ -36,6 +36,7 @@ lexer grammar FORTRANLexer;
 // C28-6003 Appendix B: GO TO, IF, DO, CONTINUE, STOP, END statements
 IF           : I F ;        // Arithmetic IF (three-way branch) - Appendix B row 3
 GOTO         : G O T O ;    // Unconditional/computed GO TO - Appendix B rows 1-2
+GO           : G O ;        // GO keyword used in the historic "GO TO" statement form
 DO           : D O ;        // DO loops with statement labels - Appendix B row 18
 END          : E N D ;      // End of program - Appendix B row 32
 CONTINUE     : C O N T I N U E ; // DO loop continuation - Appendix B row 19

--- a/grammars/src/FORTRANParser.g4
+++ b/grammars/src/FORTRANParser.g4
@@ -175,14 +175,14 @@ assignment_stmt
 // Unconditional GO TO - Appendix B row 1
 // C28-6003 Chapter II.G: GO TO n transfers to statement n
 goto_stmt
-    : GOTO label
+    : go_to_keyword label
     ;
 
 // Computed GO TO - Appendix B row 2
 // C28-6003 Chapter II.G: GO TO (n1, n2, ..., nm), i
 // Transfers to n1 if i=1, n2 if i=2, etc.
 computed_goto_stmt
-    : GOTO LPAREN label_list RPAREN COMMA expr
+    : go_to_keyword LPAREN label_list RPAREN COMMA expr
     ;
 
 // ASSIGN statement - Appendix B row 12
@@ -204,7 +204,13 @@ assign_stmt
 // 1539-1:2018 Annex B.2. Retained for historical accuracy only.
 // See docs/fortran_1957_audit.md for compliance details.
 assigned_goto_stmt
-    : GOTO variable COMMA LPAREN label_list RPAREN
+    : go_to_keyword variable COMMA LPAREN label_list RPAREN
+    ;
+
+// GO TO keyword - allows both the single-token GOTO and historic GO TO form
+go_to_keyword
+    : GOTO
+    | GO TO
     ;
 
 // Label list for computed/assigned GO TO

--- a/tests/FORTRAN/test_fortran_parser.py
+++ b/tests/FORTRAN/test_fortran_parser.py
@@ -162,6 +162,42 @@ class TestFORTRANParser(unittest.TestCase):
             with self.subTest(goto=text):
                 tree = self.parse(text, 'goto_stmt')
                 self.assertIsNotNone(tree)
+
+    def test_goto_statement_two_word_form(self):
+        """Test the historic two-word GO TO form"""
+        test_cases = [
+            "GO TO 100",
+            "GO TO 555"
+        ]
+
+        for text in test_cases:
+            with self.subTest(go_statement=text):
+                tree = self.parse(text, 'goto_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_computed_goto_two_word_form(self):
+        """Ensure computed GO TO accepts both single and two-word prefixes"""
+        test_cases = [
+            "GOTO (10, 20, 30), I",
+            "GO TO (100, 200, 300), J"
+        ]
+
+        for text in test_cases:
+            with self.subTest(computed_goto=text):
+                tree = self.parse(text, 'computed_goto_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_assigned_goto_two_word_form(self):
+        """Ensure assigned GO TO accepts both single and two-word prefixes"""
+        test_cases = [
+            "GOTO K, (10, 20)",
+            "GO TO TARGET, (1, 2, 3)"
+        ]
+
+        for text in test_cases:
+            with self.subTest(assigned_goto=text):
+                tree = self.parse(text, 'assigned_goto_stmt')
+                self.assertIsNotNone(tree)
     
     def test_arithmetic_if_statement(self):
         """Test arithmetic IF statements (1957 style)"""

--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -773,6 +773,30 @@ END
                 tree = self.parse(text, 'assign_stmt')
                 self.assertIsNotNone(tree)
 
+    def test_unconditional_goto_variants(self):
+        """Verify both GOTO and GO TO unconditional statements parse"""
+        test_cases = [
+            "GOTO 100",
+            "GO TO 200"
+        ]
+
+        for text in test_cases:
+            with self.subTest(goto=text):
+                tree = self.parse(text, 'goto_stmt')
+                self.assertIsNotNone(tree)
+
+    def test_computed_goto_variants(self):
+        """Verify both GOTO and GO TO computed branches parse"""
+        test_cases = [
+            "GOTO (100, 200), I",
+            "GO TO (300, 400), K"
+        ]
+
+        for text in test_cases:
+            with self.subTest(computed_goto=text):
+                tree = self.parse(text, 'computed_goto_stmt')
+                self.assertIsNotNone(tree)
+
     def test_assigned_goto_statement(self):
         """Test Assigned GO TO statement (ISO 1539:1980 Section 11.2)
 
@@ -783,9 +807,9 @@ END
         """
         test_cases = [
             "GO TO ILAB, (100, 200, 300)",
-            "GO TO TARGET, (10, 20)",
+            "GOTO TARGET, (10, 20)",
             "GO TO LABEL_VAR, (1, 2, 3, 4, 5)",
-            "GO TO X, (50)",
+            "GOTO X, (50)",
         ]
 
         for text in test_cases:


### PR DESCRIPTION
## Summary
- add the historic GO keyword and a shared `go_to_keyword` helper so all grammars accept both `GOTO` and `GO TO`
- update the FORTRAN 66/II/F90 control rules to reuse the helper plus cover computed/assigned forms, and refresh the FORTRAN 77/base tests to exercise both keyword spellings

## Verification
- `make test` *(logs: /tmp/make-test.log)*
- `make lint` *(logs: /tmp/make-lint.log)*
