### PR TITLE
fix: Fortran 2018 IMPLICIT NONE specifiers (fixes #568)

### DIFF
--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -93,8 +93,16 @@ Specification:
 Grammar implementation:
 
 - `specification_part_f2018`:
-  - Wraps `use_stmt`, `import_stmt`, `implicit_stmt`, and the new
+  - Wraps `use_stmt`, `import_stmt`, `implicit_stmt_f2018`, and the new
     `declaration_construct_f2018`.
+- `implicit_stmt_f2018`:
+  - Replaces the base `implicit_stmt` inside the specification part so the
+    parser accepts `IMPLICIT NONE` with the optional `(TYPE)`/`(EXTERNAL)`
+    clause defined by R863-R864 while still supporting legacy `implicit_spec`
+    lists.
+  - Supports all F2018 variants such as `IMPLICIT NONE (TYPE)`,
+    `IMPLICIT NONE (EXTERNAL)`, `IMPLICIT NONE (TYPE, EXTERNAL)`, and
+    `IMPLICIT NONE (EXTERNAL, TYPE)`, satisfying issue #568.
 - Extended USE:
   - `use_stmt` overrides the F2008 rule:
     - Supports `USE module`, `USE module, ONLY: only_list`.
@@ -138,6 +146,13 @@ Tests:
     `IMPORT, NONE`, `IMPORT, ALL`) inside an interface block.
   - Confirms the new parser rule added for issue #582 successfully parses
     the forms that interface/submodule authors rely on.
+- `tests/fixtures/Fortran2018/test_implicit_none_specifiers/implicit_none_specifiers.f90`:
+  - Contains a module plus several program units so each of the R863/R864 forms
+    (`IMPLICIT NONE (TYPE)`, `IMPLICIT NONE (EXTERNAL)`,
+    `IMPLICIT NONE (TYPE, EXTERNAL)`, `IMPLICIT NONE (EXTERNAL, TYPE)`) is
+    parsed without syntax errors.
+  - Provides direct coverage for issue #568 by exercising the new F2018
+    implicit-none clause permutations.
 
 Gaps:
 

--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -103,8 +103,27 @@ subroutine_stmt_f2018
 
 // ISO/IEC 1539-1:2018 R504: specification-part
 specification_part_f2018
-    : ((use_stmt | import_stmt | implicit_stmt | declaration_construct_f2018)
+    : ((use_stmt | import_stmt | implicit_stmt_f2018 | declaration_construct_f2018)
       NEWLINE*)*
+    ;
+
+// ISO/IEC 1539-1:2018 Section 8.7 (R863-R864): extended IMPLICIT NONE forms
+implicit_stmt_f2018
+    : IMPLICIT NONE implicit_none_spec_clause? NEWLINE?
+    | IMPLICIT implicit_spec_list NEWLINE?
+    ;
+
+implicit_none_spec_clause
+    : LPAREN implicit_none_spec_list RPAREN
+    ;
+
+implicit_none_spec_list
+    : implicit_none_spec (COMMA implicit_none_spec)*
+    ;
+
+implicit_none_spec
+    : TYPE
+    | EXTERNAL
     ;
 
 // ISO/IEC 1539-1:2018 R507: declaration-construct

--- a/tests/fixtures/Fortran2018/test_implicit_none_specifiers/implicit_none_specifiers.f90
+++ b/tests/fixtures/Fortran2018/test_implicit_none_specifiers/implicit_none_specifiers.f90
@@ -1,0 +1,19 @@
+module implicit_none_specs
+  implicit none
+end module implicit_none_specs
+
+program implicit_none_type
+  implicit none (TYPE)
+end program implicit_none_type
+
+program implicit_none_external
+  implicit none (EXTERNAL)
+end program implicit_none_external
+
+program implicit_none_type_external
+  implicit none (TYPE, EXTERNAL)
+end program implicit_none_type_external
+
+program implicit_none_external_type
+  implicit none (EXTERNAL, TYPE)
+end program implicit_none_external_type


### PR DESCRIPTION
## Summary
- extend the F2018 implicit statement rule so `IMPLICIT NONE` accepts the optional `(TYPE|EXTERNAL)` clause mandated by ISO/IEC 1539-1:2018 (resolves #568)
- add fixtures that exercise every F2018 `IMPLICIT NONE` permutation and prove the new clause is accepted without syntax errors
- document the new coverage in docs/fortran_2018_audit.md

## Verification
- `make test` (1501 passing tests; see /tmp/make-test.log)
- `make lint` (lint checks completed; see /tmp/make-lint.log)
