### PR TITLE
fix: Fortran 2018 IMPORT statement enhancements (fixes #582)

### DIFF
--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -103,6 +103,12 @@ Grammar implementation:
     - Either `ieee_module_name` or a generic `IDENTIFIER`.
     - This allows ISO_FORTRAN_ENV and other intrinsic modules even
       though they are not enumerated by name.
+- Enhanced IMPORT:
+  - `import_stmt` overrides the F2003 rule so that all R867 variants are
+    available: bare `IMPORT`, `IMPORT :: import-name-list`, `IMPORT import-name-list`,
+    `IMPORT, ONLY: import-name-list`, `IMPORT, NONE`, and `IMPORT, ALL`.
+  - These forms let interface bodies and submodules explicitly control
+    which host entities are visible without relying on ad-hoc inheritances.
 - `declaration_construct_f2018`:
   - Includes:
     - F2003 types, CLASS declarations and procedure declarations.
@@ -124,9 +130,14 @@ Tests:
 - `test_issue61_teams_and_collectives.py`:
   - Team/events fixtures (e.g. `team_skeleton_module.f90`,
     `team_event_semantics.f90`) test EVENT_TYPE/TEAM_TYPE declarations
-    via the derived‑type‑style declarations:
+    via the derived-type-style declarations:
     - `TYPE(EVENT_TYPE) :: e`.
     - `TYPE(TEAM_TYPE) :: t`.
+- `tests/fixtures/Fortran2018/import_stmt_forms.f90`:
+  - Exercises each R867 IMPORT variant (`IMPORT`, `IMPORT ::`, `IMPORT, ONLY:`,
+    `IMPORT, NONE`, `IMPORT, ALL`) inside an interface block.
+  - Confirms the new parser rule added for issue #582 successfully parses
+    the forms that interface/submodule authors rely on.
 
 Gaps:
 

--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -135,6 +135,22 @@ use_stmt
       only_list NEWLINE
     ;
 
+// ====================================================================
+// IMPORT STATEMENT (ISO/IEC 1539-1:2018 Section 8.8, R867)
+// ====================================================================
+//
+// F2018 extends IMPORT to support the ONLY/NONE/ALL variants defined by
+// R867. These forms are required by interface bodies and submodules to
+// control host association visibility explicitly.
+import_stmt
+    : IMPORT NEWLINE
+    | IMPORT DOUBLE_COLON import_name_list NEWLINE
+    | IMPORT import_name_list NEWLINE
+    | IMPORT COMMA ONLY COLON import_name_list NEWLINE
+    | IMPORT COMMA NONE NEWLINE
+    | IMPORT COMMA ALL NEWLINE
+    ;
+
 // Module name for USE statement - includes IEEE tokens which lexer matches first
 module_name_f2018
     : IDENTIFIER

--- a/tests/fixtures/Fortran2018/import_stmt_forms.f90
+++ b/tests/fixtures/Fortran2018/import_stmt_forms.f90
@@ -1,0 +1,40 @@
+module import_stmt_forms
+  type :: host_type
+    integer :: value
+  end type host_type
+
+contains
+
+  interface
+    module subroutine import_default(x)
+      import
+      integer, intent(inout) :: x
+    end subroutine import_default
+
+    module subroutine import_with_double_colon(x)
+      import :: host_type
+      type(host_type), intent(inout) :: x
+    end subroutine import_with_double_colon
+
+    module subroutine import_without_colon(x)
+      import host_type
+      type(host_type), intent(inout) :: x
+    end subroutine import_without_colon
+
+    module subroutine import_with_only(x)
+      import, only: host_type
+      type(host_type), intent(inout) :: x
+    end subroutine import_with_only
+
+    module subroutine import_with_none(value)
+      import, none
+      integer, intent(inout) :: value
+    end subroutine import_with_none
+
+    module subroutine import_with_all(value)
+      import, all
+      integer, intent(inout) :: value
+    end subroutine import_with_all
+  end interface
+
+end module import_stmt_forms


### PR DESCRIPTION
## Summary
- override the Fortran 2018 `import_stmt` so all R867 variants (bare, `::`, `ONLY`, `NONE`, `ALL`) are accepted
- add `tests/fixtures/Fortran2018/import_stmt_forms.f90` to exercise each form inside an interface
- document the coverage update in `docs/fortran_2018_audit.md` and cite issue #582

## Verification
- `make test` (pass; `/tmp/test.log` ends with `============================ 1487 passed in 28.41s =============================`)
- `make lint`
