### PR TITLE
refactor: replace Lazy Fortran terminology with LFortran/LFortranInfer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Build Marp slides
         run: |
           mkdir -p docs/slides/html
-          marp docs/slides/lazyfortran2025-open-issues.md \
+          marp docs/slides/lfortran-open-issues.md \
             --html \
             --output docs/slides/html/index.html
-          marp docs/slides/lazyfortran2025-open-issues.md \
+          marp docs/slides/lfortran-open-issues.md \
             --pdf \
-            --output docs/slides/html/lazyfortran2025-open-issues.pdf \
+            --output docs/slides/html/lfortran-open-issues.pdf \
             --allow-local-files || true
 
       - name: Upload build artifact

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fortran Standard Specifications
 
-This repository contains specifications for LFortran Standard and Lazy Fortran, plus historic ANTLR4 grammars for Fortran language standards from 1957 to 2023.
+This repository contains specifications for LFortran Standard and LFortran Infer mode, plus historic ANTLR4 grammars for Fortran language standards from 1957 to 2023.
 
 ## Standards Hierarchy
 
@@ -14,9 +14,10 @@ LFortran Standard (--std=lf)
     |   - Default real = 8 bytes, integer = 4 bytes
     |   - Default intent(in)
     |   - dp predefined
+    |   - J3 Generics (TEMPLATE, REQUIREMENT, INSTANTIATE)
     |
     v
-Lazy Fortran / LFortran Infer Mode (--infer)
+LFortran Infer Mode (--infer)
         - Adds type inference at global scope
         - Adds automatic array reallocation
         - Adds global scope (bare statements)
@@ -28,8 +29,8 @@ Lazy Fortran / LFortran Infer Mode (--infer)
 | Document | Description |
 |----------|-------------|
 | [LFortran Standard](docs/lfortran-standard.md) | Stricter Fortran 2023 dialect with sensible defaults |
-| [Lazy Fortran Standard](docs/lazy-fortran-standard.md) | Extends LFortran with type inference and modern features |
-| [Design Document](docs/lazyfortran2025-design.md) | Detailed feature descriptions and examples |
+| [LFortran Infer](docs/lfortran-infer.md) | Extends LFortran with type inference and infer mode features |
+| [Design Document](docs/lfortran-design.md) | Detailed feature descriptions and examples |
 | [Design Rationale](docs/design-rationale.md) | Explains key design decisions and trade-offs |
 
 ## Historic ANTLR4 Grammars
@@ -40,7 +41,7 @@ The `grammars/` directory contains ANTLR4 grammars for historic Fortran versions
 - Educational purposes and historical research
 - Testing and validation against the ISO standards
 
-**Note:** LFortran Standard and Lazy Fortran are NOT defined by ANTLR grammars. They are prose specifications implemented directly in the [LFortran compiler](https://lfortran.org), which uses its own bison-based parser.
+**Note:** LFortran Standard and LFortran Infer are NOT defined by ANTLR grammars. They are prose specifications implemented directly in the [LFortran compiler](https://lfortran.org), which uses its own bison-based parser.
 
 ### Grammar Inheritance Chain
 
@@ -74,8 +75,8 @@ FORTRAN IV (1962) is not implemented as a separate grammar; its functionality is
 standard/
 ├── docs/               # Specifications and documentation
 │   ├── lfortran-standard.md      # LFortran Standard spec
-│   ├── lazy-fortran-standard.md  # Lazy Fortran spec
-│   ├── lazyfortran2025-design.md # Design rationale
+│   ├── lfortran-infer.md         # LFortran Infer spec
+│   ├── lfortran-design.md        # Design rationale
 │   └── fortran_*_audit.md        # Grammar audit documents
 ├── grammars/           # Historic ANTLR4 grammar files (.g4)
 ├── tests/              # Test suites grouped by standard
@@ -205,7 +206,7 @@ The project includes a growing test suite:
 
 ## Related Projects
 
-- [LFortran Compiler](https://lfortran.org) - Implementation target for LFortran Standard and Lazy Fortran
+- [LFortran Compiler](https://lfortran.org) - Implementation target for LFortran Standard and LFortran Infer
 - [LFortran GitHub](https://github.com/lfortran/lfortran) - Source code for LFortran
 
 ## Contact

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -1,6 +1,6 @@
 # Design Rationale
 
-This document explains the design decisions behind LFortran Standard and Lazy Fortran, summarizing discussions and providing rationale for key choices.
+This document explains the design decisions behind LFortran Standard and LFortran Infer mode, summarizing discussions and providing rationale for key choices.
 
 ---
 
@@ -101,7 +101,7 @@ This approach causes:
 
 ### Solution: Explicit instantiation
 
-Lazy Fortran requires explicit template instantiation:
+LFortran requires explicit template instantiation:
 
 ```fortran
 template add_t(T)
@@ -141,7 +141,7 @@ Languages like Python infer types everywhere, which creates problems:
 
 ### Solution: Opt-in type inference
 
-Lazy Fortran restricts type inference to:
+LFortran Infer restricts type inference to:
 
 1. **Infer mode only** (`--infer` flag or REPL)
 2. **Global scope only** (not inside procedures)
@@ -172,7 +172,7 @@ Some languages force a choice:
 
 ### Solution: Both dispatch mechanisms
 
-Lazy Fortran provides both:
+LFortran provides both:
 
 | Syntax | Dispatch | Use case |
 |--------|----------|----------|
@@ -212,7 +212,7 @@ This causes security vulnerabilities and subtle bugs.
 
 ### Solution: Rust-like overflow behavior
 
-Lazy Fortran unsigned integers do not wrap by default:
+LFortran unsigned integers do not wrap by default:
 
 ```fortran
 integer, unsigned :: u = 0
@@ -241,7 +241,7 @@ a .lt. b     ! User-defined operator
 
 ### Solution: Spacing rules
 
-Lazy Fortran disambiguates by requiring spaces around user-defined operators:
+LFortran disambiguates by requiring spaces around user-defined operators:
 
 ```fortran
 a .op. b     ! User-defined operator (spaces required)
@@ -266,6 +266,6 @@ The standardizer enforces this rule and rejects ambiguous code at compile time.
 ## References
 
 - [LFortran Standard](lfortran-standard.md)
-- [Lazy Fortran Standard](lazy-fortran-standard.md)
+- [LFortran Infer](lfortran-infer.md)
 - [LFortran Compiler](https://lfortran.org)
 - [ISO/IEC 1539-1:2023](https://www.iso.org/standard/82170.html) - Fortran 2023

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Lazy Fortran 2025 Design</title>
+  <title>LFortran Design</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     :root {
@@ -275,7 +275,7 @@
   <div class="shell">
     <header>
       <h1>Fortran Standard Specifications</h1>
-      <p>LFortran Standard and Lazy Fortran specifications, plus historic ANTLR4 grammars.</p>
+      <p>LFortran Standard and LFortran Infer specifications, plus historic ANTLR4 grammars.</p>
       <p>Rendered from the Markdown sources in this repository.</p>
       <div class="badge">
         <span class="dot"></span>
@@ -288,7 +288,7 @@
         <strong>GitHub</strong>
         <span class="pill">lazy-fortran/standard</span>
       </a>
-      <a href="lazyfortran2025-design.md">
+      <a href="lfortran-design.md">
         <strong>Design Spec</strong>
         <span class="pill">LF-0001</span>
       </a>
@@ -302,7 +302,7 @@
       <div class="status-bar">
         <div>
           Source:
-          <code>docs/lazyfortran2025-design.md</code>
+          <code>docs/lfortran-design.md</code>
         </div>
         <div>
           Site:
@@ -311,12 +311,12 @@
       </div>
 
       <article id="content" class="loading">
-        Loading Lazy Fortran 2025 design document...
+        Loading LFortran design document...
       </article>
     </main>
 
     <footer>
-      Built from the Lazy Fortran documentation repository.
+      Built from the LFortran documentation repository.
     </footer>
   </div>
 
@@ -324,7 +324,7 @@
   <script>
     (function () {
       const target = document.getElementById("content");
-      const sourcePath = "lazyfortran2025-design.md";
+      const sourcePath = "lfortran-design.md";
 
       async function loadDesignDoc() {
         try {
@@ -343,7 +343,7 @@
             "Failed to load the design document from <code>" +
             sourcePath +
             "</code>. View the raw Markdown " +
-            '<a href="lazyfortran2025-design.md">directly</a>.';
+            '<a href="lfortran-design.md">directly</a>.';
         }
       }
 

--- a/docs/lfortran-design.md
+++ b/docs/lfortran-design.md
@@ -1,20 +1,20 @@
-# Lazy Fortran 2025
+# LFortran Design Document
 
 **Status:** Draft
 **Base standard:** Fortran 2023 (ISO/IEC 1539-1:2023)
 
 > **See also:** For normative specifications, refer to:
 > - [LFortran Standard](lfortran-standard.md) - Stricter Fortran 2023 dialect
-> - [Lazy Fortran Standard](lazy-fortran-standard.md) - Type inference and modern features
+> - [LFortran Infer](lfortran-infer.md) - Type inference and infer mode features
 > - [Design Rationale](design-rationale.md) - Explains key design decisions
 
 ---
 
 ## Summary
 
-Lazy Fortran 2025 extends Fortran 2023 with strongly typed generics/traits, sensible defaults, and modern syntax. The goal is reduced boilerplate while maintaining compatibility with standard Fortran compilers through a source-to-source standardizer.
+LFortran extends Fortran 2023 with J3 Generics, strongly typed traits, sensible defaults, and modern syntax. The goal is reduced boilerplate while maintaining compatibility with standard Fortran compilers through a source-to-source standardizer.
 
-All standard Fortran 2023 programs remain valid Lazy Fortran programs.
+All standard Fortran 2023 programs remain valid LFortran programs.
 
 ### Design Principles
 
@@ -48,7 +48,7 @@ All features are **single-pass (local or module-local analysis only)**:
 
 ## Dot Notation for Member Access
 
-**RESOLVED:** Lazy Fortran supports both `.` (dot) and `%` for derived type member access:
+**RESOLVED:** LFortran supports both `.` (dot) and `%` for derived type member access:
 
 ```fortran
 ! Both syntaxes are valid
@@ -66,7 +66,7 @@ The standardizer converts dot notation to `%` for standard Fortran output.
 
 ### Disambiguation from User-Defined Operators
 
-User-defined operators like `.add.` could conflict with member access. Lazy Fortran uses spacing rules:
+User-defined operators like `.add.` could conflict with member access. LFortran uses spacing rules:
 
 ```fortran
 a .op. b     ! User-defined operator (spaces required)
@@ -156,7 +156,7 @@ Expression types follow standard Fortran type promotion rules for numeric intrin
 
 ### Interaction with implicit none
 
-`implicit none` is the default in Lazy Fortran. In standard mode, undeclared names are errors. In infer mode, undeclared intrinsic-typed variables are inferred; derived types still require explicit declaration.
+`implicit none` is the default in LFortran. In standard mode, undeclared names are errors. In infer mode, undeclared intrinsic-typed variables are inferred; derived types still require explicit declaration.
 
 ### Resolved Issues (Infer Mode)
 
@@ -169,7 +169,7 @@ Expression types follow standard Fortran type promotion rules for numeric intrin
 
 ## Default Precision
 
-**RESOLVED:** Lazy Fortran uses different defaults for reals and integers:
+**RESOLVED:** LFortran uses different defaults for reals and integers:
 
 - **Reals:** 8 bytes (64-bit) - precision matters for scientific computing
 - **Integers:** 4 bytes (32-bit) - like Rust/C/Java, better performance
@@ -181,7 +181,7 @@ This applies to:
 3. **Unqualified declarations** - `real :: x` means `real(8) :: x`; `integer :: n` stays default
 
 ```fortran
-! Lazy Fortran
+! LFortran
 x = 1.0              ! real(8)
 y = 1.0e3            ! real(8)
 n = 42               ! integer (4 bytes)
@@ -211,7 +211,7 @@ real(4) :: single_precision
 The standardizer generates explicit kind specifiers for reals:
 
 ```fortran
-! Input (Lazy Fortran)
+! Input (LFortran)
 x = 1.0
 n = 42
 
@@ -226,7 +226,7 @@ n = 42
 
 ## Unsigned Integers
 
-**NEW:** Lazy Fortran adds an `unsigned` attribute for integers:
+**NEW:** LFortran adds an `unsigned` attribute for integers:
 
 ```fortran
 integer, unsigned :: count          ! 4-byte unsigned (0 to 4,294,967,295)
@@ -298,7 +298,7 @@ The standardizer emits unsigned operations using appropriate intrinsics or compi
 
 ## Default Intent
 
-Both LFortran Standard and Lazy Fortran use `intent(in)` as the default for all procedure arguments. This is stricter than ISO Fortran, which has no default intent (arguments without explicit intent can be read and modified). Lazy Fortran inherits this behavior from LFortran Standard.
+Both LFortran Standard and LFortran Infer use `intent(in)` as the default for all procedure arguments. This is stricter than ISO Fortran, which has no default intent (arguments without explicit intent can be read and modified). LFortran Infer inherits this behavior from LFortran Standard.
 
 To modify an argument, explicitly specify `intent(inout)` or `intent(out)`:
 
@@ -339,7 +339,7 @@ end subroutine
 
 ## Generic Programming
 
-**RESOLVED:** Lazy Fortran uses **strongly typed generics/traits** with explicit instantiation. No implicit monomorphization or whole-program type inference.
+**RESOLVED:** LFortran uses **strongly typed generics/traits** with explicit instantiation. No implicit monomorphization or whole-program type inference.
 
 Two complementary approaches are available:
 
@@ -348,7 +348,7 @@ Two complementary approaches are available:
 
 ### Key Design Decision: No Implicit Monomorphization
 
-Unlike C++ templates or Julia, Lazy Fortran does NOT automatically generate specializations from call sites. All generic instantiation is explicit:
+Unlike C++ templates or Julia, LFortran does NOT automatically generate specializations from call sites. All generic instantiation is explicit:
 
 ```fortran
 ! WRONG (would require whole-program analysis):
@@ -487,13 +487,13 @@ instantiate min_value{integer}, only: min_int => min_value
 - Uses **curly braces `{T}`** for generic type parameters: `function sum{INumeric :: T}(x)`
 - Type constraints precede parameter name: `{ITrait :: T}` or inline `{integer | real :: T}`
 
-Lazy Fortran adopts the traits syntax with curly braces for generic parameters.
+LFortran adopts the traits syntax with curly braces for generic parameters.
 
 ---
 
 ## Standardizer
 
-The standardizer transforms Lazy Fortran (.lf) to standard Fortran (.f90).
+The standardizer transforms LFortran code (.lf) to standard Fortran (.f90).
 
 ### Transformations
 
@@ -602,7 +602,7 @@ end program main
 
 ## Compiler Modes
 
-Lazy Fortran 2025 extends the [LFortran compiler](https://lfortran.org). LFortran provides three compilation modes:
+LFortran extends the [LFortran compiler](https://lfortran.org). LFortran provides three compilation modes:
 
 ### Mode Summary
 
@@ -666,7 +666,7 @@ print *, x + sum(y)
 - Default `intent(in)` for arguments
 - `dp` predefined for double precision
 
-**Additional Lazy Fortran 2025 features (all modes):**
+**Additional LFortran features (all modes):**
 - Dot notation `a.b` for member access
 
 **Important restrictions:**
@@ -690,7 +690,7 @@ Each compiler mode can be combined with build modes:
 
 ## LFortran Implementation
 
-Lazy Fortran 2025 features are implemented in [LFortran](https://github.com/lfortran/lfortran), a modern LLVM-based Fortran compiler.
+LFortran features are implemented in [LFortran](https://github.com/lfortran/lfortran), a modern LLVM-based Fortran compiler.
 
 ### Current Implementation Status
 
@@ -774,7 +774,7 @@ The global scope extension allows statements, declarations, and expressions at t
 
 - ISO/IEC 1539-1:2023 (Fortran 2023)
 - [LFortran Standard](lfortran-standard.md) - Stricter Fortran 2023 dialect
-- [Lazy Fortran Standard](lazy-fortran-standard.md) - Type inference and modern features
+- [LFortran Infer](lfortran-infer.md) - Type inference and infer mode features
 - [Design Rationale](design-rationale.md) - Rationale for key design decisions
 - [LFortran Compiler](https://lfortran.org) - Implementation target
 - [LFortran Design Document](https://docs.lfortran.org/design/) - Architecture details

--- a/docs/lfortran-infer.md
+++ b/docs/lfortran-infer.md
@@ -1,4 +1,4 @@
-# Lazy Fortran Standard
+# LFortran Infer Mode
 
 **Status:** Draft
 **Derived from:** [LFortran Standard](lfortran-standard.md)
@@ -8,9 +8,9 @@
 
 ## Overview
 
-The Lazy Fortran Standard extends the [LFortran Standard](lfortran-standard.md) with features for rapid prototyping and interactive use. It is enabled with the `--infer` flag or implicitly in the LFortran interactive REPL.
+LFortran Infer mode extends the [LFortran Standard](lfortran-standard.md) with features for rapid prototyping and interactive use. It is enabled with the `--infer` flag or implicitly in the LFortran interactive REPL.
 
-Lazy Fortran maintains all the safety guarantees of LFortran Standard while adding:
+LFortran Infer maintains all the safety guarantees of LFortran Standard while adding:
 
 1. **Type inference** at global scope (intrinsic types only)
 2. **Global scope** for bare statements without `program`/`end program`
@@ -21,7 +21,7 @@ Lazy Fortran maintains all the safety guarantees of LFortran Standard while addi
 
 ## Feature Comparison
 
-| Feature | LFortran Standard | Lazy Fortran (Infer) |
+| Feature | LFortran Standard | LFortran Infer |
 |---------|-------------------|----------------------|
 | Default real | 8 bytes | 8 bytes |
 | Default integer | 4 bytes | 4 bytes |
@@ -75,7 +75,7 @@ Expression types follow standard Fortran type promotion rules for numeric intrin
 Bare statements are allowed without `program`/`end program` wrapper:
 
 ```fortran
-! Valid Lazy Fortran file
+! Valid LFortran Infer file
 x = 5.0
 y = 3.0
 print *, x + y
@@ -112,7 +112,7 @@ fixed = [4.0, 5.0]        ! ERROR: shape mismatch
 
 ## Standardizer
 
-The standardizer transforms Lazy Fortran to ISO Fortran 2023.
+The standardizer transforms LFortran Infer code to ISO Fortran 2023.
 
 ### Output Structure Rules
 
@@ -194,7 +194,7 @@ a.member     ! Member access (no spaces)
 
 ## Unsigned Integers
 
-Lazy Fortran adds an `unsigned` attribute for integers:
+LFortran Infer adds an `unsigned` attribute for integers:
 
 ```fortran
 integer, unsigned :: count          ! 4-byte unsigned (0 to 4,294,967,295)
@@ -254,7 +254,7 @@ wrap_mul(a, b)              ! a * b with wraparound
 
 ## Generic Programming
 
-Lazy Fortran uses **strongly typed generics/traits** with explicit instantiation. No implicit monomorphization or whole-program type inference.
+LFortran uses **strongly typed generics/traits** with explicit instantiation. No implicit monomorphization or whole-program type inference.
 
 ### Design Principles
 
@@ -356,7 +356,7 @@ instantiate min_value{integer}, only: min_int => min_value
 
 ### Syntax Clarification
 
-Lazy Fortran uses **curly braces `{}`** for generic type parameters (following the Traits-for-Fortran proposal):
+LFortran uses **curly braces `{}`** for generic type parameters (following the Traits-for-Fortran proposal):
 
 | Construct | Syntax | Example |
 |-----------|--------|---------|
@@ -364,7 +364,7 @@ Lazy Fortran uses **curly braces `{}`** for generic type parameters (following t
 | Inline template call | `call proc{type}(args)` | `call swap{integer}(a, b)` |
 | Trait-bounded generic | `func{Trait :: T}(args)` | `min_value{IComparable :: T}(a, b)` |
 
-**Note:** The J3 TEMPLATE proposal uses `^()` syntax for inline instantiation (`call sub^(integer)(x)`). Lazy Fortran's `{}` syntax is an alternative that avoids ambiguity with exponentiation operators and aligns with the Traits-for-Fortran proposal.
+**Note:** The J3 TEMPLATE proposal uses `^()` syntax for inline instantiation (`call sub^(integer)(x)`). LFortran's `{}` syntax is an alternative that avoids ambiguity with exponentiation operators and aligns with the Traits-for-Fortran proposal.
 
 ### Why No Implicit Monomorphization
 

--- a/docs/lfortran-standard.md
+++ b/docs/lfortran-standard.md
@@ -200,7 +200,7 @@ Use `--std=f23` flag to compile in ISO Fortran 2023 mode for compatibility with 
 
 ## Related Standards
 
-- **[Lazy Fortran Standard](lazy-fortran-standard.md)** - Extends LFortran Standard with type inference and modern features
+- **[LFortran Infer](lfortran-infer.md)** - Extends LFortran Standard with type inference and infer mode features
 - **ISO/IEC 1539-1:2023** - Base standard
 
 ---

--- a/docs/lfortran_infer_audit.md
+++ b/docs/lfortran_infer_audit.md
@@ -365,9 +365,9 @@ arr = [1,2,3]  ! Inferred as integer(:) allocatable
 
 This is a **semantic analysis feature**, not grammar. Current grammar already supports parsing these as bare statements; semantic phase will add inference.
 
-### Lazy Fortran Standard
+### LFortran Infer Mode
 
-The planned Lazy Fortran Standard will add:
+The LFortran Infer mode adds:
 - Type inference at global scope (intrinsic types only)
 - Automatic array reallocation on assignment
 - Enhanced standardizer for outputting ISO Fortran
@@ -391,7 +391,7 @@ Grammar is already prepared for these features.
 
 ## REFERENCES
 
-- **Issue #708:** Create Lazy Fortran Standard specification (Infer Mode)
+- **Issue #708:** Create LFortran Infer specification (Infer Mode)
 - **Issue #707:** Create LFortran Standard specification
 - **LFortran Compiler:** https://lfortran.org (`--infer` flag)
 - **docs/lfortran_audit.md:** LFortran base (J3 Generics) audit
@@ -399,4 +399,4 @@ Grammar is already prepared for these features.
 ---
 
 **Last Updated:** 2025-12-30
-**Next Review:** After Lazy Fortran Standard specification release
+**Next Review:** After LFortran Infer specification release

--- a/scripts/setup_validation.sh
+++ b/scripts/setup_validation.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-echo "=== Lazy Fortran Standard - Validation Infrastructure Setup ==="
+echo "=== LFortran Standard - Validation Infrastructure Setup ==="
 echo "Repository root: $REPO_ROOT"
 echo ""
 

--- a/scripts/validate_all.sh
+++ b/scripts/validate_all.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-echo "=== Lazy Fortran Standard - Complete Validation Pipeline ==="
+echo "=== LFortran Standard - Complete Validation Pipeline ==="
 echo "Repository root: $REPO_ROOT"
 echo ""
 

--- a/tests/Fortran90/test_fortran_90_comprehensive.py
+++ b/tests/Fortran90/test_fortran_90_comprehensive.py
@@ -20,7 +20,7 @@ Test Coverage Philosophy:
 This suite validates that F90 grammar correctly recognizes all major
 language innovations while maintaining seamless integration with
 inherited SharedCore constructs. It serves as the foundation validation
-for the entire modern Fortran chain (F90 → F95 → F2003 → ... → LazyFortran).
+for the entire modern Fortran chain (F90 → F95 → F2003 → ... → LFortran).
 """
 
 import sys

--- a/tests/fixture_utils.py
+++ b/tests/fixture_utils.py
@@ -4,7 +4,7 @@
 Fixtures live under tests/fixtures/<Standard>/[...] with file extensions:
 - .f   : fixed-form Fortran (historical standards)
 - .f90 : free-form Fortran (Fortran 90+)
-- .lf  : Lazy Fortran source (future)
+- .lf  : LFortran source (future)
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Rename `lazy-fortran-standard.md` to `lfortran-infer.md`
- Rename `lazyfortran2025-design.md` to `lfortran-design.md`
- Replace all "Lazy Fortran" references with "LFortran" or "LFortran Infer"
- Update cross-references in all documentation files
- Update scripts, tests, and workflow files

## Terminology Hierarchy

The terminology is now clear and consistent:
- **LFortran Standard**: F2023 + J3 Generics (strict mode, `--std=lf`)
- **LFortran Infer**: LFortran + global scope/type inference (`--infer`)

## Files Changed
- Renamed: `docs/lazy-fortran-standard.md` → `docs/lfortran-infer.md`
- Renamed: `docs/lazyfortran2025-design.md` → `docs/lfortran-design.md`
- Updated: README.md, design-rationale.md, lfortran-standard.md, index.html
- Updated: lfortran_infer_audit.md, scripts, tests, workflow

## Notes
GitHub org/repo URLs and LICENSE remain unchanged as they refer to the actual repository infrastructure.

## Test plan
- [ ] CI passes
- [ ] Documentation links work correctly