### PR TITLE
fix: Fortran 2003 ALLOCATE MOLD= historically incorrect (fixes #679)

### DIFF
--- a/docs/fortran_2008_audit.md
+++ b/docs/fortran_2008_audit.md
@@ -320,6 +320,9 @@ Grammar implementation:
   - `allocation_f2008`:
     - `IDENTIFIER coarray_spec? (shape)?` or
       `derived_type_spec :: IDENTIFIER coarray_spec? (shape)?`.
+  - `alloc_opt`:
+    - Supports `STAT=`, `ERRMSG=`, `SOURCE=`, and `MOLD=` specifiers
+      (MOLD first appears in F2008; issue #679).
   - This extends F2003’s allocation with explicit coarray codimensions.
 
 Tests:
@@ -653,8 +656,9 @@ rules to grammar rules in `Fortran2008Lexer.g4` and `Fortran2008Parser.g4`.
 | ISO Rule | ISO Description | Grammar Rule |
 |----------|-----------------|--------------|
 | R626 | allocate-stmt | `allocate_stmt_f2008` |
-| R627 | allocation-list | `allocation_list_f2008` |
-| R628 | allocation | `allocation_f2008` |
+| -- | allocation-list | `allocation_list_f2008` |
+| R627 | alloc-opt | `alloc_opt` |
+| R631 | allocation | `allocation_f2008` |
 
 ### A.9 ERROR STOP (Section 8.4)
 

--- a/grammars/src/Fortran2008Parser.g4
+++ b/grammars/src/Fortran2008Parser.g4
@@ -749,10 +749,13 @@ attr_spec
 // ALLOCATE statement with coarray support for allocating coarray codimensions.
 //
 // Key rules from ISO/IEC 1539-1:2010:
-// - R626: allocate-stmt -> ALLOCATE ([type-spec::] allocation-list [, alloc-opt-list])
-// - R628: allocation -> allocate-object [(allocate-shape-spec-list)]
-//                       [allocate-coarray-spec]
-// - R636: allocate-coarray-spec -> [allocate-coshape-spec-list,] [lower-bound-expr:]
+// - R626: allocate-stmt -> ALLOCATE ([type-spec :: ] allocation-list
+//                                   [, alloc-opt-list])
+// - R627: alloc-opt -> ERRMSG=errmsg-variable | MOLD=source-expr
+//                    | SOURCE=source-expr | STAT=stat-variable
+// - R631: allocation -> allocate-object [(allocate-shape-spec-list)]
+//                       [allocate-co-array-spec]
+// - R636: allocate-co-array-spec -> [allocate-co-shape-spec-list,] [lower-bound-expr:]
 
 // ALLOCATE statement with coarray support (ISO/IEC 1539-1:2010 R626)
 allocate_stmt_f2008
@@ -762,14 +765,14 @@ allocate_stmt_f2008
       (COMMA alloc_opt_list)? RPAREN NEWLINE
     ;
 
-// Allocation option list (ISO/IEC 1539-1:2010 R627, with MOLD= added in F2008)
+// Allocation option list (alloc-opt-list in R626; elements are R627 alloc-opt)
 alloc_opt_list
     : alloc_opt (COMMA alloc_opt)*
     ;
 
-// Allocation option (ISO/IEC 1539-1:2010 R629)
-// R629: alloc-opt -> STAT=stat-variable | ERRMSG=errmsg-variable
-//                  | SOURCE=source-expr | MOLD=source-expr
+// Allocation option (ISO/IEC 1539-1:2010 R627)
+// R627: alloc-opt -> ERRMSG=errmsg-variable | MOLD=source-expr
+//                  | SOURCE=source-expr | STAT=stat-variable
 alloc_opt
     : STAT EQUALS identifier_or_keyword
     | ERRMSG EQUALS identifier_or_keyword
@@ -777,14 +780,14 @@ alloc_opt
     | MOLD EQUALS expr_f2003
     ;
 
-// Allocation list (ISO/IEC 1539-1:2010 R627)
+// Allocation list (allocation-list in R626)
 allocation_list_f2008
     : allocation_f2008 (COMMA allocation_f2008)*
     ;
 
-// Allocation with coarray codimension (ISO/IEC 1539-1:2010 R628)
-// R628: allocation -> allocate-object [(allocate-shape-spec-list)]
-//                     [allocate-coarray-spec]
+// Allocation with coarray codimension (ISO/IEC 1539-1:2010 R631)
+// R631: allocation -> allocate-object [(allocate-shape-spec-list)]
+//                     [allocate-co-array-spec]
 allocation_f2008
     : IDENTIFIER coarray_spec? (LPAREN allocate_shape_spec_list RPAREN)?
     | derived_type_spec DOUBLE_COLON IDENTIFIER coarray_spec?


### PR DESCRIPTION
Fixes #679.

Summary:
- Updated `grammars/src/Fortran2008Parser.g4` ALLOCATE annotations to match ISO/IEC 1539-1:2010 R626/R627/R631/R636, confirming MOLD= is F2008+.
- Updated `docs/fortran_2008_audit.md` to document MOLD= as first introduced in F2008 and to correct the A.8 ALLOCATE rule map.

Verification:
- `make test 2>&1 | tee /tmp/make-test-679.log`
  - Full suite run once; only failure was line-length compliance for a comment line.
- `python -m pytest tests/test_code_compliance.py::TestCodeCompliance::test_line_length_compliance`
  - Passed after wrapping the comment.
- `make lint 2>&1 | tee /tmp/make-lint-679.log`
  - Lint completed successfully.