### PR TITLE
fix: FORTRAN II inherit FORTRAN I statements (fixes #637)

### DIFF
--- a/grammars/src/FORTRANIIParser.g4
+++ b/grammars/src/FORTRANIIParser.g4
@@ -230,8 +230,10 @@ end_stmt
 // FORTRAN II re-exports the 1958-era names here.
 
 // Arithmetic IF - Appendix A: IF (e) n1, n2, n3
+// Inherited from FORTRAN I as `if_stmt_arithmetic`; re-exported here under the
+// FORTRAN II name to preserve downstream rule references.
 arithmetic_if_stmt
-    : IF LPAREN expr RPAREN label COMMA label COMMA label
+    : if_stmt_arithmetic
     ;
 
 // CONTINUE statement - Appendix A: CONTINUE
@@ -245,8 +247,12 @@ stop_stmt
     ;
 
 // READ statement - Appendix A: READ forms
+// Re-export inherited FORTRAN I basic READ forms and add FORTRAN II positional
+// unit/format variants. This avoids duplicating the FORTRAN I alternatives while
+// retaining FORTRAN II enhancements.
 read_stmt
-    : READ integer_expr COMMA input_list              // READ unit, list
+    : read_stmt_basic                                 // Inherited basic READ forms
+    | READ integer_expr COMMA input_list              // READ unit, list
     | READ integer_expr COMMA label COMMA input_list  // READ unit, format, list
     ;
 


### PR DESCRIPTION
Summary:
- Remove remaining FORTRAN I duplication in FORTRAN II by delegating `arithmetic_if_stmt` to inherited `if_stmt_arithmetic`.
- Re-export inherited basic READ forms via `read_stmt_basic` while keeping FORTRAN II positional unit/format variants.

Verification:
- `make test 2>&1 | tee /tmp/test.log`
- Result: `1505 passed` (see `/tmp/test.log`).

Notes:
- This completes the historical-inheritance cleanup described in #637; no behavior regressions observed.