### PR TITLE
fix: FORTRAN II inherit expressions from 1957 (fixes #638)

### DIFF
--- a/grammars/src/FORTRAN66Parser.g4
+++ b/grammars/src/FORTRAN66Parser.g4
@@ -190,6 +190,17 @@ logical_variable
     ;
 
 // ============================================================================
+// ARITHMETIC EXPRESSIONS - X3.9-1966 Section 6.2
+// ============================================================================
+// FORTRAN 66 retains the FORTRAN I/II arithmetic expression syntax. The
+// top-level `expr` is defined here as an arithmetic expression so that
+// relational and logical expressions introduced in FORTRAN 66 remain separate.
+
+expr
+    : additive_expr
+    ;
+
+// ============================================================================
 // RELATIONAL EXPRESSIONS - X3.9-1966 Section 6.3
 // ============================================================================
 // X3.9-1966 Section 6.3 defines relational expressions that compare two

--- a/grammars/src/FORTRANIIParser.g4
+++ b/grammars/src/FORTRANIIParser.g4
@@ -253,13 +253,10 @@ read_stmt
 // ============================================================================
 // EXPRESSIONS
 // ============================================================================
-// FORTRAN II expression syntax matches 1957 arithmetic expressions.
-// Relational operators (.EQ., .NE., etc.) are not part of the top-level expr in
-// FORTRAN II; FORTRAN 66 introduces logical types and relational expressions.
-
-expr
-    : additive_expr
-    ;
+// FORTRAN II expression syntax is unchanged from FORTRAN I (1957).
+// All expression rules, including relational operators, are inherited from
+// FORTRANParser. This grammar only widens numeric handling via `literal` and
+// `label` to accept LABEL tokens from FORTRANIILexer.
 
 // ============================================================================
 // UTILITY RULES

--- a/tests/FORTRANII/test_fortran_ii_parser.py
+++ b/tests/FORTRANII/test_fortran_ii_parser.py
@@ -316,6 +316,22 @@ class TestFORTRANIIParser(unittest.TestCase):
                 self.assertIsNotNone(tree, f"Failed to parse: {expr_text}")
                 self.assertEqual(tree.getText(), expected)
 
+    def test_relational_expressions_parse(self):
+        """Test relational operators in FORTRAN II expressions (inherited from 1957)."""
+        test_cases = [
+            "A .EQ. B",
+            "X+1 .GT. Y",
+            "I .LE. 10",
+            "J .NE. K",
+        ]
+
+        for expr_text in test_cases:
+            with self.subTest(expr=expr_text):
+                tree = self.parse(expr_text, 'expr')
+                self.assertIsNotNone(tree, f"Failed to parse: {expr_text}")
+                expected = expr_text.replace(' ', '')
+                self.assertEqual(tree.getText(), expected)
+
     def test_parenthesized_expressions(self):
         """Test parentheses override default precedence"""
         test_cases = [


### PR DESCRIPTION
Implements issue #638 by removing the redundant FORTRAN II `expr` override so expressions are inherited from FORTRAN I, consistent with IBM C28-6000-2 and the audit.

Also defines FORTRAN 66 `expr` as arithmetic-only to keep relational/logical expressions separate and avoid ANTLR mutual left recursion.

Verification:
- `make test 2>&1 | tee /tmp/test.log` (initial run caught left-recursion regression)
- `make test-fortran2 2>&1 | tee /tmp/test-fortran2.log` → `89 passed`
- `make test-fortran66 2>&1 | tee /tmp/test-fortran66.log` → `124 passed`
- `make lint 2>&1 | tee /tmp/lint.log` → success
