### PR TITLE
fix: Fortran 90: Incomplete MODULE PROCEDURE statement (fixes #594)

### DIFF
--- a/docs/fortran_90_audit.md
+++ b/docs/fortran_90_audit.md
@@ -45,6 +45,14 @@ Grammar:
     - Optional `specification_part`, `execution_part`, and
       `internal_subprogram_part` (F90 internal procedures via
       `contains_stmt`).
+- Interfaces and procedure statements:
+  - `interface_block`, `interface_specification` and `interface_body`
+    wire together generic interface declarations, procedure definitions,
+    and the `procedure_stmt` entry point used inside interface blocks.
+  - `procedure_stmt` now implements `MODULE PROCEDURE procedure-name-list`
+    per ISO/IEC 1539:1991 Section 12.3.2.2 (R1206), driven by
+    `F90ProcsParser.g4:procedure_stmt` and `procedure_name_list` (fixes
+    #594).
 
 Notable simplifications / gaps:
 
@@ -296,6 +304,10 @@ exercised in focused unit tests. The generic fixture harness in
 
 **Current status:** All F90 fixtures pass (0 xfail).
 
+- Added `tests/fixtures/Fortran90/test_interface_module_procedure/module_procedure_interface.f90`
+  to assert that `MODULE PROCEDURE procedure-name-list` declarations (ISO/IEC
+  1539:1991 Section 12.3.2.2, R1206) parse successfully (fixes #594).
+
 Previous xfail fixtures were corrected to use valid F90 syntax:
 
 - `array_constructor_program.f90`: Updated to use F90 parenthesis array
@@ -409,6 +421,7 @@ The Fortran 90 grammar in this repository:
 |----------|-------------|--------|
 | R531–R534 | `data-implied-do` nested forms (DATA implied-DO lists) | Implemented (fixes #378) |
 | R620 | `section-subscript` with vector subscript (R620-R621) | Implemented (fixes #381) |
+| R1206 | `procedure_stmt` (`MODULE PROCEDURE` procedure-name-list) in interface blocks | Implemented (fixes #594) |
 | R1219 | `entry-stmt` | Implemented (F90 extension via `entry_stmt_f90`) |
 
 **xfail Fixtures:** 0 (Issue #311 resolved; fixtures corrected)

--- a/grammars/src/F90ProcsParser.g4
+++ b/grammars/src/F90ProcsParser.g4
@@ -66,8 +66,13 @@ procedure_designator
     ;
 
 // Procedure statement (in interface blocks)
+// ISO/IEC 1539:1991 Section 12.3.2.2, R1206
 procedure_stmt
-    : PROCEDURE
+    : MODULE PROCEDURE procedure_name_list NEWLINE?
+    ;
+
+procedure_name_list
+    : identifier_or_keyword (COMMA identifier_or_keyword)*
     ;
 
 // ====================================================================

--- a/tests/fixtures/Fortran90/test_interface_module_procedure/module_procedure_interface.f90
+++ b/tests/fixtures/Fortran90/test_interface_module_procedure/module_procedure_interface.f90
@@ -1,0 +1,18 @@
+module math_ops
+    implicit none
+
+    interface sqrt_generic module procedure sqrt_real, sqrt_complex
+    end interface
+
+contains
+
+    real function sqrt_real(x)
+        real, intent(in) :: x
+        sqrt_real = sqrt(x)
+    end function sqrt_real
+
+    complex function sqrt_complex(z)
+        complex, intent(in) :: z
+        sqrt_complex = sqrt(z)
+    end function sqrt_complex
+end module math_ops


### PR DESCRIPTION
## Summary
- implement the module procedure statement so interface blocks can declare module procedures via `procedure_stmt`
- add a fixture that exercises `MODULE PROCEDURE procedure-name-list` inside an interface block
- document the R1206 coverage and reference the new fixture in the Fortran 90 audit

## Verification
- `make test 2>&1 | tee /tmp/make_test.log` (1486 passed in 26.8s; see /tmp/make_test.log)
- `make lint 2>&1 | tee /tmp/make_lint.log`