### PR TITLE
fix: Fortran 2018: Missing complex part %RE/%IM and type param (fixes #572)

### DIFF
--- a/docs/fortran_2003_audit.md
+++ b/docs/fortran_2003_audit.md
@@ -688,6 +688,10 @@ Grammar implementation:
   - `complex_part_designator` implements ISO/IEC 1539-1:2004 Section 6.1.2.5 (R615) so `%RE`/`%IM` access is parsed as both a primary expression and a left-hand side.
   - New fixture `tests/fixtures/Fortran2003/test_issue584_complex_parts/complex_part_designator.f90` covers simple access, assignments, expressions, array elements, and derived-component chains that exercise the feature.
   - Issue #584 tracks this functionality and can now be marked as resolved.
+- Type parameter inquiry:
+  - `type_param_inquiry` implements ISO/IEC 1539-1:2004 R916 so `designator % type-param-name` lookups on parameterized derived types parse as primary expressions.
+  - New fixture `tests/fixtures/Fortran2003/test_issue572_type_param_inquiry/type_param_inquiry.f90` exercises `%len_param` and `%kind_param` accesses on array elements created from a parameterized derived type.
+  - Issue #572 (Fortran 2018 type parameter inquiries) can now be considered resolved for F2003 and all inheriting grammars that reuse this rule.
 - Array constructors:
   - `array_constructor` is defined with `LSQUARE ... RSQUARE` and
     allows:

--- a/docs/fortran_2008_audit.md
+++ b/docs/fortran_2008_audit.md
@@ -511,6 +511,7 @@ The Fortran 2008 layer in this repository:
     (Section 13.7.41-42) with grammar coverage, fixture
     `compiler_inquiry_intrinsics.f90`, and issue #454.
   - Atomic subroutine intrinsics (`ATOMIC_DEFINE`/`ATOMIC_REF`, ISO/IEC 1539-1:2010 Sections 13.7.19-13.7.20) with lexer/parser coverage and fixture `atomic_intrinsics.f90` (#327).
+  - Type parameter inquiries (`type_param_inquiry`, R916) now parse `designator % type-param-name` expressions, and the new fixture `tests/fixtures/Fortran2008/test_issue572_type_param_inquiry/type_param_inquiry.f90` covers `%len_param` and `%kind_param` lookups; resolves Issue #572 for F2008.
   - Integration of all of the above into F2008 specification and
     execution parts and program units.
 

--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -637,6 +637,13 @@ The Fortran 2018 layer in this repository:
   - Assumed‑rank dummy arguments via DIMENSION(..).
   - Additional intrinsic procedures from F2018 (image status, teams,
     collectives, RANDOM_INIT, OUT_OF_RANGE, REDUCE extensions).
+  - Type parameter inquiries (`type_param_inquiry`, R916) ensure `designator % type-param-name`
+    syntax parses across the modern grammars; new fixtures under
+    `tests/fixtures/Fortran2003/...`, `tests/fixtures/Fortran2008/...`, and
+    `tests/fixtures/Fortran2023/test_issue572_type_param_inquiry/type_param_inquiry.f90`
+    exercise `%len_param`/`%kind_param` lookups and close Issue #572 for the inherited F2018 layer,
+    while `tests/Fortran2018/test_issue572_type_param_inquiry.py` covers the same syntax via the
+    `program_unit_f2018` entry rule.
   - Inheritance of all F2008 syntax (submodules, coarrays, CONTIGUOUS,
     etc.) with F2018 entry points.
 - **Intentionally leaves to semantic tooling:**

--- a/docs/fortran_2023_audit.md
+++ b/docs/fortran_2023_audit.md
@@ -389,7 +389,7 @@ Current status:
 The Fortran 2023 layer in this repository:
 
 - **Currently implements (partially):**
-  - A F2023‑specific program entry (`program_unit_f2023`) that re‑uses
+  - A F2023-specific program entry (`program_unit_f2023`) that re-uses
     F2018 program units.
   - A specification part overlay (`specification_part_f2023`) that
     supports ENUM/ENUMERATOR definitions and F2023 type declarations.
@@ -402,7 +402,8 @@ The Fortran 2023 layer in this repository:
     - Conditional expressions using `? :` (limited).
     - IEEE_MAX/MIN/MAX_MAG/MIN_MAG.
     - BOZ literals and basic NAMELIST/SYSTEM_CLOCK refinements.
-  - Token‑level compatibility with F2018 and earlier standards.
+  - Token-level compatibility with F2018 and earlier standards.
+  - Type parameter inquiries (`type_param_inquiry`, R916) parse `designator % type-param-name` expressions; the fixture `tests/fixtures/Fortran2023/test_issue572_type_param_inquiry/type_param_inquiry.f90` exercises the derived-type lookup patterns and closes Issue #572 for the F2023 layer.
 
 **CRITICAL Gaps (Issues #328–#335, #345–#348):**
 

--- a/grammars/src/Fortran2003Parser.g4
+++ b/grammars/src/Fortran2003Parser.g4
@@ -1789,6 +1789,17 @@ complex_part_designator
     : designator_core PERCENT (RE | IM)
     ;
 
+// Type parameter inquiry (ISO/IEC 1539-1:2004 R916)
+// F2003 derives type parameters for parameterized derived types and
+// supports designator % type-param-name lookups.
+type_param_inquiry
+    : designator PERCENT type_param_name
+    ;
+
+type_param_name
+    : IDENTIFIER
+    ;
+
 // Left-hand side expression (variable reference)
 // ISO/IEC 1539-1:2004 R601: variable -> designator
 // F2003 adds component access and complex part selectors (Section 6.1.2.5)
@@ -1892,6 +1903,7 @@ case_value_list
 primary
     : pdt_structure_constructor
     | complex_part_designator
+    | type_param_inquiry
     | identifier_or_keyword (PERCENT identifier_or_keyword)*
     | identifier_or_keyword LPAREN actual_arg_list? RPAREN
     | identifier_or_keyword DOUBLE_QUOTE_STRING      // Prefixed string

--- a/grammars/src/Fortran2008Parser.g4
+++ b/grammars/src/Fortran2008Parser.g4
@@ -995,7 +995,8 @@ system_command_call
 // Primary expression (ISO/IEC 1539-1:2010 R701)
 // Override F2003 to include F2008 intrinsic functions
 primary
-    : complex_part_designator
+    : type_param_inquiry
+    | complex_part_designator
     | identifier_or_keyword (PERCENT identifier_or_keyword)*
     | identifier_or_keyword LPAREN actual_arg_list? RPAREN
     | identifier_or_keyword DOUBLE_QUOTE_STRING

--- a/grammars/src/Fortran2018Parser.g4
+++ b/grammars/src/Fortran2018Parser.g4
@@ -701,6 +701,7 @@ array_expr
 primary
     : designator
     | complex_part_designator
+    | type_param_inquiry
     | identifier_or_keyword (PERCENT identifier_or_keyword)*
     | identifier_or_keyword LPAREN actual_arg_list? RPAREN
     | identifier_or_keyword DOUBLE_QUOTE_STRING

--- a/tests/Fortran2018/test_issue572_type_param_inquiry.py
+++ b/tests/Fortran2018/test_issue572_type_param_inquiry.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Verify that type parameter inquiries parse cleanly in F2018."""
+
+import os
+import sys
+from pathlib import Path
+
+from antlr4 import CommonTokenStream, InputStream
+
+sys.path.append(str(Path(__file__).parent.parent))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../grammars/generated/modern"))
+
+from Fortran2018Lexer import Fortran2018Lexer  # noqa: E402
+from Fortran2018Parser import Fortran2018Parser  # noqa: E402
+
+
+def parse_f2018(code: str):
+    """Return a parser after parsing the given F2018 code string."""
+
+    input_stream = InputStream(code)
+    lexer = Fortran2018Lexer(input_stream)
+    parser = Fortran2018Parser(CommonTokenStream(lexer))
+    parser.program_unit_f2018()
+    return parser
+
+
+def test_type_param_inquiry_expression_parses():
+    """`designator % type-param-name` expressions parse without errors."""
+
+    code = """PROGRAM type_param_inquiry
+  IMPLICIT NONE
+
+  TYPE :: t(k, n)
+    INTEGER, KIND :: k = 0
+    INTEGER, LEN :: n = 0
+  END TYPE t
+
+  TYPE(t(k=0, n=0)) :: sample
+  INTEGER :: recorded_k, recorded_n
+
+  recorded_k = sample%k
+  recorded_n = sample%n
+END PROGRAM type_param_inquiry"""
+
+    parser = parse_f2018(code)
+    assert parser.getNumberOfSyntaxErrors() == 0

--- a/tests/fixtures/Fortran2003/test_issue572_type_param_inquiry/type_param_inquiry.f90
+++ b/tests/fixtures/Fortran2003/test_issue572_type_param_inquiry/type_param_inquiry.f90
@@ -1,0 +1,19 @@
+PROGRAM type_param_inquiry
+  IMPLICIT NONE
+
+  TYPE param_holder(len_param, kind_param)
+    INTEGER, LEN :: len_param = 4
+    INTEGER, KIND :: kind_param = 8
+    REAL(KIND=kind_param) :: data(len_param)
+  END TYPE param_holder
+
+  TYPE(param_holder(len_param=5, kind_param=8)) :: instance
+  INTEGER :: observed_len
+  INTEGER :: observed_kind
+
+  instance%data = [1.0, 2.0, 3.0, 4.0, 5.0]
+  observed_len = instance%len_param
+  observed_kind = instance%kind_param
+
+  PRINT *, 'LEN:', observed_len, 'KIND:', observed_kind
+END PROGRAM type_param_inquiry

--- a/tests/fixtures/Fortran2008/test_issue572_type_param_inquiry/type_param_inquiry.f90
+++ b/tests/fixtures/Fortran2008/test_issue572_type_param_inquiry/type_param_inquiry.f90
@@ -1,0 +1,19 @@
+PROGRAM type_param_inquiry
+  IMPLICIT NONE
+
+  TYPE param_holder(len_param, kind_param)
+    INTEGER, LEN :: len_param = 4
+    INTEGER, KIND :: kind_param = 8
+    REAL(KIND=kind_param) :: data(len_param)
+  END TYPE param_holder
+
+  TYPE(param_holder(len_param=5, kind_param=8)) :: instance
+  INTEGER :: observed_len
+  INTEGER :: observed_kind
+
+  instance%data = [1.0, 2.0, 3.0, 4.0, 5.0]
+  observed_len = instance%len_param
+  observed_kind = instance%kind_param
+
+  PRINT *, 'LEN:', observed_len, 'KIND:', observed_kind
+END PROGRAM type_param_inquiry

--- a/tests/fixtures/Fortran2023/test_issue572_type_param_inquiry/type_param_inquiry.f90
+++ b/tests/fixtures/Fortran2023/test_issue572_type_param_inquiry/type_param_inquiry.f90
@@ -1,0 +1,19 @@
+PROGRAM type_param_inquiry
+  IMPLICIT NONE
+
+  TYPE param_holder(len_param, kind_param)
+    INTEGER, LEN :: len_param = 4
+    INTEGER, KIND :: kind_param = 8
+    REAL(KIND=kind_param) :: data(len_param)
+  END TYPE param_holder
+
+  TYPE(param_holder(len_param=5, kind_param=8)) :: instance
+  INTEGER :: observed_len
+  INTEGER :: observed_kind
+
+  instance%data = [1.0, 2.0, 3.0, 4.0, 5.0]
+  observed_len = instance%len_param
+  observed_kind = instance%kind_param
+
+  PRINT *, 'LEN:', observed_len, 'KIND:', observed_kind
+END PROGRAM type_param_inquiry


### PR DESCRIPTION
## Summary
- extend the Fortran2003 grammar with `type_param_inquiry` and plug it into the F2008/F2018 primary so `%type-param-name` expressions become first-class designators
- add documentation and fixtures for Fortran2003, Fortran2008, and Fortran2023 that demonstrate `%len_param`/`%kind_param` lookups on parameterized derived types
- add a focused Fortran2018 unit test that parses a `program_unit_f2018` script exercising `%type-param-name` inquiries

## Verification
- `make test 2>&1 | tee /tmp/make_test.log` (1505 passed in 27.59s, see log for detail)
- `make lint 2>&1 | tee /tmp/make_lint.log`
