### PR TITLE
chore: clean stale docs references and tighten fixed-form alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ standard/
 ├── grammars/src/       # ANTLR4 grammar files (.g4)
 ├── tests/              # Test suites by standard
 ├── tools/              # Semantic validators
-└── validation/         # Standard PDFs
+└── validation/         # Reference corpora, standards PDFs, and validation tooling
 ```
 
 ## Grammar Inheritance

--- a/scripts/validate_all.sh
+++ b/scripts/validate_all.sh
@@ -54,7 +54,7 @@ then
         validation/tools/run_extraction.py "$REPO_ROOT" "Fortran 2018"
 else
     echo "⚠ External extraction toolchain unavailable (.NET/Trash tools missing)"
-    echo "  Skipping grammar extraction steps (see issue #92)."
+    echo "  Skipping grammar extraction steps on this machine."
     echo ""
     echo "=== Validation Pipeline Complete (Partial) ==="
     echo "✓ Validation tests passing"

--- a/tests/FORTRAN77/test_strict_fixed_form_77.py
+++ b/tests/FORTRAN77/test_strict_fixed_form_77.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Test suite for strict fixed-form card layout semantics for FORTRAN 77.
+
+Tests strict card parsing/validation wrappers against ANSI X3.9-1978
+fixed-form source assumptions (label field, continuation column, statement
+field, sequence field).
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT.parent / "tools"))
+sys.path.insert(0, str(ROOT))
+
+try:
+    from strict_fixed_form import (
+        CardType,
+        StrictFixedFormProcessor,
+        convert_to_lenient_77,
+        validate_strict_fixed_form_77,
+    )
+
+    PROCESSOR_AVAILABLE = True
+except ImportError as e:
+    print(f"Import error: {e}")
+    PROCESSOR_AVAILABLE = False
+
+
+class TestFORTRAN77CardParsing(unittest.TestCase):
+    """Basic card parsing checks for FORTRAN 77 strict mode."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+        self.processor = StrictFixedFormProcessor(dialect="77")
+
+    def test_comment_and_statement_cards(self):
+        comment = self.processor.parse_card("C     COMMENT CARD", 1)
+        statement = self.processor.parse_card("  100 CONTINUE", 2)
+
+        self.assertEqual(comment.card_type, CardType.COMMENT)
+        self.assertEqual(statement.card_type, CardType.STATEMENT)
+        self.assertEqual(statement.label, "100")
+
+    def test_continuation_card(self):
+        continuation = self.processor.parse_card("     1    A = B + C", 1)
+        self.assertEqual(continuation.card_type, CardType.CONTINUATION)
+        self.assertTrue(continuation.continuation)
+
+
+class TestFORTRAN77Validation(unittest.TestCase):
+    """Validation behavior for FORTRAN 77 strict mode wrappers."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+
+    def test_valid_simple_program(self):
+        source = """\
+C     FORTRAN 77 SAMPLE
+      PROGRAM DEMO
+      INTEGER I
+      I = 1
+      END
+"""
+        result = validate_strict_fixed_form_77(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+    def test_invalid_alpha_label(self):
+        source = """\
+AB123 CONTINUE
+      END
+"""
+        result = validate_strict_fixed_form_77(source)
+        self.assertFalse(result.valid)
+        self.assertTrue(any("label" in err.message.lower() for err in result.errors))
+
+    def test_invalid_continuation_with_label(self):
+        source = """\
+      REAL A, B,
+  1001      C
+      END
+"""
+        result = validate_strict_fixed_form_77(source)
+        self.assertFalse(result.valid)
+
+    def test_max_label_valid(self):
+        source = """\
+99999 CONTINUE
+      END
+"""
+        result = validate_strict_fixed_form_77(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+
+
+class TestFORTRAN77LenientConversion(unittest.TestCase):
+    """Conversion behavior from strict card form to lenient parser input."""
+
+    def setUp(self):
+        if not PROCESSOR_AVAILABLE:
+            self.skipTest("StrictFixedFormProcessor not available")
+
+    def test_comment_conversion(self):
+        source = """\
+C     COMMENT
+      END
+"""
+        lenient, result = convert_to_lenient_77(source)
+        self.assertTrue(result.valid)
+        self.assertIn("!", lenient)
+
+    def test_continuation_joining(self):
+        source = """\
+      X = A + B +
+     1    C + D
+      END
+"""
+        lenient, result = convert_to_lenient_77(source)
+        self.assertTrue(result.valid, f"Errors: {result.errors}")
+        self.assertIn("A + B +", lenient)
+        self.assertIn("C + D", lenient)
+
+
+if __name__ == "__main__":
+    os.environ["OMP_NUM_THREADS"] = "24"
+    unittest.main()

--- a/tests/test_fixed_form_docs.py
+++ b/tests/test_fixed_form_docs.py
@@ -11,12 +11,12 @@ def test_fixed_form_docs_exist() -> None:
   assert path.is_file(), "docs/fixed_form_support.md must exist"
 
 
-def test_fixed_form_docs_reference_issue_91_and_subset() -> None:
-  """Fixed-form docs should describe subset and link to Issue #91."""
+def test_fixed_form_docs_reference_subset_and_strict_mode() -> None:
+  """Fixed-form docs should describe subset mode and strict validation mode."""
   path = _repo_root() / "docs" / "fixed_form_support.md"
   content = path.read_text(encoding="utf-8")
 
-  assert "Issue #91" in content
   assert "layout\u2011lenient model" in content
   assert "80-column card layout" in content
-
+  assert "strict fixed-form preprocessor" in content
+  assert "fortran_2003_audit.md" not in content

--- a/validation/tools/test_validation_pipeline.py
+++ b/validation/tools/test_validation_pipeline.py
@@ -39,7 +39,7 @@ class TestValidationPipeline(unittest.TestCase):
         except Exception as exc:
             pytest.skip(
                 f"External kaby76/fortran repository not available "
-                f"(see issue #92): {exc}"
+                f"(validation environment not provisioned): {exc}"
             )
         return ExtractionRunner(self.test_dir)
     
@@ -51,7 +51,7 @@ class TestValidationPipeline(unittest.TestCase):
         if not runner.verify_setup():
             pytest.skip(
                 "External Trash/.NET toolchain not available "
-                "(verify_setup() is False, see issue #92)"
+                "(verify_setup() is False)"
             )
         
         self.assertTrue(runner.verify_setup())
@@ -82,7 +82,7 @@ class TestValidationPipeline(unittest.TestCase):
         if not runner.verify_setup():
             pytest.skip(
                 "External Trash/.NET toolchain not available "
-                "(verify_setup() is False, see issue #92)"
+                "(verify_setup() is False)"
             )
         
         # Try to extract Fortran 2023 (should be most complete).
@@ -99,7 +99,7 @@ class TestValidationPipeline(unittest.TestCase):
         if not runner.verify_setup():
             pytest.skip(
                 "External Trash/.NET toolchain not available "
-                "(verify_setup() is False, see issue #92)"
+                "(verify_setup() is False)"
             )
         
         result = runner.extract_standard('Fortran 2023')


### PR DESCRIPTION
### **User description**
## Summary
- remove stale fixed-form references to closed Issue #91 and missing `docs/fortran_2003_audit.md`
- update `docs/fixed_form_support.md` to match current implementation: strict card-image mode is available for 1957/II/66/77/90; Fortran 2003+ remains unified grammar without dedicated strict preprocessor mode
- update `tests/test_fixed_form_docs.py` to enforce current fixed-form doc invariants
- remove closed Issue #92 references from validation script/tests and use condition-based skip messaging
- add dedicated `FORTRAN77` strict fixed-form tests for the existing 77 wrappers
- update root README directory description for `validation/`

## Verification
- `python3 -m pytest -q tests/test_fixed_form_docs.py`
- `python3 -m pytest -q tests/FORTRAN77/test_strict_fixed_form_77.py`
- `python3 -m pytest -q validation/tools/test_validation_pipeline.py`
- `./scripts/validate_all.sh`
- `make test` (`1829 passed, 917 subtests passed`)


___

### **PR Type**
Documentation, Enhancement, Tests


___

### **Description**
- Remove stale Issue #91 and #92 references throughout codebase

- Update fixed-form documentation to reflect current implementation reality

- Add dedicated FORTRAN 77 strict fixed-form test suite

- Clarify strict card-image validation availability by dialect

- Update validation pipeline skip messages to be condition-based


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stale Issue References<br/>#91, #92, #673"] -->|Remove| B["Clean Documentation"]
  C["Fixed-form Docs"] -->|Update| D["Current Implementation<br/>Clarity"]
  E["FORTRAN 77 Wrappers"] -->|Add Tests| F["test_strict_fixed_form_77.py"]
  G["Validation Scripts"] -->|Condition-based| H["Skip Messages"]
  B --> I["Aligned Codebase"]
  D --> I
  F --> I
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_strict_fixed_form_77.py</strong><dd><code>Add FORTRAN 77 strict fixed-form test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/FORTRAN77/test_strict_fixed_form_77.py

<ul><li>New test file with 130 lines covering FORTRAN 77 strict fixed-form <br>validation<br> <li> Tests card parsing (comment, statement, continuation types)<br> <li> Validates label constraints and continuation rules<br> <li> Tests lenient conversion from strict card-image format</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/724/files#diff-20d63ffa0c1c9efbb2c7a40ef6b478ab33421c2e7d3328875bc2dc4342070c0a">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_fixed_form_docs.py</strong><dd><code>Update fixed-form docs test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_fixed_form_docs.py

<ul><li>Rename test from <code>test_fixed_form_docs_reference_issue_91_and_subset</code> to <br><code>test_fixed_form_docs_reference_subset_and_strict_mode</code><br> <li> Remove assertion checking for "Issue #91" reference<br> <li> Add assertion for "strict fixed-form preprocessor" presence<br> <li> Add assertion ensuring <code>fortran_2003_audit.md</code> is not referenced</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/724/files#diff-ca192bd8ca9b19fbf1152dbdbef8c6611b17f9338eb5498234661d353554cf24">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_validation_pipeline.py</strong><dd><code>Replace Issue #92 with condition-based skip messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

validation/tools/test_validation_pipeline.py

<ul><li>Replace Issue #92 reference with generic "validation environment not <br>provisioned" message<br> <li> Update skip message in <code>test_pipeline_setup</code> to remove issue reference<br> <li> Update skip message in <code>test_can_extract_single_standard</code> to remove <br>issue reference<br> <li> Update skip message in <code>test_generated_grammar_is_valid_antlr</code> to remove <br>issue reference</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/724/files#diff-d9f31792da0df8038814ee749997ac3722edb00aeccde66de53406071345c027">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_all.sh</strong><dd><code>Update validation script skip messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/validate_all.sh

<ul><li>Replace "see issue #92" with "on this machine" in skip message<br> <li> Clarify that grammar extraction steps are skipped due to local <br>environment constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/724/files#diff-9eaaec7dcb8b35de6dd0bb2396ea8dedbd49c487bc2ea945bd8bde25cc7a08a7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify validation directory purpose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Expand <code>validation/</code> directory description from "Standard PDFs" to <br>"Reference corpora, standards PDFs, and validation tooling"<br> <li> Better reflects actual contents and purpose of validation directory</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/724/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fixed_form_support.md</strong><dd><code>Align fixed-form documentation with current implementation</code></dd></summary>
<hr>

docs/fixed_form_support.md

<ul><li>Remove references to Issue #91 as umbrella tracker for future work<br> <li> Replace "out of scope" language with description of available strict <br>validation tools<br> <li> Document <code>tools/strict_fixed_form.py</code> availability for FORTRAN <br>1957/II/66/77/90<br> <li> Clarify that Fortran 2003+ uses unified grammar without dedicated <br>strict preprocessor<br> <li> Remove reference to <code>docs/fortran_2003_audit.md</code> (stale document)<br> <li> Add section on "Strict Fixed-Form Mode for FORTRAN 66/77" with wrapper <br>functions<br> <li> Update Fortran 90 section to remove Issue #673 reference<br> <li> Simplify Fortran 2003 section to remove audit document references<br> <li> Rename "Out-of-scope Fixed-form Features" to "Remaining Fixed-form <br>Gaps"<br> <li> Reframe gaps as current implementation status rather than tracked <br>issues</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/standard/pull/724/files#diff-8ff84efc1d3187dd5fb3bf89ed94efe13cde4c89337993f29dc957860b1d7f57">+33/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

