### PR TITLE
fix: Fortran 90: Missing INQUIRE(IOLENGTH=) statement form (fixes #601)

### DIFF
--- a/docs/fortran_90_audit.md
+++ b/docs/fortran_90_audit.md
@@ -294,10 +294,13 @@ Grammar:
 - `namelist_stmt`:
   - Included in `declaration_construct` as an F90 declaration form.
 - File I/O statements (N692 §9):
-  - `open_stmt_f90`, `close_stmt_f90`, `backspace_stmt_f90`,
-    `endfile_stmt_f90`, `rewind_stmt_f90`, `inquire_stmt_f90` are
-    all wired into `executable_construct_f90` with proper ISO section
-    references (R904, R908, R923, R924, R925, R929).
+- `open_stmt_f90`, `close_stmt_f90`, `backspace_stmt_f90`,
+  `endfile_stmt_f90`, `rewind_stmt_f90`, `inquire_stmt_f90` are
+  all wired into `executable_construct_f90` with proper ISO section
+  references (R904, R908, R923, R924, R925, R929).
+- `inquire_stmt_f90` now also supports the `INQUIRE(IOLENGTH=...)`
+  record-length inquiry (ISO/IEC 1539:1991 Section 9.7.3 R931) paired
+  with `output_item_list_f90`, closing issue #601.
 
 ## 8. Fixtures and integration status
 
@@ -313,6 +316,9 @@ exercised in focused unit tests. The generic fixture harness in
 - Added `tests/fixtures/Fortran90/test_interface_module_procedure/module_procedure_interface.f90`
   to assert that `MODULE PROCEDURE procedure-name-list` declarations (ISO/IEC
   1539:1991 Section 12.3.2.2, R1206) parse successfully (fixes #594).
+- Added `tests/fixtures/Fortran90/test_file_io_statements/inquire_iolength.f90`
+  to exercise `INQUIRE(IOLENGTH=...)` record-length inquiries with
+  `output_item_list_f90` and closing issue #601 (ISO/IEC 1539:1991 Section 9.7.3, R931).
 
 Previous xfail fixtures were corrected to use valid F90 syntax:
 
@@ -414,7 +420,9 @@ The Fortran 90 grammar in this repository:
     intrinsics and statements (ALLOCATE/DEALLOCATE/NULLIFY).
   - Block IF, CASE, DO, DO WHILE, WHERE, named constructs, CYCLE/EXIT.
   - Enhanced expressions and literals (kinded numerics, BOZ, strings).
-  - Enhanced I/O (I/O control lists, NAMELIST, list‑directed I/O).
+  - Enhanced I/O (I/O control lists, NAMELIST, list‑directed I/O,
+    plus `INQUIRE(IOLENGTH=...)` record-length inquiries per
+    ISO/IEC 1539:1991 Section 9.7.3, R931, fixes #601).
   - Internal subprograms and unified program‑unit structure.
 - Uses a unified lexer for free‑form and fixed‑form with **lenient
   fixed‑form** handling (no card‑accurate column enforcement).

--- a/grammars/src/F90IOParser.g4
+++ b/grammars/src/F90IOParser.g4
@@ -159,9 +159,12 @@ close_stmt_f90
     : CLOSE LPAREN close_spec_list_f90 RPAREN
     ;
 
-// INQUIRE statement - ISO/IEC 1539:1991 Section 9.7.3, R929
+// INQUIRE statement - ISO/IEC 1539:1991 Section 9.7.3 (R929 file inquiry,
+// R931 IOLENGTH inquiry)
 inquire_stmt_f90
     : INQUIRE LPAREN inquire_spec_list_f90 RPAREN
+    | INQUIRE LPAREN IOLENGTH EQUALS variable_f90 RPAREN
+      output_item_list_f90
     ;
 
 // BACKSPACE statement - ISO/IEC 1539:1991 Section 9.6.1, R923

--- a/grammars/src/Fortran90Lexer.g4
+++ b/grammars/src/Fortran90Lexer.g4
@@ -402,6 +402,9 @@ ACTION          : A C T I O N ;
 DELIM           : D E L I M ;
 // PAD= specifier - ISO/IEC 1539:1991 Section 9.7.1.15 (F90)
 PAD             : P A D ;
+// IOLENGTH= specifier - ISO/IEC 1539:1991 Section 9.7.3, R931
+IOLENGTH        : ('i'|'I') ('o'|'O') ('l'|'L') ('e'|'E') ('n'|'N')
+                  ('g'|'G') ('t'|'T') ('h'|'H') ;
 // EXIST= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.4
 EXIST           : E X I S T ;
 // OPENED= specifier (INQUIRE) - ISO/IEC 1539:1991 Section 9.7.3.5

--- a/tests/Fortran90/test_fortran_90_comprehensive.py
+++ b/tests/Fortran90/test_fortran_90_comprehensive.py
@@ -197,7 +197,8 @@ class TestFortran90Lexer:
             'SIZE': Fortran90Lexer.SIZE,
             'STAT': Fortran90Lexer.STAT,
             'EOR': Fortran90Lexer.EOR,
-            'IOSTAT': Fortran90Lexer.IOSTAT
+            'IOSTAT': Fortran90Lexer.IOSTAT,
+            'IOLENGTH': Fortran90Lexer.IOLENGTH
         }
         
         for keyword, expected_token in io_keywords.items():

--- a/tests/fixtures/Fortran90/test_file_io_statements/inquire_iolength.f90
+++ b/tests/fixtures/Fortran90/test_file_io_statements/inquire_iolength.f90
@@ -1,0 +1,22 @@
+program test_inquire_iolength
+    implicit none
+    integer :: iolength_value, ios, direct_unit
+    real :: data_values(5)
+    complex :: complex_data(2)
+    character(len=12) :: label
+
+    direct_unit = 20
+    data_values = (/ 1.0, 2.0, 3.0, 4.0, 5.0 /)
+    complex_data = (/ cmplx(1.0, 1.0), cmplx(2.0, -1.0) /)
+    label = 'F90RECORD'
+
+    inquire(iolength=iolength_value) data_values, complex_data, label
+
+    open(unit=direct_unit, file='record.bin', access='direct', form='unformatted', recl=iolength_value, status='replace', iostat=ios)
+
+    if (ios == 0) then
+        write(direct_unit, rec=1) data_values, complex_data, label
+        close(unit=direct_unit)
+    end if
+
+end program test_inquire_iolength

--- a/tests/test_comprehensive_parsing.py
+++ b/tests/test_comprehensive_parsing.py
@@ -182,6 +182,7 @@ class TestUnifiedGrammarArchitecture:
             "open_close_inquire.f90",
             "file_positioning.f90",
             "advanced_io_specs.f90",
+            "inquire_iolength.f90",
         ]
 
         for filename in test_files:


### PR DESCRIPTION
## Summary
- add the IOLENGTH token and the `INQUIRE(IOLENGTH=...)` branch to the F90 lexer/parser so the record-length inquiry (ISO/IEC 1539:1991 Section 9.7.3 R931) is treated like the standard form
- expand lexer coverage and add `tests/fixtures/Fortran90/test_file_io_statements/inquire_iolength.f90`, then exercise the fixture via the comprehensive file I/O test
- document the completion in `docs/fortran_90_audit.md` so issue #601 is tracked alongside the implemented feature

## Verification
- `make test` (see /tmp/make_test.log) – 1499 tests passed in 28.01s
- `make lint` (see /tmp/make_lint.log)
