### PR TITLE
fix: Fortran 2018 missing image-selector specs (fixes #599)

### DIFF
--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -224,12 +224,18 @@ Grammar implementation:
       `RESULT_IMAGE = variable_f90`.
   - `operation_spec` and `source_image_spec`:
     - Generic identifier / expression forms.
+  - `image_selector`, `designator`, and `variable_f2008` now accept
+    optional image-selector-spec-lists so STAT=, TEAM=, and TEAM_NUMBER=
+    specifiers follow R924-R926 (issue #599).
 
 Tests:
 
 - `test_issue61_teams_and_collectives.py::test_collective_subroutines_parse_without_errors`:
   - `teams_collectives_module.f90` exercises all five collective calls
     with representative STAT/ERRMSG/RESULT_IMAGE usage.
+- `test_issue61_teams_and_collectives.py::test_image_selector_team_specs_parse_cleanly`:
+  - `image_selector_team.f90` verifies TEAM=, TEAM_NUMBER=, and STAT= specifiers inside
+    image selectors for coarrays (issue #599).
 
 Gaps:
 
@@ -789,3 +795,11 @@ The following tokens were removed as dead code:
 - `DEFAULT_ACCESS`: Not in ISO standard. F2018 uses DEFAULT with PUBLIC/PRIVATE keywords.
 
 All 5 tokens had zero references in Fortran2018Parser.g4, confirming they were unused.
+
+### A.13 Image selectors (Section 9.5.3)
+
+| ISO Rule | Description | Grammar Rule |
+|----------|-------------|--------------|
+| R924 | image-selector with optional spec list | `image_selector` with `image_selector_spec_list` and `coarray_spec` |
+| R925 | cosubscript list within the selector | `cosubscript` (inherited from Fortran 2008) |
+| R926 | image-selector-spec (STAT=, TEAM=, TEAM_NUMBER=) | `image_selector_spec` |

--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -342,7 +342,45 @@ source_image_spec
     : SOURCE_IMAGE EQUALS expr_f90
     ;
 
-// ============================================================================
+// ISO/IEC 1539-1:2018 Section 9.5.3: Image selectors with team specs
+// R924: image-selector -> [ cosubscript-list [, image-selector-spec-list] ]
+// R925: cosubscript -> scalar-int-expr
+// R926: image-selector-spec -> STAT = stat-variable | TEAM = team-value
+//                                       | TEAM_NUMBER = scalar-int-expr
+image_selector
+    : LBRACKET cosubscript_list (COMMA image_selector_spec_list)? RBRACKET
+    ;
+
+image_selector_spec_list
+    : image_selector_spec (COMMA image_selector_spec)*
+    ;
+
+image_selector_spec
+    : STAT EQUALS variable_f90
+    | TEAM EQUALS team_value
+    | TEAM_NUMBER EQUALS expr_f90
+    ;
+
+// Override F2008 designators to permit the F2018 image-selector spec list.
+designator
+    : designator_core image_selector?
+    ;
+
+complex_part_designator
+    : designator_core PERCENT (RE | IM) image_selector?
+    ;
+
+lhs_expression
+    : designator
+    | complex_part_designator
+    ;
+
+// Override the F2008 variable rule so image selectors pick up the F2018 specs.
+variable_f2008
+    : IDENTIFIER image_selector? (PERCENT IDENTIFIER)*
+    | IDENTIFIER (LPAREN actual_arg_list RPAREN)? image_selector?
+    ;
+
 // TEAM SUPPORT (ISO/IEC 1539-1:2018 Section 11.6)
 // ============================================================================
 
@@ -630,7 +668,8 @@ array_expr
 // ISO/IEC 1539-1:2018 R1023: primary (override to include F2018 intrinsics)
 // Override F2008 primary to include F2018 intrinsic function calls
 primary
-    : complex_part_designator
+    : designator
+    | complex_part_designator
     | identifier_or_keyword (PERCENT identifier_or_keyword)*
     | identifier_or_keyword LPAREN actual_arg_list? RPAREN
     | identifier_or_keyword DOUBLE_QUOTE_STRING

--- a/tests/Fortran2018/test_issue61_teams_and_collectives.py
+++ b/tests/Fortran2018/test_issue61_teams_and_collectives.py
@@ -114,3 +114,14 @@ class TestF2018TeamsAndCollectivesStatus:
         tree, errors, _ = parse_f2018(code)
         assert tree is not None
         assert errors == 0
+
+    def test_image_selector_team_specs_parse_cleanly(self):
+        """TEAM/TEAM_NUMBER image selectors with STAT= parse without errors."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_issue61_teams_and_collectives",
+            "image_selector_team.f90",
+        )
+        tree, errors, _ = parse_f2018(code)
+        assert tree is not None
+        assert errors == 0

--- a/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/image_selector_team.f90
+++ b/tests/fixtures/Fortran2018/test_issue61_teams_and_collectives/image_selector_team.f90
@@ -1,0 +1,12 @@
+program team_image_selector_example
+  implicit none
+  TYPE(TEAM_TYPE) :: my_team
+  integer :: ierr
+  integer :: a[*]
+  integer :: b
+
+  b = a[5, TEAM=my_team]
+  b = a[2, TEAM_NUMBER=1]
+  b = a[3, STAT=ierr]
+  b = a[4, TEAM=my_team, STAT=ierr]
+end program team_image_selector_example


### PR DESCRIPTION
## Summary
- allow the F2018 image-selector spec list (STAT/TEAM/TEAM_NUMBER) on designators, variables, and primary expressions
- add a fixture+status test exercising TEAM/TEAM_NUMBER selectors and update the F2018 audit

## Verification
- `make test` (see /tmp/make_test.log)
- `make lint` (see /tmp/make_lint.log)
