### PR TITLE
fix: Fortran 2023: SIMPLE prefix-spec for procedures not implemented (fixes #588)

### DIFF
--- a/docs/fortran_2023_audit.md
+++ b/docs/fortran_2023_audit.md
@@ -438,6 +438,7 @@ Other Missing Features:
 | -- | NOTIFY_TYPE derived type | NOT IMPLEMENTED |
 | -- | C_F_STRPOINTER procedure | IMPLEMENTED (Issue #346) |
 | -- | AT edit descriptor | IMPLEMENTED (Issue #347) |
+| -- | SIMPLE prefix-spec for procedures (Section 15.8) | IMPLEMENTED (Issue #588) |
 | -- | LEADING_ZERO I/O specifier | NOT IMPLEMENTED |
 
 - R1130 REDUCE locality-spec: Implemented via Issue #345. The REDUCE locality
@@ -466,6 +467,13 @@ Other Missing Features:
   strings are treated as opaque character literals, and for legacy FORMAT
   statements the `AT` is recognized as an IDENTIFIER by the existing
   format_item rules.
+- SIMPLE prefix-spec for procedures: Implemented via Issue #588. The new
+  `SIMPLE` keyword (ISO/IEC 1539-1:2023 Section 15.8) is recognized by
+  `Fortran2023Lexer.g4` and the F2023 parser overrides `prefix_spec_f2008`
+  to accept `SIMPLE`. The new fixture
+  `tests/fixtures/Fortran2023/test_fortran_2023_comprehensive/simple_procedures.f90`
+  and `TestFortran2023Parser::test_simple_procedures_parsing` prove that
+  simple functions/subroutines are parsed as part of `program_unit_f2023`.
 - LEADING_ZERO I/O specifier tracked by Issue #348.
 
 **Missing Intrinsic Functions (remaining gaps):**

--- a/grammars/src/Fortran2023Lexer.g4
+++ b/grammars/src/Fortran2023Lexer.g4
@@ -15,6 +15,7 @@
 
 lexer grammar Fortran2023Lexer;
 
+
 import Fortran2018Lexer;
 
 // ============================================================================
@@ -205,7 +206,6 @@ C_F_STRPOINTER   : C '_' F '_' S T R P O I N T E R ;
 // STRING: character scalar of kind C_CHAR
 // ASIS: optional logical, if true, preserves embedded nulls
 F_C_STRING       : F '_' C '_' S T R I N G ;
-
 // ============================================================================
 // FORTRAN 2023 STANDARD OVERVIEW (ISO/IEC 1539-1:2023)
 // ============================================================================
@@ -243,3 +243,11 @@ F_C_STRING       : F '_' C '_' S T R I N G ;
 // with F2018. Foundation for LazyFortran2025 type inference extensions.
 //
 // ============================================================================
+
+// ----------------------------------------------------------------------------
+// SIMPLE prefix-spec keyword (NEW in F2023)
+// ISO/IEC 1539-1:2023 Section 15.8: A SIMPLE procedure only references
+// non-local variables through its dummy arguments.
+// ----------------------------------------------------------------------------
+
+SIMPLE           : S I M P L E ;

--- a/grammars/src/Fortran2023Parser.g4
+++ b/grammars/src/Fortran2023Parser.g4
@@ -596,6 +596,34 @@ only_item_f2018
     ;
 
 // ============================================================================
+// PROCEDURE PREFIX OVERRIDE (ISO/IEC 1539-1:2023 Section 15.8)
+// ============================================================================
+// F2023 introduces the SIMPLE prefix-spec for procedures. Override the
+// inherited F2008 `prefix_spec_f2008` rule to consume SIMPLE without affecting
+// earlier standards.
+prefix_spec_f2008
+    : RECURSIVE                     // F90 recursive procedures
+    | PURE                          // F95 pure procedures
+    | ELEMENTAL                     // F95 elemental procedures
+    | IMPURE                        // F2008 IMPURE procedures
+    | MODULE                        // F2008 MODULE procedures
+    | SIMPLE                        // F2023 SIMPLE procedures (Section 15.8)
+    | NON_RECURSIVE                 // F2008 NON_RECURSIVE procedures
+    | type_spec                     // Function return type
+    ;
+
+// ============================================================================ 
+// F90 Prefix Specification Extension (Section 12.5.2 + F2023 Section 15.8)
+// ============================================================================
+// Override the inherited F90 prefix_spec rule to allow the SIMPLE keyword
+// in addition to the original RECURSIVE and type-spec options.
+prefix_spec
+    : RECURSIVE
+    | type_spec_f90
+    | SIMPLE                        // F2023 SIMPLE procedures (Section 15.8)
+    ;
+
+// ============================================================================ 
 // DERIVED TYPE SPEC OVERRIDE (F2023 Extension)
 // ============================================================================
 // Override F2003 derived_type_spec to include NOTIFY_TYPE for use in

--- a/tests/Fortran2023/test_fortran_2023_comprehensive.py
+++ b/tests/Fortran2023/test_fortran_2023_comprehensive.py
@@ -611,6 +611,21 @@ class TestFortran2023Parser:
         except Exception as e:
             pytest.fail(f"F2023 AT edit descriptor parsing failed: {e}")
 
+    def test_simple_procedures_parsing(self):
+        """Test F2023 SIMPLE prefix-spec parsing for procedures (Section 15.8)."""
+        simple_input = load_fixture(
+            "Fortran2023",
+            "test_fortran_2023_comprehensive",
+            "simple_procedures.f90",
+        )
+        parser = self.create_parser(simple_input)
+
+        try:
+            tree = parser.program_unit_f2023()
+            assert tree is not None
+        except Exception as e:
+            pytest.fail(f"F2023 SIMPLE procedure parsing failed: {e}")
+
     def test_do_concurrent_reduce_parsing(self):
         """Test F2023 DO CONCURRENT REDUCE locality specifier parsing.
 

--- a/tests/fixtures/Fortran2023/test_fortran_2023_comprehensive/simple_procedures.f90
+++ b/tests/fixtures/Fortran2023/test_fortran_2023_comprehensive/simple_procedures.f90
@@ -1,0 +1,21 @@
+module simple_procedures_mod
+  implicit none
+
+contains
+
+  simple function add_values(x, y) result(z)
+    real, intent(in) :: x, y
+    real :: z
+    z = x + y
+  end function add_values
+
+  simple subroutine double_array(values, n)
+    real, intent(inout) :: values(n)
+    integer, intent(in) :: n
+    integer :: idx
+    do idx = 1, n
+      values(idx) = values(idx) * 2.0
+    end do
+  end subroutine double_array
+
+end module simple_procedures_mod


### PR DESCRIPTION
## Summary
- add the SIMPLE keyword/token to the F2023 lexer so procedures can carry the SIMPLE prefix
- extend F2023 parser prefix_spec rules so SIMPLE is accepted in both F90-style and F2008-style declarations
- document the fix, introduce a simple procedures fixture, and guard it with a parser test

## Verification
- `make test` (pass; log: /tmp/make_test.log)
- `make lint` (pass; log: /tmp/make_lint.log)
