### PR TITLE
fix: prevent Pages workflow from failing when slides source is removed

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,14 +22,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ hashFiles('docs/slides/lfortran-open-issues.md') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install Marp CLI
+        if: ${{ hashFiles('docs/slides/lfortran-open-issues.md') != '' }}
         run: npm install -g @marp-team/marp-cli
 
       - name: Build Marp slides
+        if: ${{ hashFiles('docs/slides/lfortran-open-issues.md') != '' }}
         run: |
           mkdir -p docs/slides/html
           marp docs/slides/lfortran-open-issues.md \
@@ -70,4 +73,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
## Summary
- gate Marp setup and slide build behind presence of `docs/slides/lfortran-open-issues.md`
- keep docs artifact upload/deploy running even when slides are not part of the repo

## Why
Recent docs restructuring removed `docs/slides/`, but the Pages workflow still unconditionally builds that file, causing Pages runs on `main` to fail in the build job.
