### PR TITLE
Add LFortran infer/walrus grammar support and fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ LFortran Standard (--std=lf)
     |
     v
 LFortran Infer (--infer)
-    - Type inference at global scope
+    - Type inference (`:=` and first assignment with `--infer`)
     - Automatic array reallocation
     - Interactive REPL mode
 ```
@@ -42,7 +42,7 @@ All grammars are **complete and tested**.
 | Fortran 2018 | Complete | Yes | Teams, events, atomics |
 | Fortran 2023 | Complete | Yes | Conditional expressions, TYPEOF/CLASSOF |
 | LFortran | Complete | Yes | J3 Generics (TEMPLATE, REQUIREMENT, INSTANTIATE) |
-| LFortran Infer | Complete | Yes | Type inference, global scope |
+| LFortran Infer | Complete | Yes | Type inference (`:=`, `--infer`), global scope |
 
 ## Quick Start
 

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -128,7 +128,7 @@ Benefits:
 
 ---
 
-## Why Type Inference is Infer Mode Only
+## Why Type Inference Is Opt-In
 
 ### Problem with mandatory type inference
 
@@ -139,25 +139,23 @@ Languages like Python infer types everywhere, which creates problems:
 - IDE support is weaker without explicit types
 - Runtime type errors instead of compile-time
 
-### Solution: Opt-in type inference
+### Solution: opt-in inference forms
 
-LFortran Infer restricts type inference to:
+LFortran provides two explicit inference paths:
 
-1. **Infer mode only** (`--infer` flag or REPL)
-2. **Global scope only** (not inside procedures)
-3. **Intrinsic types only** (not derived types)
+1. `x := expr` (walrus) always declares a new variable
+2. `x = expr` first-assignment declaration when `--infer` is enabled
 
 ```fortran
-! Infer mode - types inferred at global scope
-x = 42             ! integer
-y = 3.14           ! real(8)
+! Explicit inference form
+x := 42
 
-! But NOT for derived types
-type(particle_t) :: p   ! Required explicit declaration
-p = particle_t(x=1.0)   ! OK after declaration
+! REPL / notebook-friendly inference form
+! (with --infer)
+y = 3.14
 ```
 
-This provides the convenience of type inference for prototyping while maintaining explicit typing for production code.
+This keeps production code explicit by default while allowing concise, inferred declarations where desired.
 
 ---
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -19,7 +19,7 @@ All grammars are **complete and tested**. Each implements the full syntax of its
 | Fortran 2018 | Complete | Yes | Teams, events, atomics |
 | Fortran 2023 | Complete | Yes | Conditional expressions, TYPEOF/CLASSOF |
 | LFortran | Complete | Yes | J3 Generics (TEMPLATE, REQUIREMENT, INSTANTIATE) |
-| LFortran Infer | Complete | Yes | Type inference, global scope, auto realloc |
+| LFortran Infer | Complete | Yes | Type inference (`:=`, `--infer`), global scope, auto realloc |
 
 ## Semantic Validation
 

--- a/docs/lfortran-design.md
+++ b/docs/lfortran-design.md
@@ -29,7 +29,7 @@ All features are **single-pass** (local or module-local analysis only):
 - Default `implicit none` injection
 - Default precision (real=8 bytes, integer=4 bytes)
 - Template/requirement instantiation
-- Type inference (infer mode only, intrinsic types only)
+- Type inference (`:=` syntax and `--infer` first assignment)
 
 **Explicitly NOT supported** (would require whole-program analysis):
 - Implicit monomorphization from call sites

--- a/docs/lfortran-infer.md
+++ b/docs/lfortran-infer.md
@@ -1,115 +1,86 @@
 # LFortran Infer Mode
 
-**Status:** Draft
-**Derived from:** [LFortran Standard](lfortran-standard.md)
+**Status:** Draft  
+**Derived from:** [LFortran Standard](lfortran-standard.md)  
 **Compiler flag:** `--infer`
 
 ## Overview
 
-LFortran Infer mode extends LFortran Standard with features for rapid prototyping and interactive use. Enabled with `--infer` flag or implicitly in the REPL.
+LFortran Infer mode extends LFortran Standard for interactive and rapid-prototyping workflows. It keeps standard Fortran syntax and adds inference-oriented behavior.
 
-## Feature Comparison
+## Inference Forms
 
-| Feature | LFortran Standard | LFortran Infer |
-|---------|-------------------|----------------|
-| Default real | 8 bytes | 8 bytes |
-| Default integer | 4 bytes | 4 bytes |
-| `dp` predefined | YES | YES |
-| Bounds checking | ON | ON |
-| Default intent | `intent(in)` | `intent(in)` |
-| Implicit typing | OFF (error) | **Type inference** |
-| Array realloc | OFF (error) | **ON** |
-| Global scope | No | **YES** |
+### 1. Walrus declaration (`:=`)
 
-## Type Inference
-
-### First Assignment Rule
-
-Variables at global scope get their type from the first value assigned:
+`:=` declares a new variable and infers its type from the right-hand side.
 
 ```fortran
-x = 42             ! integer (4 bytes)
-y = 3.14           ! real(8)
-z = (1.0, 2.0)     ! complex(8)
-flag = .true.      ! logical
-s = "hello"        ! character(:), allocatable
+x := 42
+coeffs := [1.0d0, 0.5d0]
+p := point_t(1.0, 2.0)
 ```
 
-### Restrictions
+Rules:
+- `:=` declares, it does not assign to an existing symbol.
+- Redeclaring in the same scope is an error.
+- Inner scopes may shadow outer variables.
+- Walrus syntax is an LFortran extension.
 
-- **Intrinsic types only** - integer, real, complex, logical, character
-- **Derived types require explicit declaration**
-- **Global scope only** - Inside procedures, standard declaration rules apply
-- **Compile error on ambiguity**
+### 2. First-assignment inference (`=` with `--infer`)
+
+With `--infer`, a first plain assignment to an undeclared name declares it.
+
+```fortran
+x = 42
+y = 3.14
+```
+
+This is intended for scripts, REPL sessions, and notebooks.
+
+## Inference Coverage
+
+Current LFortran behavior includes inference for:
+- Intrinsic scalars (`integer`, `real`, `complex`, `logical`, `character`)
+- Arrays inferred from RHS expressions
+- Derived types inferred from structure constructors or typed expressions
+
+The inferred kind follows the RHS expression kind.
 
 ## Global Scope
 
-Bare statements allowed without `program`/`end program`:
+Infer mode allows bare statements and declarations without a `program ... end program` wrapper:
 
 ```fortran
-x = 5.0
-y = 3.0
-print *, x + y
+x := 5
+print *, x
 ```
 
 ## Automatic Array Reallocation
 
-Allocatable arrays reallocate on shape mismatch:
+Allocatable arrays reallocate on shape mismatch in infer mode:
 
 ```fortran
 real, allocatable :: arr(:)
-arr = [1.0, 2.0, 3.0]   ! size 3
-arr = [7.0, 8.0]        ! reallocates to size 2
+arr = [1.0, 2.0, 3.0]
+arr = [7.0, 8.0]
 ```
 
-Equivalent to `--realloc-lhs-arrays` flag.
-
-## Dot Notation
-
-Both `.` and `%` supported for member access:
-
-```fortran
-particle.x = 1.0           ! Modern style
-particle%x = 1.0           ! Standard Fortran
-```
-
-User-defined operators require spaces: `a .op. b`
-
-## Unsigned Integers
-
-```fortran
-integer, unsigned :: count          ! 4-byte unsigned
-integer(8), unsigned :: big_count   ! 8-byte unsigned
-```
-
-No implicit mixing of signed/unsigned. Explicit conversion required:
-```fortran
-u + uint(i)                 ! OK
-i + int(u)                  ! OK
-```
-
-Overflow behavior:
-- Debug mode: Runtime error
-- `--fast` mode: Wraparound
-- Explicit: `wrap_add`, `wrap_sub`, `wrap_mul`
-
-## Standardizer
-
-Transforms LFortran Infer code to ISO Fortran 2023:
-
-| Input Structure | Output |
-|-----------------|--------|
-| Bare statements only | `program main ... end program` |
-| Bare statements + procedures | `program main ... contains ... end program` |
-| Only procedures | `module <filename> ... end module` |
+Equivalent to enabling `--realloc-lhs-arrays` behavior.
 
 ## Compiler Modes
 
-| Mode | Flag | Type Inference | Array Realloc |
-|------|------|----------------|---------------|
-| **Strict** | `--std=lf` (default) | OFF | OFF |
-| **Standard** | `--std=f23` | OFF | ON |
-| **Infer** | `--infer` | ON | ON |
+| Mode | Flag | `:=` | First `=` inference | Array Realloc |
+|------|------|------|----------------------|---------------|
+| **Strict** | `--std=lf` (default) | YES (extension) | OFF | OFF |
+| **Standard** | `--std=f23` | YES (extension) | OFF | ON |
+| **Infer** | `--infer` | YES | ON | ON |
+
+## Standardizer
+
+The standardizer can lower infer-mode source to explicit standard Fortran by:
+- Wrapping bare statements in program units
+- Emitting explicit declarations for inferred symbols
+- Preserving explicit declaration semantics
 
 ## References
 

--- a/grammars/src/LFortranInferLexer.g4
+++ b/grammars/src/LFortranInferLexer.g4
@@ -27,5 +27,6 @@ import LFortranLexer;
 // All tokens are inherited from LFortranLexer (which includes):
 //   - Fortran 2023 tokens (from Fortran2023Lexer)
 //   - J3 Generics tokens (TEMPLATE, REQUIREMENT, REQUIRE, INSTANTIATE, DEFERRED)
-//   - No new tokens required for infer mode (handled in parser)
+//   - Type inference token (COLON_EQUAL for :=)
+//   - No additional infer-specific tokens required here
 // ============================================================================

--- a/grammars/src/LFortranInferParser.g4
+++ b/grammars/src/LFortranInferParser.g4
@@ -9,6 +9,7 @@
 //   - Bare expressions at top level (REPL mode)
 //   - Bare declarations at top level
 //   - Bare use/implicit statements at top level
+//   - Type inference syntax inherited from LFortran (:= walrus assignments)
 //
 // This enables script-style Fortran programming and interactive use.
 //
@@ -50,6 +51,6 @@ script_unit
     | NEWLINE* use_stmt NEWLINE*             // Bare use statement (global scope)
     | NEWLINE* implicit_stmt NEWLINE*        // Bare implicit statement (global scope)
     | NEWLINE* declaration_construct NEWLINE* // Bare declaration (global scope)
-    | NEWLINE* executable_construct NEWLINE* // Bare statement (global scope)
+    | NEWLINE* executable_construct_f2018 NEWLINE* // Bare statement (global scope)
     | NEWLINE* expr_f2003 NEWLINE*           // Bare expression (global scope / REPL)
     ;

--- a/grammars/src/LFortranLexer.g4
+++ b/grammars/src/LFortranLexer.g4
@@ -8,7 +8,10 @@
 //    - TEMPLATE, REQUIREMENT, REQUIRE, INSTANTIATE keywords
 //    - DEFERRED keyword for type parameters
 //
-// 2. Global scope support:
+// 2. Type inference syntax:
+//    - := walrus declaration operator
+//
+// 3. Global scope support:
 //    - Bare statements at top level (handled in parser)
 //
 // Reference: LFortran compiler (https://lfortran.org)
@@ -80,4 +83,13 @@ RBRACE
 // Caret for inline instantiation (J3 r4 alternative)
 CARET
     : '^'
+    ;
+
+// ============================================================================
+// TYPE INFERENCE TOKENS
+// ============================================================================
+// Walrus declaration syntax used by LFortran type inference:
+//   x := expr
+COLON_EQUAL
+    : ':='
     ;

--- a/tests/LFortran/fixtures/infer_walrus_01.f90
+++ b/tests/LFortran/fixtures/infer_walrus_01.f90
@@ -1,0 +1,14 @@
+program infer_walrus_01
+    implicit none
+    call test()
+contains
+    subroutine test()
+        x := 42
+        y := 3.14d0
+        z := (1.0d0, 2.0d0)
+        flag := .true.
+        s := "hello"
+        x = 100
+        print *, x, y, z, flag, s
+    end subroutine
+end program infer_walrus_01

--- a/tests/LFortran/fixtures/infer_walrus_02.f90
+++ b/tests/LFortran/fixtures/infer_walrus_02.f90
@@ -1,0 +1,6 @@
+program infer_walrus_02
+    implicit none
+    x := 10
+    y := 2.5d0
+    print *, x + int(y)
+end program infer_walrus_02

--- a/tests/LFortran/fixtures/infer_walrus_03.f90
+++ b/tests/LFortran/fixtures/infer_walrus_03.f90
@@ -1,0 +1,8 @@
+program infer_walrus_03
+    implicit none
+    x := 5
+    y := 10
+    x = x + y
+    y = x * 2
+    print *, x, y
+end program infer_walrus_03

--- a/tests/LFortran/fixtures/infer_walrus_array_01.f90
+++ b/tests/LFortran/fixtures/infer_walrus_array_01.f90
@@ -1,0 +1,5 @@
+program infer_walrus_array_01
+    implicit none
+    x := [1, 2, 3]
+    print *, size(x), x(1), x(2), x(3)
+end program infer_walrus_array_01

--- a/tests/LFortran/fixtures/infer_walrus_array_02.f90
+++ b/tests/LFortran/fixtures/infer_walrus_array_02.f90
@@ -1,0 +1,5 @@
+program infer_walrus_array_02
+    implicit none
+    x := reshape([1, 2, 3, 4, 5, 6], [2, 3])
+    print *, size(x, 1), size(x, 2), x(1, 1), x(2, 1), x(1, 2)
+end program infer_walrus_array_02

--- a/tests/LFortran/fixtures/infer_walrus_array_03.f90
+++ b/tests/LFortran/fixtures/infer_walrus_array_03.f90
@@ -1,0 +1,6 @@
+program infer_walrus_array_03
+    implicit none
+    x = [10, 20, 30]
+    y = [1.0d0, 2.0d0, 3.0d0]
+    print *, x(1), x(3), y(2)
+end program infer_walrus_array_03

--- a/tests/LFortran/fixtures/infer_walrus_error_01.f90
+++ b/tests/LFortran/fixtures/infer_walrus_error_01.f90
@@ -1,0 +1,5 @@
+program infer_walrus_error_01
+    implicit none
+    integer :: x
+    x := 5
+end program infer_walrus_error_01

--- a/tests/LFortran/fixtures/infer_walrus_error_02.f90
+++ b/tests/LFortran/fixtures/infer_walrus_error_02.f90
@@ -1,0 +1,8 @@
+program infer_walrus_error_02
+    implicit none
+    type :: t
+        integer :: n
+    end type
+    type(t) :: obj
+    a := obj
+end program infer_walrus_error_02

--- a/tests/LFortran/fixtures/infer_walrus_redecl_01.f90
+++ b/tests/LFortran/fixtures/infer_walrus_redecl_01.f90
@@ -1,0 +1,5 @@
+program infer_walrus_redecl_01
+    implicit none
+    x := 5
+    x := 10
+end program infer_walrus_redecl_01

--- a/tests/LFortran/fixtures/infer_walrus_shadow_01.f90
+++ b/tests/LFortran/fixtures/infer_walrus_shadow_01.f90
@@ -1,0 +1,9 @@
+program infer_walrus_shadow_01
+    implicit none
+    x := 5
+    block
+        x := "hello"
+        print *, x
+    end block
+    print *, x
+end program infer_walrus_shadow_01

--- a/tests/LFortran/fixtures/infer_walrus_shadow_02.f90
+++ b/tests/LFortran/fixtures/infer_walrus_shadow_02.f90
@@ -1,0 +1,13 @@
+program infer_walrus_shadow_02
+    implicit none
+    x := 10
+    block
+        x := 3.14d0
+        block
+            x := .true.
+            print *, x
+        end block
+        print *, x
+    end block
+    print *, x
+end program infer_walrus_shadow_02

--- a/tests/LFortran/fixtures/infer_walrus_shadow_03.f90
+++ b/tests/LFortran/fixtures/infer_walrus_shadow_03.f90
@@ -1,0 +1,9 @@
+program infer_walrus_shadow_03
+    implicit none
+    x = 42
+    block
+        x = 2.718d0
+        print *, x
+    end block
+    print *, x
+end program infer_walrus_shadow_03

--- a/tests/LFortran/fixtures/infer_walrus_struct_01.f90
+++ b/tests/LFortran/fixtures/infer_walrus_struct_01.f90
@@ -1,0 +1,8 @@
+program infer_walrus_struct_01
+    implicit none
+    type :: point_t
+        real :: x, y
+    end type
+    p := point_t(1.0, 2.0)
+    print *, p%x, p%y
+end program infer_walrus_struct_01

--- a/tests/LFortran/fixtures/infer_walrus_struct_02.f90
+++ b/tests/LFortran/fixtures/infer_walrus_struct_02.f90
@@ -1,0 +1,19 @@
+program infer_walrus_struct_02
+    implicit none
+    type :: pair_t
+        integer :: a, b
+    end type
+    call test()
+contains
+    function make_pair(x, y) result(res)
+        integer, intent(in) :: x, y
+        type(pair_t) :: res
+        res%a = x
+        res%b = y
+    end function make_pair
+
+    subroutine test()
+        q := make_pair(10, 20)
+        print *, q%a, q%b
+    end subroutine test
+end program infer_walrus_struct_02

--- a/tests/LFortran/fixtures/infer_walrus_struct_03.f90
+++ b/tests/LFortran/fixtures/infer_walrus_struct_03.f90
@@ -1,0 +1,8 @@
+program infer_walrus_struct_03
+    implicit none
+    type :: vec_t
+        integer :: x, y, z
+    end type
+    p = vec_t(1, 2, 3)
+    print *, p%x, p%y, p%z
+end program infer_walrus_struct_03

--- a/tests/LFortranInfer/fixtures/infer_first_assignment_01.f90
+++ b/tests/LFortranInfer/fixtures/infer_first_assignment_01.f90
@@ -1,0 +1,7 @@
+x = 42
+y = 3.14
+z = (1.0, 2.0)
+flag = .true.
+s = "hello"
+x = x + 1
+print *, x, y, z, flag, s

--- a/tests/LFortranInfer/fixtures/infer_first_assignment_derived_01.f90
+++ b/tests/LFortranInfer/fixtures/infer_first_assignment_derived_01.f90
@@ -1,0 +1,6 @@
+type :: t
+    integer :: n
+end type
+
+a = t(1)
+print *, a%n

--- a/tests/LFortranInfer/fixtures/infer_walrus_error_shape_01.f90
+++ b/tests/LFortranInfer/fixtures/infer_walrus_error_shape_01.f90
@@ -1,0 +1,3 @@
+integer :: arr(3)
+arr(1) := 99
+print *, arr(1)

--- a/tests/LFortranInfer/fixtures/infer_walrus_global_01.f90
+++ b/tests/LFortranInfer/fixtures/infer_walrus_global_01.f90
@@ -1,0 +1,6 @@
+x := 42
+y := 3.14d0
+z := (1.0d0, 2.0d0)
+flag := .true.
+s := "hello"
+print *, x, y, z, flag, s

--- a/tests/LFortranInfer/fixtures/infer_walrus_global_02.f90
+++ b/tests/LFortranInfer/fixtures/infer_walrus_global_02.f90
@@ -1,0 +1,7 @@
+type :: point_t
+    real :: x, y
+end type
+
+arr := [1, 2, 3]
+p := point_t(1.0, 2.0)
+print *, size(arr), p%x, p%y

--- a/tests/LFortranInfer/fixtures/infer_walrus_shadow_01.f90
+++ b/tests/LFortranInfer/fixtures/infer_walrus_shadow_01.f90
@@ -1,0 +1,6 @@
+x := 5
+block
+    x := "hello"
+    print *, x
+end block
+print *, x


### PR DESCRIPTION
### **User description**
## Summary
- extend LFortran/LFortranInfer grammars for merged J3 generics changes and infer-mode walrus () assignment
- update parser overrides for LFortran name handling, template/instantiate paths, and infer executable construct routing
- add infer/walrus fixture coverage for LFortran and LFortranInfer
- refresh related docs for infer mode and design notes

## Validation
- make LFortran LFortranInfer
- pytest -q tests/LFortran/test_lfortran_grammar.py -q
- pytest -q tests/LFortranInfer/test_lfortran_infer_grammar.py -q
- make test (1821 passed, 917 subtests passed)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add walrus (`:=`) operator support to LFortran and LFortranInfer grammars

- Extend parser overrides for LFortran name handling and executable constructs

- Add comprehensive test fixtures for walrus syntax and type inference

- Update documentation to clarify inference forms and opt-in behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lexer: COLON_EQUAL token"] --> B["Parser: assignment_stmt override"]
  B --> C["Walrus syntax: x := expr"]
  C --> D["Test fixtures: 12 walrus + 3 error cases"]
  E["Parser overrides: lfortran_name, prefix, procedures"] --> F["Robust name handling"]
  F --> D
  G["Documentation updates"] --> H["Clarify inference forms"]
  D --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>LFortranLexer.g4</strong><dd><code>Add COLON_EQUAL token for walrus operator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-da673321b4f2c9d095f8c2531c35ec4e38941953eac6609edcb2333d6c3aae25">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LFortranParser.g4</strong><dd><code>Extend parser with walrus assignment and name overrides</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-1b1e1992092b6fd9c6dad0ef91cce532f7e4c897d9c17dff4349c9153c3790c6">+197/-29</a></td>

</tr>

<tr>
  <td><strong>LFortranInferParser.g4</strong><dd><code>Route executable constructs to F2018 variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-6ca82f719aa3262b2fa93a93a8e30894320e50d5adb85c12b4d32b3fb401cf09">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>LFortranInferLexer.g4</strong><dd><code>Document COLON_EQUAL token inheritance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-6851c7e2bd2f9f18c126a77f1485faed0b1fae2676a357f60e071fe46bfa226b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Clarify type inference forms in overview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design-rationale.md</strong><dd><code>Revise type inference rationale for opt-in forms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-7b73d93a5adf8104516cffa2dd4e122c654d745fd1b376111ed90e526e838de3">+11/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>implementation-notes.md</strong><dd><code>Update inference feature description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-98b6e27dbe8eb6ef31b254532a60f1ccb7efa5eb4f1ee8267fa24b37b69f5f22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lfortran-design.md</strong><dd><code>Update type inference documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-a4c1da5481772d1a2eda9d918e89208ae0c7febfb999a6bea1cf501bdbefea1a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lfortran-infer.md</strong><dd><code>Restructure infer mode docs for walrus and first-assignment</code></dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-eb7a1bd85009aa9cf347bc1aa21b337e9d6e705ecee0f6408a3e86220143fb98">+46/-75</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>23 files</summary><table>
<tr>
  <td><strong>test_lfortran_grammar.py</strong><dd><code>Add walrus fixture tests and syntax error validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-65fd28dd391e069412763f1c907e3dd13568a0805bb513b7c33b58e21e5210d6">+62/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_lfortran_infer_grammar.py</strong><dd><code>Add infer-mode fixture tests with parametrization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-dc32f13a5e945b82f96282766f37879ddb38ad405444acd5797f9320b8a0f89b">+35/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_01.f90</strong><dd><code>Walrus syntax in subroutine with multiple types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-317929a4156d9dbf0e32eb475f3c2ac6e40e68ad74c1ce1e52f796102ef81541">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_02.f90</strong><dd><code>Walrus syntax at program scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-d616d5946604fb59838fa0eb1b106ee74f7780694a3a57f5a05682f55c5076b2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_03.f90</strong><dd><code>Walrus with subsequent reassignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-baab4d51d6d33fd355c0051f490ff045e63a49fb14a6b145c42222e8a4153ccd">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_array_01.f90</strong><dd><code>Walrus with array constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-c26419f542ffa56b290e4e6b6b4057998ff71eed5eed8d6334ddbdcbc7ef17f7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_array_02.f90</strong><dd><code>Walrus with reshaped array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-aefa0c0a05c229059f080aa98c870a80d1387da00b4ee357ce074641e0e360aa">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_array_03.f90</strong><dd><code>Regular assignment with array constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-c02de19c1176665b684f5c24b209debcb8a2221d23e503348501131a8b5e2bd3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_error_01.f90</strong><dd><code>Semantic error: walrus on explicit declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-a2029326ddd40caaf449daef9d3f9d1f23127f9fd26baa8db8410ecc49a169a2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_error_02.f90</strong><dd><code>Semantic error: walrus with derived type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-7a6d7f9e17f0a3b4e37b8b6bb210e5ee96609389f4fffb05d0d917d66d3341a5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_redecl_01.f90</strong><dd><code>Semantic error: walrus redeclaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-734c593888d06fac4300a50fea6fbe3714bfb7b8eb1517db555ba4ceb15a4caf">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_shadow_01.f90</strong><dd><code>Walrus with variable shadowing in block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-b09e6201bbaa58ef4e17374bb3b844bc968349e311c5d814c774ee73f30b42c8">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_shadow_02.f90</strong><dd><code>Walrus with nested block shadowing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-6f184f926262afb42f100eba64c925b0ea0d350ae398db17b31dc88b9c63d3b4">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_shadow_03.f90</strong><dd><code>Regular assignment with nested block shadowing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-b74c54baaabf60a2fc4576b9f0c5de51fd4d1ba02961e4f6595b2179d16da475">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_struct_01.f90</strong><dd><code>Walrus with derived type constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-bcb700abf5d2a3122cd8f32aeb40226228fee0a8a579943683633d5716e88ca2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_struct_02.f90</strong><dd><code>Walrus with function-returned derived type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-45459d3e8350c8bad695dd3fdb68ebdeefd71aba24eea2229f6c2041b25ae0d9">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_struct_03.f90</strong><dd><code>Regular assignment with derived type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-5fde700c6921ad550cbc50f22a0cb7bf966f223dacd25bf482198665126df3b5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_first_assignment_01.f90</strong><dd><code>First-assignment inference at global scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-c90d5c6054ef2b1a26004e7f0a8448a1edcf5800536a6f68dfd76c506439672a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_first_assignment_derived_01.f90</strong><dd><code>First-assignment with derived type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-9b2679c61f494a117e1090d05c122b56739448cf018d2d231c927377ac2aa2d1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_global_01.f90</strong><dd><code>Walrus at global scope in infer mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-642edc8807132e1981523ce5773e0cb738286a5a43b81addaeaa5cc3ac6e7461">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_global_02.f90</strong><dd><code>Walrus with arrays and derived types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-4e4d077b01f6964a290d2a8309070156cb879162004dbada6d1562f9f1c99fee">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_shadow_01.f90</strong><dd><code>Walrus shadowing in infer mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-d4a5bc8ff408a379c6278268748fda03759b0ac2aae8e9f55af1ccd3da9e42a3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>infer_walrus_error_shape_01.f90</strong><dd><code>Semantic error shape: walrus on array element</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/720/files#diff-4c22315511fb1977efd5ee0b8c7cae502e4149ef462017fafb142ed569985cf3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

