### PR TITLE
fix: Fortran 2018 lock/unlock coverage (fixes #581)

### DIFF
--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -239,6 +239,10 @@ Grammar implementation:
       `RESULT_IMAGE = variable_f90`.
   - `operation_spec` and `source_image_spec`:
     - Generic identifier / expression forms.
+  - `lock_stmt`, `unlock_stmt`, `lock_stat`, and `lock_variable` continue to be inherited
+    from Fortran 2008 so LOCK/UNLOCK statements accept `type(lock_type)` declarations from
+    `ISO_FORTRAN_ENV`, the `ACQUIRED_LOCK = scalar-logical-variable` status specifier,
+    and STAT/ERRMSG forms described by R1179-R1182 (issue #581).
   - `image_selector`, `designator`, and `variable_f2008` now accept
     optional image-selector-spec-lists so STAT=, TEAM=, and TEAM_NUMBER=
     specifiers follow R924-R926 (issue #599).
@@ -251,6 +255,12 @@ Tests:
 - `test_issue61_teams_and_collectives.py::test_image_selector_team_specs_parse_cleanly`:
   - `image_selector_team.f90` verifies TEAM=, TEAM_NUMBER=, and STAT= specifiers inside
     image selectors for coarrays (issue #599).
+- `tests/Fortran2018/test_basic_f2018_features.py::test_lock_unlock_statements` and its
+  fixture `tests/fixtures/Fortran2018/test_basic_f2018_features/lock_unlock.f90`:
+  - Parse LOCK/UNLOCK statements with STAT, ERRMSG, ACQUIRED_LOCK, and
+    `type(lock_type)` declarations pulled from `use iso_fortran_env` to confirm the
+    inherited syntax successfully covers ISO/IEC 1539-1:2018 Section 11.6.11-12
+    (issue #581).
 
 Gaps:
 
@@ -627,6 +637,11 @@ The Fortran 2018 layer in this repository:
   - SELECT RANK, including RANK cases and RANK DEFAULT.
   - Collective coarray subroutines (CO_SUM, CO_MIN, CO_MAX, CO_REDUCE,
     CO_BROADCAST) with STAT/ERRMSG/RESULT_IMAGE.
+  - LOCK/UNLOCK statements (ISO/IEC 1539-1:2018 Sections 11.6.11-12) with
+    STAT/ERRMSG, `ACQUIRED_LOCK`, and `LOCK_TYPE` usage are tested via
+    `tests/Fortran2018/test_basic_f2018_features.py::test_lock_unlock_statements`
+    and its fixture `tests/fixtures/Fortran2018/test_basic_f2018_features/lock_unlock.f90`,
+    closing issue #581.
   - Team constructs (FORM TEAM, CHANGE TEAM, END TEAM), TEAM_TYPE
     declarations, and coarray association syntax.
   - Event constructs (EVENT POST/WAIT/QUERY) and EVENT_TYPE
@@ -809,6 +824,9 @@ syntax rules to grammar rules in `Fortran2018Lexer.g4` and `Fortran2018Parser.g4
 | Section 11.6.8 | EVENT POST | `EVENT_POST` |
 | Section 11.6.8 | EVENT WAIT | `EVENT_WAIT` |
 | Section 11.6.9 | FORM TEAM | `FORM_TEAM` |
+| Section 11.6.11 | LOCK | `LOCK` |
+| Section 11.6.12 | UNLOCK | `UNLOCK` |
+| R861 | ACQUIRED_LOCK | `ACQUIRED_LOCK` |
 | Section 11.6.6 | FAIL IMAGE | `FAIL_IMAGE` |
 | Section 11.1.7.5 | LOCAL | `LOCAL` |
 | Section 11.1.7.5 | LOCAL_INIT | `LOCAL_INIT` |

--- a/tests/Fortran2018/test_basic_f2018_features.py
+++ b/tests/Fortran2018/test_basic_f2018_features.py
@@ -83,6 +83,19 @@ class TestBasicF2018Features:
         # (see issues #83 and #88).
         assert errors == 0, f"F2008 inheritance should parse with zero errors, got {errors}"
     
+    def test_lock_unlock_statements(self):
+        """REAL TEST: Ensure LOCK/UNLOCK (R1179-R1182) and LOCK_TYPE/ACQUIRED_LOCK specifiers parse (issue #581)."""
+        code = load_fixture(
+            "Fortran2018",
+            "test_basic_f2018_features",
+            "lock_unlock.f90",
+        )
+
+        tree, errors = self.parse_code(code)
+
+        assert tree is not None, "LOCK/UNLOCK fixture should produce a parse tree"
+        assert errors == 0, f"LOCK/UNLOCK statements should parse without errors, got {errors}"
+
     def test_f2018_parser_vs_f2008_functionality(self):
         """REAL TEST: Compare F2018 vs F2008 parsing on same code"""
         code = load_fixture(

--- a/tests/fixtures/Fortran2018/test_basic_f2018_features/lock_unlock.f90
+++ b/tests/fixtures/Fortran2018/test_basic_f2018_features/lock_unlock.f90
@@ -1,0 +1,20 @@
+program test_lock_unlock
+    use iso_fortran_env
+    implicit none
+    type(lock_type) :: my_lock[*]
+    integer :: stat_var
+    character(len=128) :: errmsg_var
+    logical :: acquired
+
+    lock(my_lock)
+    unlock(my_lock)
+
+    lock(my_lock, stat=stat_var)
+    unlock(my_lock, stat=stat_var)
+
+    lock(my_lock, acquired_lock=acquired)
+    lock(my_lock, stat=stat_var, errmsg=errmsg_var)
+    lock(my_lock, acquired_lock=acquired, stat=stat_var)
+
+    unlock(my_lock, stat=stat_var, errmsg=errmsg_var)
+end program test_lock_unlock


### PR DESCRIPTION
## Summary
- Add `tests/fixtures/Fortran2018/test_basic_f2018_features/lock_unlock.f90` plus `tests/Fortran2018/test_basic_f2018_features.py::test_lock_unlock_statements` so LOCK/UNLOCK (ISO/IEC 1539-1:2018 Sections 11.6.11-12) with STAT/ERRMSG/ACQUIRED_LOCK and ISO_FORTRAN_ENV's LOCK_TYPE parse through F2018 (closes #581).
- Document the coverage in `docs/fortran_2018_audit.md`, calling out the new fixture/test, ISO references, and Appendix tokens for `LOCK`, `UNLOCK`, and `ACQUIRED_LOCK`.

## Verification
- `make test` (output: `✅ All tests completed!`; log: `/tmp/make-test.log`)
- `make lint` (output: `✅ Lint completed successfully`; log: `/tmp/make-lint.log`)
