### PR TITLE
fix: Docs: update audit file paths to grammars/src (fixes #652)

### DIFF
--- a/docs/fortran_1957_audit.md
+++ b/docs/fortran_1957_audit.md
@@ -3,7 +3,7 @@
 This document summarizes what the **FORTRAN (1957)** grammar in this
 repository actually supports today, based only on the contents of:
 
-- `grammars/FORTRANLexer.g4`, `grammars/FORTRANParser.g4`
+- `grammars/src/FORTRANLexer.g4`, `grammars/src/FORTRANParser.g4`
 - `docs/fixed_form_support.md`
 - `tests/FORTRAN/test_fortran_historical_stub.py`
 - `tests/test_fixture_parsing.py` and the fixtures it references

--- a/docs/fortran_2003_audit.md
+++ b/docs/fortran_2003_audit.md
@@ -12,9 +12,9 @@ Because the OCR’d text file is currently empty
 itself and the standard’s well‑known feature set as the primary reference
 and cross‑checks against:
 
-- `grammars/Fortran2003Lexer.g4`, `grammars/Fortran2003Parser.g4`
+- `grammars/src/Fortran2003Lexer.g4`, `grammars/src/Fortran2003Parser.g4`
 - Inherited grammars:
-  - `grammars/Fortran95Lexer.g4`, `grammars/Fortran95Parser.g4`
+  - `grammars/src/Fortran95Lexer.g4`, `grammars/src/Fortran95Parser.g4`
 - Tests under `tests/Fortran2003/`
   - `test_fortran_2003_comprehensive.py`
   - `test_simple_f2003.py`, `test_working_f2003.py`

--- a/docs/fortran_2008_audit.md
+++ b/docs/fortran_2008_audit.md
@@ -10,9 +10,9 @@ implements and how it relates to the Fortran 2008 language as defined in:
 The OCR’d `.txt` file is currently empty, so this audit uses the known
 F2008 feature set plus the local PDF and compares that to:
 
-- `grammars/Fortran2008Lexer.g4`, `grammars/Fortran2008Parser.g4`
+- `grammars/src/Fortran2008Lexer.g4`, `grammars/src/Fortran2008Parser.g4`
 - Inherited grammars:
-  - `grammars/Fortran2003Lexer.g4`, `grammars/Fortran2003Parser.g4`
+  - `grammars/src/Fortran2003Lexer.g4`, `grammars/src/Fortran2003Parser.g4`
 - Tests under `tests/Fortran2008/`:
   - `test_basic_f2008_features.py`
   - `test_f2008_coarrays.py`

--- a/docs/fortran_2018_audit.md
+++ b/docs/fortran_2018_audit.md
@@ -10,9 +10,9 @@ implements and how it relates to the Fortran 2018 language as defined in:
 The OCR’d `.txt` file is currently empty, so this audit uses the known
 F2018 feature set plus the local PDF and compares that to:
 
-- `grammars/Fortran2018Lexer.g4`, `grammars/Fortran2018Parser.g4`
+- `grammars/src/Fortran2018Lexer.g4`, `grammars/src/Fortran2018Parser.g4`
 - Inherited grammars:
-  - `grammars/Fortran2008Lexer.g4`, `grammars/Fortran2008Parser.g4`
+  - `grammars/src/Fortran2008Lexer.g4`, `grammars/src/Fortran2008Parser.g4`
 - Tests under `tests/Fortran2018/`:
   - `test_basic_f2018_features.py`
   - `test_issue61_teams_and_collectives.py`

--- a/docs/fortran_2023_audit.md
+++ b/docs/fortran_2023_audit.md
@@ -10,9 +10,9 @@ implements and how it relates to the Fortran 2023 language as defined in:
 The OCR'd `.txt` file is currently empty, so this audit uses the known
 F2023 feature set plus the local PDF and compares that to:
 
-- `grammars/Fortran2023Lexer.g4`, `grammars/Fortran2023Parser.g4`
+- `grammars/src/Fortran2023Lexer.g4`, `grammars/src/Fortran2023Parser.g4`
 - Inherited grammars:
-  - `grammars/Fortran2018Lexer.g4`, `grammars/Fortran2018Parser.g4`
+  - `grammars/src/Fortran2018Lexer.g4`, `grammars/src/Fortran2018Parser.g4`
 - Tests under:
   - `tests/Fortran2023/test_fortran_2023_comprehensive.py`
   - Generic fixture harness: `tests/test_fixture_parsing.py` and

--- a/docs/fortran_66_audit.md
+++ b/docs/fortran_66_audit.md
@@ -3,8 +3,8 @@
 This document summarizes the **FORTRAN 66** grammar implemented in this
 repository, based on:
 
-- `grammars/FORTRAN66Lexer.g4`, `grammars/FORTRAN66Parser.g4`
-- Inherited grammars (`FORTRANIILexer.g4`, `FORTRANIIParser.g4`)
+- `grammars/src/FORTRAN66Lexer.g4`, `grammars/src/FORTRAN66Parser.g4`
+- Inherited grammars (`grammars/src/FORTRANIILexer.g4`, `grammars/src/FORTRANIIParser.g4`)
 - `docs/fixed_form_support.md`
 - Tests in `tests/FORTRAN66/test_fortran66_parser.py`
 - XPASS fixtures listed in `tests/test_fixture_parsing.py`

--- a/docs/fortran_77_audit.md
+++ b/docs/fortran_77_audit.md
@@ -10,8 +10,8 @@ in the local copy of the standard:
 
 The implementation view is based on:
 
-- `grammars/FORTRAN77Lexer.g4`, `grammars/FORTRAN77Parser.g4`
-- Inherited grammars (`FORTRAN66Lexer.g4`, `FORTRAN66Parser.g4`)
+- `grammars/src/FORTRAN77Lexer.g4`, `grammars/src/FORTRAN77Parser.g4`
+- Inherited grammars (`grammars/src/FORTRAN66Lexer.g4`, `grammars/src/FORTRAN66Parser.g4`)
 - `docs/fixed_form_support.md`
 - Tests under `tests/FORTRAN77/`
 - XPASS fixtures in `tests/test_fixture_parsing.py`

--- a/docs/fortran_90_audit.md
+++ b/docs/fortran_90_audit.md
@@ -9,7 +9,7 @@ locally:
 
 The implementation view is based on:
 
-- `grammars/Fortran90Lexer.g4`, `grammars/Fortran90Parser.g4`
+- `grammars/src/Fortran90Lexer.g4`, `grammars/src/Fortran90Parser.g4`
 - `docs/fixed_form_support.md`
 - `tests/Fortran90/test_fortran_90_comprehensive.py`
 - XPASS fixtures recorded in `tests/test_fixture_parsing.py`

--- a/docs/fortran_95_audit.md
+++ b/docs/fortran_95_audit.md
@@ -11,9 +11,9 @@ implements and how it relates to the Fortran 95 language as defined in:
 
 The implementation view is based on:
 
-- `grammars/Fortran95Lexer.g4`, `grammars/Fortran95Parser.g4`
+- `grammars/src/Fortran95Lexer.g4`, `grammars/src/Fortran95Parser.g4`
 - Inherited F90 grammar:
-  - `grammars/Fortran90Lexer.g4`, `grammars/Fortran90Parser.g4`
+  - `grammars/src/Fortran90Lexer.g4`, `grammars/src/Fortran90Parser.g4`
 - Tests in `tests/Fortran95/test_fortran_95_features.py` and fixtures
   under `tests/fixtures/Fortran95/test_fortran_95_features/`
 

--- a/docs/fortran_ii_audit.md
+++ b/docs/fortran_ii_audit.md
@@ -4,7 +4,7 @@ This document describes what the **FORTRAN II** grammar in this
 repository currently supports, based on:
 
 - `grammars/src/FORTRANIILexer.g4`, `grammars/src/FORTRANIIParser.g4`
-- `grammars/FORTRANLexer.g4`, `grammars/FORTRANParser.g4`
+- `grammars/src/FORTRANLexer.g4`, `grammars/src/FORTRANParser.g4`
 - `docs/fixed_form_support.md`
 - `tests/FORTRANII/test_fortran_ii_parser.py`
 - `tests/test_fixture_parsing.py` (XPASS fixtures)


### PR DESCRIPTION
Summary:
- Update all docs/fortran_*_audit.md to use grammars/src/*.g4 paths consistently.

Verification:
- make test 2>&1 | tee /tmp/test.log
- Result: 1505 passed (log: /tmp/test.log)
- Path check: rg 'grammars/[^\s`]*\.g4' docs/fortran_*_audit.md