### PR TITLE
fix: FORTRAN 77: DO loop terminal statement forms beyond CONTINUE (fixes #586)

### DIFF
--- a/tests/FORTRAN77/test_fortran77_parser.py
+++ b/tests/FORTRAN77/test_fortran77_parser.py
@@ -137,30 +137,13 @@ END IF"""
 
     def test_do_loop_terminal_statement_forms(self):
         """DO loops may end on any labeled executable statement except restricted ones."""
-        terminal_loops = """      PROGRAM DO_LOOP_TERMINALS
-      REAL A(5), B(5), C(5), TEMP
-      DO 10 I = 1, 5
-      A(I) = B(I) + C(I)
-10   A(I) = A(I) * 2.0
-      DO 20 J = 1, 3
-      B(J) = J
-20   CALL HANDLE(B(J))
-      DO 30 K = 1, 2
-      C(K) = K * 2
-30   READ(5,*) C(K)
-      DO 31 L = 1, 2
-      C(L) = L - 1
-31   WRITE(6,*) C(L)
-      DO 40 M = 1, 4
-      TEMP = M - 2
- 40   IF (TEMP .GT. 0) 50, 60, 70
- 50   CONTINUE
- 60   CONTINUE
- 70   CONTINUE
-      END
-"""
+        fixture_text = load_fixture(
+            "FORTRAN77",
+            "test_fortran77_parser",
+            "do_loop_terminal_statement_forms.f",
+        )
 
-        tree = self.parse(terminal_loops, 'main_program')
+        tree = self.parse(fixture_text, 'main_program')
         self.assertIsNotNone(tree)
     
     def test_save_statement(self):

--- a/tests/fixtures/FORTRAN77/test_fortran77_parser/do_loop_terminal_statement_forms.f
+++ b/tests/fixtures/FORTRAN77/test_fortran77_parser/do_loop_terminal_statement_forms.f
@@ -1,0 +1,21 @@
+      PROGRAM DO_LOOP_TERMINALS
+      REAL A(5), B(5), C(5), TEMP
+      DO 10 I = 1, 5
+      A(I) = B(I) + C(I)
+ 10   A(I) = A(I) * 2.0
+      DO 20 J = 1, 3
+      B(J) = J
+ 20   CALL HANDLE(B(J))
+      DO 30 K = 1, 2
+      C(K) = K * 2
+ 30   READ(5,*) C(K)
+      DO 31 L = 1, 2
+      C(L) = L - 1
+ 31   WRITE(6,*) C(L)
+      DO 40 M = 1, 4
+      TEMP = M - 2
+ 40   IF (TEMP) 50, 60, 70
+ 50   CONTINUE
+ 60   CONTINUE
+ 70   CONTINUE
+      END


### PR DESCRIPTION
Summary
- Adds FORTRAN77 fixture covering DO-loop terminal statement forms (assignment, CALL, READ, WRITE, arithmetic IF).
- Updates unit test to load this fixture.

Standard notes
- Grammar enforces only presence of the terminal label; terminal statement restrictions from ANSI X3.9-1978 Section 11.10.4 remain semantic.

Verification
- make test 2>&1 | tee /tmp/test.log
  - Initially failed only on new fixture (arithmetic IF used logical .GT.); fixture corrected.
- make test-fortran77 2>&1 | tee /tmp/test-fortran77.log
  - 58 passed, 158 subtests passed.
- make lint 2>&1 | tee /tmp/lint.log
  - Lint completed successfully.