### PR TITLE
chore: improve validation pipeline reliability and standard refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,26 +378,38 @@ download-standards:
 	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran90_WG5_N692.pdf \
 		https://wg5-fortran.org/N001-N1100/N692.pdf \
 		|| echo "    ⚠️  Failed to download WG5 N692 (Fortran 90 draft)"
-	@echo "  - Fortran 95 related document (Fortran 95 Request for Interpretation)"
+	@echo "  - Fortran 95 draft/final text (WG5 N1191)"
+	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran95_WG5_N1191.pdf \
+		https://wg5-fortran.org/N1151-N1200/N1191.pdf \
+		|| echo "    ⚠️  Failed to download WG5 N1191 (Fortran 95 draft/final)"
+	@echo "  - Fortran 95 related document (J3 RFI paper 98-114)"
 	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran95_J3_98-114_RFI.txt \
 		https://j3-fortran.org/doc/year/98/98-114.txt \
 		|| echo "    ⚠️  Failed to download J3 98-114 (Fortran 95 RFI)"
-	@echo "  - Fortran 2003 draft/final text (J3/03-007)"
-	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2003_J3_03-007.pdf \
+	@echo "  - Fortran 2003 draft/final text (J3/04-007 preferred, 03-007 fallback)"
+	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2003_J3_04-007.pdf \
+		https://j3-fortran.org/doc/year/04/04-007.pdf \
+		|| $(CURL_STD) -o $(STANDARDS_DIR)/Fortran2003_J3_04-007.pdf \
 		https://j3-fortran.org/doc/year/03/03-007.pdf \
-		|| echo "    ⚠️  Failed to download J3 03-007 (Fortran 2003)"
-	@echo "  - Fortran 2008 draft/final text (J3/08-007)"
-	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2008_J3_08-007.pdf \
+		|| echo "    ⚠️  Failed to download J3 04-007/03-007 (Fortran 2003)"
+	@echo "  - Fortran 2008 draft/final text (J3/10-007r1 preferred, 08-007 fallback)"
+	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2008_J3_10-007r1.pdf \
+		https://j3-fortran.org/doc/year/10/10-007r1.pdf \
+		|| $(CURL_STD) -o $(STANDARDS_DIR)/Fortran2008_J3_10-007r1.pdf \
 		https://j3-fortran.org/doc/year/08/08-007.pdf \
-		|| echo "    ⚠️  Failed to download J3 08-007 (Fortran 2008)"
-	@echo "  - Fortran 2018 draft/final text (J3/15-007)"
-	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2018_J3_15-007.pdf \
+		|| echo "    ⚠️  Failed to download J3 10-007r1/08-007 (Fortran 2008)"
+	@echo "  - Fortran 2018 draft/final text (J3/18-007r1 preferred, 15-007 fallback)"
+	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2018_J3_18-007r1.pdf \
+		https://j3-fortran.org/doc/year/18/18-007r1.pdf \
+		|| $(CURL_STD) -o $(STANDARDS_DIR)/Fortran2018_J3_18-007r1.pdf \
 		https://j3-fortran.org/doc/year/15/15-007.pdf \
-		|| echo "    ⚠️  Failed to download J3 15-007 (Fortran 2018)"
-	@echo "  - Fortran 2023 draft/final text (J3/22-007)"
-	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2023_J3_22-007.pdf \
+		|| echo "    ⚠️  Failed to download J3 18-007r1/15-007 (Fortran 2018)"
+	@echo "  - Fortran 2023 draft/final text (J3/23-007r1 preferred, 22-007 fallback)"
+	@$(CURL_STD) -o $(STANDARDS_DIR)/Fortran2023_J3_23-007r1.pdf \
+		https://j3-fortran.org/doc/year/23/23-007r1.pdf \
+		|| $(CURL_STD) -o $(STANDARDS_DIR)/Fortran2023_J3_23-007r1.pdf \
 		https://j3-fortran.org/doc/year/22/22-007.pdf \
-		|| echo "    ⚠️  Failed to download J3 22-007 (Fortran 2023)"
+		|| echo "    ⚠️  Failed to download J3 23-007r1/22-007 (Fortran 2023)"
 	@echo "✅ Download complete (see $(STANDARDS_DIR))"
 
 # OCR historical scanned PDFs into plain text for audit use.
@@ -413,10 +425,11 @@ ocr-standards:
 		FORTRANII_1958_IBM704_C28-6000-2.pdf \
 		FORTRAN66_ANSI_X3.9-1966.pdf \
 		Fortran90_WG5_N692.pdf \
-		Fortran2003_J3_03-007.pdf \
-		Fortran2008_J3_08-007.pdf \
-		Fortran2018_J3_15-007.pdf \
-		Fortran2023_J3_22-007.pdf; do \
+		Fortran95_WG5_N1191.pdf \
+		Fortran2003_J3_04-007.pdf \
+		Fortran2008_J3_10-007r1.pdf \
+		Fortran2018_J3_18-007r1.pdf \
+		Fortran2023_J3_23-007r1.pdf; do \
 		if [ -f "$(STANDARDS_DIR)/$$pdf" ]; then \
 			base=$${pdf%.pdf}; \
 			txt_file="$(STANDARDS_DIR)/$${base}.txt"; \

--- a/validation/README.md
+++ b/validation/README.md
@@ -11,7 +11,9 @@ To download the kaby76/fortran reference repository:
 ./setup_validation.sh
 ```
 
-This will download the [kaby76/fortran](https://github.com/kaby76/fortran.git) repository into `external/kaby76-fortran/` for comparison with our grammar implementation.
+This ensures the [kaby76/fortran](https://github.com/kaby76/fortran.git)
+reference material is available under `external/kaby76-fortran/` for
+comparison with our grammar implementation.
 
 ## Directory Structure
 
@@ -20,8 +22,10 @@ validation/
 ├── tools/              # Validation utilities
 │   ├── download_kaby76.py      # Downloads kaby76/fortran repo
 │   └── ...
-├── external/           # External resources (git-ignored)
-│   └── kaby76-fortran/ # Downloaded on-demand from GitHub
+├── external/           # External resources (some committed, some synced)
+│   ├── flang-grammar/  # Committed reference material
+│   ├── FortranAS/      # Committed extraction framework mirror
+│   └── kaby76-fortran/ # Synced/updated by setup scripts
 ├── cache/             # Processing cache (git-ignored) 
 ├── auto-generated/    # Generated reference files (git-ignored)
 └── setup_validation.sh # One-click setup script
@@ -29,7 +33,10 @@ validation/
 
 ## Git Policy
 
-All content in `external/`, `cache/`, `auto-generated/`, and `pdfs/` directories is **git-ignored** and downloaded on-demand. This keeps the repository clean while providing access to reference materials for validation.
+- `cache/` and `auto-generated/` are git-ignored local artifacts.
+- `external/` contains committed reference materials plus content that setup
+  scripts may refresh locally.
+- `validation/pdfs/` is used by `make download-standards` as a local cache.
 
 ## Usage
 

--- a/validation/setup_validation.sh
+++ b/validation/setup_validation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Setup validation environment by downloading kaby76/fortran repository on-demand
-# This keeps the repo clean while providing access to reference grammars and examples
+# Setup validation environment by syncing the kaby76/fortran reference repository.
+# The validation tree also includes committed external reference material.
 #
 
 set -e
@@ -26,7 +26,7 @@ if [ -d "$KABY76_DIR" ]; then
     echo "    - $(ls -la "$KABY76_DIR/examples"/*.f90 2>/dev/null | wc -l) example files found"
     echo ""
     echo "Validation environment ready!"
-    echo "Files are git-ignored and downloaded on-demand."
+    echo "kaby76 reference content is now available/updated under external/."
 else
     echo "✗ Failed to setup validation environment"
     exit 1


### PR DESCRIPTION
### **User description**
## Summary
- fix `scripts/validate_all.sh` so it runs as valid shell and executes tests via `pytest`
- make validation pipeline gracefully skip extraction when external .NET/Trash toolchain is unavailable
- update validation docs to match actual git policy for `validation/external/`
- refresh `download-standards` references to newer canonical J3/WG5 documents with fallbacks
- align `ocr-standards` inputs with updated downloaded filenames

## Verification
- `make test` (1821 passed, 917 subtests passed)
- `./scripts/validate_all.sh` (tests pass; extraction skipped with explicit partial-success message on this machine)
- `make download-standards`


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Fix validation script to use pytest and handle missing toolchain gracefully

- Add fallback URLs for downloading canonical J3/WG5 standard documents

- Update validation documentation to clarify git policy for external resources

- Align OCR standards filenames with refreshed download references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["validate_all.sh"] -->|"pytest execution"| B["Test Suite"]
  A -->|"toolchain check"| C{"External Tools<br/>Available?"}
  C -->|"Yes"| D["Extract Grammars"]
  C -->|"No"| E["Skip Gracefully"]
  F["Makefile"] -->|"primary URLs"| G["J3/WG5 Standards"]
  G -->|"fallback URLs"| H["Alternative Sources"]
  I["validation/README.md"] -->|"clarify policy"| J["Git Ignore Rules"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_all.sh</strong><dd><code>Fix shell syntax and add graceful toolchain fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/validate_all.sh

<ul><li>Convert docstring from Python triple-quotes to bash comments for valid <br>shell syntax<br> <li> Replace direct Python execution with pytest for test discovery and <br>reporting<br> <li> Add configurable <code>OMP_NUM_THREADS</code> environment variable with default <br>value<br> <li> Implement toolchain availability check before extraction steps<br> <li> Gracefully skip grammar extraction when .NET/Trash tools unavailable <br>with partial-success message<br> <li> Renumber validation steps to account for new toolchain verification <br>step</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/723/files#diff-9eaaec7dcb8b35de6dd0bb2396ea8dedbd49c487bc2ea945bd8bde25cc7a08a7">+34/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup_validation.sh</strong><dd><code>Clarify validation environment setup messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

validation/setup_validation.sh

<ul><li>Update documentation comments to clarify syncing behavior vs on-demand <br>downloads<br> <li> Change final message to reflect that kaby76 content is now available <br>under external/<br> <li> Improve clarity about validation environment setup</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/723/files#diff-367bfa1d86033a64291a6df49fc211bbaa70c15df9f7969c9ff818fff60e54bb">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation on external resources and git policy</code></dd></summary>
<hr>

validation/README.md

<ul><li>Clarify that external resources include both committed materials and <br>synced content<br> <li> Add examples of committed reference materials (flang-grammar, <br>FortranAS)<br> <li> Update git policy section to distinguish between git-ignored artifacts <br>and committed external resources<br> <li> Clarify that <code>validation/pdfs/</code> is used as local cache by <br>download-standards<br> <li> Improve documentation formatting and clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/723/files#diff-e48280075b9da927c93ea914c35eacfb07f037dc283ca6cd678b808c3ed91e3b">+12/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement, configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add fallback URLs for canonical standard documents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Add Fortran 95 standard download (WG5 N1191) with fallback support<br> <li> Update Fortran 2003 to prefer J3/04-007 with fallback to 03-007<br> <li> Update Fortran 2008 to prefer J3/10-007r1 with fallback to 08-007<br> <li> Update Fortran 2018 to prefer J3/18-007r1 with fallback to 15-007<br> <li> Update Fortran 2023 to prefer J3/23-007r1 with fallback to 22-007<br> <li> Align <code>ocr-standards</code> target filenames to match new download references<br> <li> Add fallback download mechanism using <code>||</code> operator for robustness</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/723/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+30/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

