### PR TITLE
fix: Fortran 2018 missing FAIL IMAGE statement (fixes #574)

### DIFF
--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -455,7 +455,36 @@ Gaps:
   - It does not enforce that STOP/ERROR STOP codes satisfy all
     constraints; it only accepts the syntactic forms.
 
-## 9. FORMAT statements (ISO/IEC 1539-1:2018 Section 13.2)
+---
+
+## 9. FAIL IMAGE statement (ISO/IEC 1539-1:2018 Section 11.6.6)
+
+Specification:
+
+- R1163: `fail-image-stmt` is simply `FAIL IMAGE`, which terminates the
+  invoking image when executed within a coarray control path.
+
+Grammar implementation:
+
+- `fail_image_stmt` is a dedicated rule (`FAIL_IMAGE NEWLINE`) that
+  participates in `executable_construct_f2018`.
+- The `FAIL_IMAGE` lexer token captures the two-word keyword pair so that
+  the parser treats `FAIL IMAGE` as a single statement terminator.
+
+Tests:
+
+- `tests/fixtures/Fortran2018/test_issue574_fail_image/fail_image_stmt.f90`
+  exercises the statement within an `IF` block so the surrounding control
+  structure retains its validity while the statement executes.
+
+Gaps:
+
+- None; issue #574 tracked the missing syntax and is resolved by this
+  implementation.
+
+---
+
+## 10. FORMAT statements (ISO/IEC 1539-1:2018 Section 13.2)
 
 Specification:
 
@@ -509,7 +538,7 @@ Gaps:
   semantic constraints (descriptor widths, descriptor-type pairing) outside the
   grammar.
 
-## 10. ALLOCATE statement coverage (ISO/IEC 1539-1:2018 R927-R928)
+## 11. ALLOCATE statement coverage (ISO/IEC 1539-1:2018 R927-R928)
 
 Specification:
 
@@ -535,7 +564,7 @@ Gaps:
 
 ---
 
-## 11. Inheritance from F2008 and control‑flow tests
+## 12. Inheritance from F2008 and control‑flow tests
 
 Specification:
 
@@ -567,7 +596,7 @@ Gaps:
 
 ---
 
-## 12. Summary and issue mapping
+## 13. Summary and issue mapping
 
 The Fortran 2018 layer in this repository:
 
@@ -583,6 +612,7 @@ The Fortran 2018 layer in this repository:
     declarations.
   - DO CONCURRENT with locality specifiers and mask.
   - Enhanced STOP and ERROR STOP with QUIET.
+  - FAIL IMAGE statements for coarray image termination (R1163).
   - Assumed‑rank dummy arguments via DIMENSION(..).
   - Additional intrinsic procedures from F2018 (image status, teams,
     collectives, RANDOM_INIT, OUT_OF_RANGE, REDUCE extensions).
@@ -703,6 +733,7 @@ syntax rules to grammar rules in `Fortran2018Lexer.g4` and `Fortran2018Parser.g4
 | R1160 | stop-stmt | `stop_stmt_f2018` |
 | R1161 | error-stop-stmt | `error_stop_stmt_f2018` |
 | R1162 | stop-code | `stop_code` |
+| R1163 | fail-image-stmt | `fail_image_stmt` |
 
 ### A.8 Type Declarations (Section 8)
 
@@ -750,6 +781,7 @@ syntax rules to grammar rules in `Fortran2018Lexer.g4` and `Fortran2018Parser.g4
 | Section 11.6.8 | EVENT POST | `EVENT_POST` |
 | Section 11.6.8 | EVENT WAIT | `EVENT_WAIT` |
 | Section 11.6.9 | FORM TEAM | `FORM_TEAM` |
+| Section 11.6.6 | FAIL IMAGE | `FAIL_IMAGE` |
 | Section 11.1.7.5 | LOCAL | `LOCAL` |
 | Section 11.1.7.5 | LOCAL_INIT | `LOCAL_INIT` |
 | Section 11.1.7.5 | SHARED | `SHARED` |

--- a/grammars/src/Fortran2018Lexer.g4
+++ b/grammars/src/Fortran2018Lexer.g4
@@ -103,6 +103,11 @@ EVENT_WAIT       : E V E N T WS+ W A I T ;
 EVENT_QUERY      : E V E N T WS+ Q U E R Y ;
 
 // ----------------------------------------------------------------------------
+// FAIL IMAGE statement (ISO/IEC 1539-1:2018 Section 11.6.6)
+// ----------------------------------------------------------------------------
+FAIL_IMAGE       : F A I L WS+ I M A G E ;
+
+// ----------------------------------------------------------------------------
 // Assumed Rank Support (NEW in F2018)
 // ISO/IEC 1539-1:2018 Section 8.5.8.7: Assumed-rank entity
 // ISO/IEC 1539-1:2018 R825: assumed-rank-spec is ..

--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -212,6 +212,7 @@ executable_construct_f2018
     | format_stmt                     // FORMAT statements (R1301)
     | stop_stmt_f2018                 // Enhanced in F2018 (R1160)
     | error_stop_stmt_f2018           // Enhanced in F2018 (R1161)
+    | fail_image_stmt                 // NEW in F2018 (R1163)
     | select_type_construct           // Inherit from F2003
     | select_rank_construct           // NEW in F2018 (R1148-R1151)
     | associate_construct             // Inherit from F2003
@@ -588,6 +589,11 @@ stop_stmt_f2018
 // ISO/IEC 1539-1:2018 R1161: error-stop-stmt with optional QUIET= specifier
 error_stop_stmt_f2018
     : ERROR_STOP (stop_code)? (COMMA QUIET EQUALS logical_expr)? NEWLINE
+    ;
+
+// ISO/IEC 1539-1:2018 R1163: fail-image-stmt
+fail_image_stmt
+    : FAIL_IMAGE NEWLINE
     ;
 
 // ISO/IEC 1539-1:2018 R1162: stop-code

--- a/tests/fixtures/Fortran2018/test_issue574_fail_image/fail_image_stmt.f90
+++ b/tests/fixtures/Fortran2018/test_issue574_fail_image/fail_image_stmt.f90
@@ -1,0 +1,8 @@
+program fail_image_stmt
+  implicit none
+  logical :: triggered
+  triggered = .true.
+  if (triggered) then
+    fail image
+  end if
+end program fail_image_stmt


### PR DESCRIPTION
## Summary
- add the FAIL_IMAGE lexer token and parser rule so ISO R1163 statements parse under Fortran 2018
- include FAIL IMAGE in the executable construct list and add a fixture to cover the new statement
- document the coverage update in docs/fortran_2018_audit.md and note that issue #574 is resolved

## Verification
- `make test` (see /tmp/make-test.log; existing ANTLR warnings remain but the run succeeds)
- `make lint`
