### PR TITLE
fix: FORTRAN II statement functions inherited from 1957 (fixes #639)

### DIFF
--- a/docs/fortran_ii_audit.md
+++ b/docs/fortran_ii_audit.md
@@ -336,6 +336,9 @@ Most core FORTRAN (1957) statements remain available in FORTRAN II.
 These are either inherited from `FORTRANParser.g4` or redefined in
 `FORTRANIIParser.g4`:
 
+Statement functions are explicitly inherited unchanged from FORTRAN I
+and are not redefined in the FORTRAN II grammar (issue #639).
+
 | Statement Form                       | Grammar Rule(s)                | Status          |
 |--------------------------------------|--------------------------------|-----------------|
 | v = e (assignment)                   | `assignment_stmt`              | Implemented     |

--- a/tests/FORTRANII/test_fortran_ii_parser.py
+++ b/tests/FORTRANII/test_fortran_ii_parser.py
@@ -102,6 +102,24 @@ class TestFORTRANIIParser(unittest.TestCase):
         self.assertIn('X', text)
         self.assertIn('Y', text)
 
+    def test_statement_function_in_main_program(self):
+        """Test statement functions parse in FORTRAN II main programs.
+
+        Statement functions were introduced in FORTRAN I (1957) and are
+        inherited unchanged in FORTRAN II (1958). This verifies the FORTRAN II
+        parser continues to accept the inherited rule without redefinition.
+        """
+        program_text = """
+        F(X,Y) = X + Y
+        A = F(1,2)
+        END
+        """
+        tree = self.parse(program_text, 'main_program')
+        self.assertIsNotNone(tree)
+        text = tree.getText().replace(' ', '')
+        self.assertIn('F(X,Y)=X+Y', text)
+        self.assertIn('A=F(1,2)', text)
+
     def test_function_definition(self):
         """Test FUNCTION definitions (introduced in FORTRAN II)"""
         function_text = load_fixture(


### PR DESCRIPTION
Implements issue #639.

- Confirms FORTRAN II grammar inherits statement functions from FORTRAN I.
- Adds FORTRAN II regression test for statement functions.
- Documents inheritance explicitly in audit.

Verification:
- `make test 2>&1 | tee /tmp/test.log`
- Result: `1507 passed` (see `/tmp/test.log`).
